### PR TITLE
Prevent duplicate suggestion fetches in chat messages

### DIFF
--- a/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/sendMessage.ts
+++ b/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/sendMessage.ts
@@ -145,6 +145,7 @@ export async function sendMessage(
   // Accumulator for streaming response
   let receivedMessage = "";
   let added = false;
+  let suggestionsFetched = false;
 
   // Generate or use provided message ID
   const messageId = providedMessageId ?? crypto.randomBytes(7).toString("hex");
@@ -240,35 +241,31 @@ export async function sendMessage(
         document.getElementById(`search-videos-${lastMsg.messageId}`)?.click();
       }
 
-      // Fetch follow-up suggestions if we have sources and no existing suggestions
-      const userMessageIndex = messagesRef.current.findIndex(
-        (msg) => msg.messageId === messageId && msg.role === "user",
-      );
+      // Fetch follow-up suggestions if we have sources and haven't fetched yet for this request
+      if (!suggestionsFetched) {
+        suggestionsFetched = true;
 
-      const sourceMessage = messagesRef.current.find(
-        (msg, i) => i > userMessageIndex && msg.role === "source",
-      ) as SourceMessage | undefined;
+        const userMessageIndex = messagesRef.current.findIndex(
+          (msg) => msg.messageId === messageId && msg.role === "user",
+        );
 
-      const suggestionMessageIndex = messagesRef.current.findIndex(
-        (msg, i) => i > userMessageIndex && msg.role === "suggestion",
-      );
+        const sourceMessage = messagesRef.current.find(
+          (msg, i) => i > userMessageIndex && msg.role === "source",
+        ) as SourceMessage | undefined;
 
-      if (
-        sourceMessage &&
-        sourceMessage.sources.length > 0 &&
-        suggestionMessageIndex === -1
-      ) {
-        const suggestions = await getSuggestions(messagesRef.current);
-        setMessages((prev) => [
-          ...prev,
-          {
-            role: "suggestion",
-            suggestions: suggestions,
-            chatId: chatId,
-            createdAt: new Date(),
-            messageId: crypto.randomBytes(7).toString("hex"),
-          },
-        ]);
+        if (sourceMessage && sourceMessage.sources.length > 0) {
+          const suggestions = await getSuggestions(messagesRef.current);
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "suggestion",
+              suggestions: suggestions,
+              chatId: chatId,
+              createdAt: new Date(),
+              messageId: crypto.randomBytes(7).toString("hex"),
+            },
+          ]);
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
This change fixes a bug where follow-up suggestions could be fetched multiple times for a single user message by introducing a flag to track whether suggestions have already been fetched during the current request.

## Key Changes
- Added `suggestionsFetched` flag to prevent multiple suggestion fetch calls for the same message
- Simplified the suggestion fetching logic by removing the check for existing suggestion messages
- Wrapped the suggestion fetching logic in a conditional guard that ensures it only runs once per request
- Removed the `suggestionMessageIndex` lookup since we now rely on the flag instead

## Implementation Details
The previous implementation checked if a suggestion message already existed in the message history (`suggestionMessageIndex === -1`), but this approach could fail if the suggestion message hadn't been added to the state yet when the condition was re-evaluated. By using a local `suggestionsFetched` flag that persists across the async operations within a single `sendMessage` call, we ensure suggestions are only fetched once per user message, regardless of timing issues with state updates.

https://claude.ai/code/session_01YKC3PQ8znucutzRTKJeaxw