### PR TITLE
Refactor FontSize component and improve toolbar UX

### DIFF
--- a/packages/reason-editor/src/documents/DocumentTabs.tsx
+++ b/packages/reason-editor/src/documents/DocumentTabs.tsx
@@ -135,7 +135,7 @@ export const DocumentTabs = ({
             <TabsList className="h-10 bg-transparent p-0 rounded-none border-0 w-full flex flex-nowrap">
               {openTabs.map((tabId) => (
                 <ContextMenu key={tabId}>
-                  <ContextMenuTrigger className="flex-1 min-w-0" style={{ minWidth: '2.5rem' }}>
+                  <ContextMenuTrigger className="flex-1 min-w-[80px]">
                     <div className="relative group h-10 w-full">
                       <TabsTrigger
                         value={tabId}

--- a/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
+++ b/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
@@ -171,7 +171,7 @@ export const Sidebar = ({
               onViewModeChange={onViewModeChange}
               onToggleRightOutline={onToggleRightOutline}
             />
-            <FileManagerModal open={isFileManagerOpen} onOpenChange={setIsFileManagerOpen} documents={activeDocuments} />
+            <FileManagerModal open={isFileManagerOpen} onOpenChange={setIsFileManagerOpen} documents={activeDocuments} onSelectDocument={onSelect} />
           </aside>
         </SheetContent>
       </Sheet>
@@ -231,7 +231,7 @@ export const Sidebar = ({
         onViewModeChange={onViewModeChange}
         onToggleRightOutline={onToggleRightOutline}
       />
-      <FileManagerModal open={isFileManagerOpen} onOpenChange={setIsFileManagerOpen} />
+      <FileManagerModal open={isFileManagerOpen} onOpenChange={setIsFileManagerOpen} documents={activeDocuments} onSelectDocument={onSelect} />
     </aside>
   );
 };

--- a/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/fontSize.tsx
@@ -2,20 +2,20 @@
 import { LexicalEditor } from 'lexical';
 import * as React from 'react';
 
-import { cn } from '../../../lib/utils';
-import Icon from '../../ui/Icon';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../../ui/select';
 import {
   MAX_ALLOWED_FONT_SIZE,
   MIN_ALLOWED_FONT_SIZE,
 } from '../../context/ToolbarContext';
-import { isKeyboardInput } from '../../utils/focusUtils';
-import { SHORTCUTS } from '../ShortcutsPlugin/shortcuts';
-import {
-  updateFontSize,
-  updateFontSizeInSelection,
-  UpdateFontSizeType,
-} from './utils';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
+import { updateFontSizeInSelection } from './utils';
+
+const FONT_SIZE_OPTIONS = [8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
 
 function parseFontSize(input: string): [number, string] | null {
   const match = input.match(/^(\d+(?:\.\d+)?)(px|pt)$/);
@@ -34,10 +34,7 @@ function isValidFontSize(fontSizePx: number): boolean {
 
 export function parseFontSizeForToolbar(input: string): string {
   const parsed = parseFontSize(input);
-  if (!parsed) {
-    return '';
-  }
-
+  if (!parsed) return '';
   const [fontSize, unit] = parsed;
   const fontSizePx = normalizeToPx(fontSize, unit);
   return `${fontSizePx}px`;
@@ -45,10 +42,7 @@ export function parseFontSizeForToolbar(input: string): string {
 
 export function parseAllowedFontSize(input: string): string {
   const parsed = parseFontSize(input);
-  if (!parsed) {
-    return '';
-  }
-
+  if (!parsed) return '';
   const [fontSize, unit] = parsed;
   const fontSizePx = normalizeToPx(fontSize, unit);
   return isValidFontSize(fontSizePx) ? input : '';
@@ -63,120 +57,27 @@ export default function FontSize({
   disabled: boolean;
   editor: LexicalEditor;
 }) {
-  const [inputValue, setInputValue] = React.useState<string>(selectionFontSize);
-  const [inputChangeFlag, setInputChangeFlag] = React.useState<boolean>(false);
-  const [isMouseMode, setIsMouseMode] = React.useState(false);
-  const [lastAppliedSize, setLastAppliedSize] = React.useState<string>(selectionFontSize);
+  const currentSize = selectionFontSize ? String(parseInt(selectionFontSize, 10)) : '';
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const inputValueNumber = Number(inputValue);
-
-    if (e.key === 'Tab') {
-      return;
-    }
-    if (['e', 'E', '+', '-'].includes(e.key) || isNaN(inputValueNumber)) {
-      e.preventDefault();
-      setInputValue('');
-      return;
-    }
-    setInputChangeFlag(true);
-
-    // Apply immediately on arrow up/down keys
-    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-      // Let the browser update the input value first
-      setTimeout(() => {
-        const newValue = Number((e.target as HTMLInputElement).value);
-        if (!isNaN(newValue)) {
-          updateFontSizeByInputValue(newValue, true);
-        }
-      }, 0);
-    } else if (e.key === 'Enter' || e.key === 'Escape') {
-      e.preventDefault();
-      updateFontSizeByInputValue(inputValueNumber, !isMouseMode);
-    }
+  const handleValueChange = (value: string) => {
+    updateFontSizeInSelection(editor, value + 'px', null, false);
   };
-
-  const handleInputBlur = () => {
-    setIsMouseMode(false);
-
-    if (inputValue !== '' && inputChangeFlag) {
-      const inputValueNumber = Number(inputValue);
-      updateFontSizeByInputValue(inputValueNumber);
-    }
-  };
-
-  const handleClick = (e: React.MouseEvent) => {
-    setIsMouseMode(true);
-  };
-
-  const updateFontSizeByInputValue = (
-    inputValueNumber: number,
-    skipRefocus: boolean = false,
-  ) => {
-    let updatedFontSize = inputValueNumber;
-    if (inputValueNumber > MAX_ALLOWED_FONT_SIZE) {
-      updatedFontSize = MAX_ALLOWED_FONT_SIZE;
-    } else if (inputValueNumber < MIN_ALLOWED_FONT_SIZE) {
-      updatedFontSize = MIN_ALLOWED_FONT_SIZE;
-    }
-
-    const fontSizeStr = String(updatedFontSize);
-    setInputValue(fontSizeStr);
-    setLastAppliedSize(fontSizeStr);
-    updateFontSizeInSelection(
-      editor,
-      fontSizeStr + 'px',
-      null,
-      skipRefocus,
-    );
-    setInputChangeFlag(false);
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    setInputValue(newValue);
-    setInputChangeFlag(true);
-
-    // Auto-apply when using spinner buttons (value changes by exactly 1)
-    const numValue = Number(newValue);
-    const lastNum = Number(lastAppliedSize);
-    if (!isNaN(numValue) && !isNaN(lastNum) && Math.abs(numValue - lastNum) === 1) {
-      // This is likely from spinner buttons
-      updateFontSizeByInputValue(numValue, true);
-    }
-  };
-
-  React.useEffect(() => {
-    setInputValue(selectionFontSize);
-    setLastAppliedSize(selectionFontSize);
-  }, [selectionFontSize]);
-
-  const btnClass = 'inline-flex items-center justify-center rounded-md h-7 w-7 bg-transparent border-0 cursor-pointer text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50';
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="inline-flex items-center gap-0.5 shrink-0">
-          <input
-            type="number"
-            value={inputValue}
-            disabled={disabled}
-            className={cn(
-              'w-9 h-7 text-center text-sm font-semibold bg-transparent border border-border rounded-md',
-              'focus:outline-none focus:ring-1 focus:ring-ring',
-              'disabled:opacity-50 disabled:cursor-not-allowed',
-              '[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none',
-            )}
-            min={MIN_ALLOWED_FONT_SIZE}
-            max={MAX_ALLOWED_FONT_SIZE}
-            onChange={handleInputChange}
-            onClick={handleClick}
-            onKeyDown={handleKeyPress}
-            onBlur={handleInputBlur}
-          />
-        </div>
-      </TooltipTrigger>
-      <TooltipContent>Font size</TooltipContent>
-    </Tooltip>
+    <Select value={currentSize} onValueChange={handleValueChange} disabled={disabled}>
+      <SelectTrigger
+        className="h-7 w-14 text-xs font-semibold px-2 border-border focus:ring-ring shrink-0"
+        aria-label="Font size"
+      >
+        <SelectValue placeholder="–" />
+      </SelectTrigger>
+      <SelectContent className="min-w-[4rem]">
+        {FONT_SIZE_OPTIONS.map((size) => (
+          <SelectItem key={size} value={String(size)} className="text-xs">
+            {size}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }

--- a/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/fontSize.tsx
+++ b/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/fontSize.tsx
@@ -1,14 +1,14 @@
 
 import { LexicalEditor } from 'lexical';
 import * as React from 'react';
+import { ChevronDown } from 'lucide-react';
 
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '../../../ui/select';
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../../../ui/dropdown-menu';
 import {
   MAX_ALLOWED_FONT_SIZE,
   MIN_ALLOWED_FONT_SIZE,
@@ -57,27 +57,78 @@ export default function FontSize({
   disabled: boolean;
   editor: LexicalEditor;
 }) {
-  const currentSize = selectionFontSize ? String(parseInt(selectionFontSize, 10)) : '';
+  const [inputValue, setInputValue] = React.useState(
+    selectionFontSize ? String(parseInt(selectionFontSize, 10)) : '',
+  );
 
-  const handleValueChange = (value: string) => {
-    updateFontSizeInSelection(editor, value + 'px', null, false);
+  React.useEffect(() => {
+    setInputValue(selectionFontSize ? String(parseInt(selectionFontSize, 10)) : '');
+  }, [selectionFontSize]);
+
+  const applySize = (value: string, skipRefocus = false) => {
+    const num = parseInt(value, 10);
+    if (isNaN(num)) return;
+    const clamped = Math.min(MAX_ALLOWED_FONT_SIZE, Math.max(MIN_ALLOWED_FONT_SIZE, num));
+    setInputValue(String(clamped));
+    updateFontSizeInSelection(editor, clamped + 'px', null, skipRefocus);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      applySize(inputValue);
+    } else if (e.key === 'Escape') {
+      setInputValue(selectionFontSize ? String(parseInt(selectionFontSize, 10)) : '');
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputValue) applySize(inputValue);
+  };
+
+  const handlePresetSelect = (size: number) => {
+    setInputValue(String(size));
+    updateFontSizeInSelection(editor, size + 'px', null, false);
   };
 
   return (
-    <Select value={currentSize} onValueChange={handleValueChange} disabled={disabled}>
-      <SelectTrigger
-        className="h-7 w-14 text-xs font-semibold px-2 border-border focus:ring-ring shrink-0"
-        aria-label="Font size"
-      >
-        <SelectValue placeholder="–" />
-      </SelectTrigger>
-      <SelectContent className="min-w-[4rem]">
-        {FONT_SIZE_OPTIONS.map((size) => (
-          <SelectItem key={size} value={String(size)} className="text-xs">
-            {size}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <div
+      className="inline-flex items-center h-7 rounded-md border border-border shrink-0 overflow-hidden focus-within:ring-1 focus-within:ring-ring"
+      aria-label="Font size"
+    >
+      <input
+        type="number"
+        value={inputValue}
+        disabled={disabled}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        className="w-8 h-full text-center text-xs font-semibold bg-transparent border-0 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        min={MIN_ALLOWED_FONT_SIZE}
+        max={MAX_ALLOWED_FONT_SIZE}
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild disabled={disabled}>
+          <button
+            className="h-full px-0.5 flex items-center border-l border-border hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
+            tabIndex={-1}
+            aria-label="Font size presets"
+          >
+            <ChevronDown className="h-3 w-3" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-[4rem] max-h-64 overflow-y-auto">
+          {FONT_SIZE_OPTIONS.map((size) => (
+            <DropdownMenuItem
+              key={size}
+              className="text-xs justify-center"
+              onSelect={() => handlePresetSelect(size)}
+            >
+              {size}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/index.tsx
+++ b/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/index.tsx
@@ -1541,11 +1541,11 @@ export default function ToolbarPlugin({
               </DropDown>
               <Divider />
 
-              {/* Invite Dropdown */}
-              {documentTitle && documentId && (
+              {/* Share Menu */}
+              {documentId && (
                 <div className="toolbar-item spaced">
                   <InviteDropdown
-                    documentTitle={documentTitle}
+                    documentTitle={documentTitle || 'Untitled'}
                     documentId={documentId}
                   />
                 </div>

--- a/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/index.tsx
+++ b/packages/reason-editor/src/lexical/plugins/ToolbarPlugin/index.tsx
@@ -1059,40 +1059,42 @@ export default function ToolbarPlugin({
 
   return (
     <div className="toolbar flex items-center gap-0 flex-nowrap overflow-x-auto scrollbar-thin px-1 py-0.5 border-b border-border bg-card">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            disabled={!toolbarState.canUndo || !isEditable}
-            onClick={(e) =>
-              dispatchToolbarCommand(UNDO_COMMAND, undefined, isKeyboardInput(e))
-            }
-            type="button"
-            className={toolbarBtnClass}
-            aria-label="Undo">
-            <Icon name="undo" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>
-          {IS_APPLE ? 'Undo (⌘Z)' : 'Undo (Ctrl+Z)'}
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            disabled={!toolbarState.canRedo || !isEditable}
-            onClick={(e) =>
-              dispatchToolbarCommand(REDO_COMMAND, undefined, isKeyboardInput(e))
-            }
-            type="button"
-            className={toolbarBtnClass}
-            aria-label="Redo">
-            <Icon name="redo" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>
-          {IS_APPLE ? 'Redo (⇧⌘Z)' : 'Redo (Ctrl+Y)'}
-        </TooltipContent>
-      </Tooltip>
+      {toolbarState.canUndo && isEditable && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) =>
+                dispatchToolbarCommand(UNDO_COMMAND, undefined, isKeyboardInput(e))
+              }
+              type="button"
+              className={toolbarBtnClass}
+              aria-label="Undo">
+              <Icon name="undo" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {IS_APPLE ? 'Undo (⌘Z)' : 'Undo (Ctrl+Z)'}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {toolbarState.canRedo && isEditable && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) =>
+                dispatchToolbarCommand(REDO_COMMAND, undefined, isKeyboardInput(e))
+              }
+              type="button"
+              className={toolbarBtnClass}
+              aria-label="Redo">
+              <Icon name="redo" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {IS_APPLE ? 'Redo (⇧⌘Z)' : 'Redo (Ctrl+Y)'}
+          </TooltipContent>
+        </Tooltip>
+      )}
       <Divider />
       {toolbarState.blockType in blockTypeToBlockName &&
         activeEditor === editor && (
@@ -1335,20 +1337,6 @@ export default function ToolbarPlugin({
             isRTL={toolbarState.isRTL}
           />
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                disabled={!isEditable}
-                onClick={insertLink}
-                className={cn(toolbarBtnClass, toolbarState.isLink && toolbarBtnActiveClass)}
-                aria-label="Insert link"
-                type="button">
-                <Icon name="link" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Insert link ({SHORTCUTS.INSERT_LINK})</TooltipContent>
-          </Tooltip>
-
           {/* <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -1371,6 +1359,12 @@ export default function ToolbarPlugin({
                 buttonIconClassName="icon plus"
                 tooltip="Insert">
 
+                <DropDownItem
+                  onClick={insertLink}
+                  className={cn('item', toolbarState.isLink && 'active')}>
+                  <Icon name="link" />
+                  <span className="text">Link ({SHORTCUTS.INSERT_LINK})</span>
+                </DropDownItem>
                 {/* <DropDownItem
                   onClick={() => dispatchToolbarCommand(INSERT_PAGE_BREAK)}
                   className="item">

--- a/packages/reason-editor/src/modals/FileManagerModal.tsx
+++ b/packages/reason-editor/src/modals/FileManagerModal.tsx
@@ -6,7 +6,7 @@ import {
   Dialog,
   DialogContent
 } from "../ui/dialog";
-import { getData } from "./filemanager-data";
+import { getData, getPathToDocIdMap } from "./filemanager-data";
 import { defaultDocuments } from "../documents/defaultDocuments";
 import type { Document } from "../documents/DocumentTree";
 
@@ -14,9 +14,15 @@ interface FileManagerModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   documents?: Document[];
+  onSelectDocument?: (docId: string) => void;
 }
 
-export function FileManagerModal({ open, onOpenChange, documents = defaultDocuments }: FileManagerModalProps) {
+export function FileManagerModal({
+  open,
+  onOpenChange,
+  documents = defaultDocuments,
+  onSelectDocument,
+}: FileManagerModalProps) {
   const data = getData(documents).map((item) => ({
     id: item.id,
     type: item.type,
@@ -24,14 +30,26 @@ export function FileManagerModal({ open, onOpenChange, documents = defaultDocume
     date: item.date ?? new Date(),
   }));
 
+  const pathToDocId = getPathToDocIdMap(documents);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl h-[80vh] p-0 flex flex-col">
-
-        <div className="flex-1 overflow-hidden ">
-          <div className="h-full rounded-md overflow-hidden">
+      <DialogContent className="max-w-5xl w-[95vw] max-h-[85vh] p-0 flex flex-col overflow-hidden">
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <div className="h-[75vh] min-h-[300px] rounded-md overflow-hidden">
             <Willow>
-              <Filemanager data={data} />
+              <Filemanager
+                data={data}
+                init={(api) => {
+                  api.on("open-file", ({ id }: { id: string }) => {
+                    const docId = pathToDocId.get(id);
+                    if (docId && onSelectDocument) {
+                      onSelectDocument(docId);
+                      onOpenChange(false);
+                    }
+                  });
+                }}
+              />
             </Willow>
           </div>
         </div>

--- a/packages/reason-editor/src/modals/filemanager-data.ts
+++ b/packages/reason-editor/src/modals/filemanager-data.ts
@@ -43,3 +43,29 @@ export function convertDocumentsToFileItems(documents: Document[]): FileItem[] {
 export function getData(documents: Document[] = []): FileItem[] {
   return convertDocumentsToFileItems(documents);
 }
+
+/** Returns a map from file path → document ID for reverse-lookup when a file is opened. */
+export function getPathToDocIdMap(documents: Document[]): Map<string, string> {
+  const byId = new Map<string, Document>();
+  for (const doc of documents) byId.set(doc.id, doc);
+
+  function pathFor(doc: Document): string {
+    const segments: string[] = [slugify(doc.title)];
+    let current = doc;
+    while (current.parentId) {
+      const parent = byId.get(current.parentId);
+      if (!parent) break;
+      segments.unshift(slugify(parent.title));
+      current = parent;
+    }
+    return '/' + segments.join('/');
+  }
+
+  const map = new Map<string, string>();
+  for (const doc of documents) {
+    if (!doc.isFolder) {
+      map.set(pathFor(doc), doc.id);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary
This PR refactors the FontSize component to use a dropdown menu with preset options instead of a complex input-based approach, and makes several UX improvements to the toolbar including conditional rendering of undo/redo buttons and moving the link insertion to a dropdown menu.

## Key Changes

### FontSize Component Refactor (`fontSize.tsx`)
- Replaced Tooltip-wrapped input with a combined input + dropdown menu UI using `lucide-react` ChevronDown icon and shadcn dropdown components
- Introduced `FONT_SIZE_OPTIONS` constant with predefined font sizes (8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72)
- Simplified state management by removing `inputChangeFlag`, `isMouseMode`, and `lastAppliedSize` flags
- Removed complex keyboard handling logic (arrow keys, spinner button detection) in favor of simpler Enter/Escape handling
- Consolidated font size application into single `applySize()` function with automatic clamping to allowed range
- Added `useEffect` hook to sync input value when `selectionFontSize` prop changes
- Improved accessibility with proper `aria-label` attributes

### Toolbar Component Updates (`index.tsx`)
- Made Undo/Redo buttons conditionally render only when available (`canUndo`/`canRedo` && `isEditable`)
- Moved "Insert Link" button from standalone toolbar button to a menu item within the Insert dropdown
- Updated Share/Invite section to handle missing `documentTitle` with fallback to 'Untitled'

### FileManager Modal Enhancements (`FileManagerModal.tsx`, `filemanager-data.ts`)
- Added `onSelectDocument` callback prop to FileManagerModal
- Implemented `getPathToDocIdMap()` utility function to create reverse-lookup map from file paths to document IDs
- Connected file manager "open-file" event to trigger document selection and close modal
- Improved modal styling with better responsive sizing and overflow handling

### Sidebar Integration (`Sidebar.tsx`)
- Connected FileManagerModal's `onSelectDocument` callback to sidebar's `onSelect` handler for seamless document navigation

## Implementation Details
- The new FontSize UI uses a flex container with an input field and a dropdown trigger button separated by a border
- Font size input now only accepts numeric values and automatically clamps to MIN/MAX bounds on blur or Enter
- Dropdown menu items are scrollable with `max-h-64 overflow-y-auto` for better UX with many preset options
- File manager integration uses event-driven architecture to maintain separation of concerns

https://claude.ai/code/session_012TVP7V96KF6zL33PJAFeq3