### PR TITLE
Add extraction time limit and progress tracking for URL source extraction

### DIFF
--- a/apps/qwksearch-web/components/ResearchAgent/ChatConversation/ChatMessageBubble.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/ChatConversation/ChatMessageBubble.tsx
@@ -16,6 +16,7 @@ import ThinkTagProcessor from './MessageBubble/ThinkTagProcessor';
 import UserMessageHeader from './MessageBubble/UserMessageHeader';
 import AssistantMessageActions from './MessageBubble/AssistantMessageActions';
 import FollowUpSuggestions from './MessageBubble/FollowUpSuggestions';
+import ExtractionProgressPanel from './ExtractionProgressPanel';
 
 /**
  * Component that renders a single chat section (user message + assistant response).
@@ -38,7 +39,8 @@ const MessageBox = ({
   dividerRef?: Ref<HTMLDivElement>;
   isLast: boolean;
 }) => {
-  const { loading, sendMessage } = useChat();
+  const { loading, sendMessage, extractionByMessageId } = useChat();
+  const extraction = extractionByMessageId[section.userMessage.messageId];
   const [isExpanded, setIsExpanded] = useState(true);
   const [fontFamily, setFontFamily] = useState('');
   const [copiedUserMsg, setCopiedUserMsg] = useState(false);
@@ -168,6 +170,13 @@ const MessageBox = ({
           ref={dividerRef}
           className="flex flex-col space-y-6 w-full"
         >
+          {extraction && (
+            <ExtractionProgressPanel
+              progress={extraction}
+              active={loading && isLast}
+            />
+          )}
+
           {section.sourceMessage &&
             section.sourceMessage.sources.length > 0 && (
               <div className="flex flex-col space-y-2">

--- a/apps/qwksearch-web/components/ResearchAgent/ChatConversation/ExtractionProgressPanel.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/ChatConversation/ExtractionProgressPanel.tsx
@@ -1,0 +1,91 @@
+/**
+ * Progress indicator shown while the research agent extracts URL contents
+ * from the top sources of search results. Mirrors the elicit-style
+ * "Running analysis..." panel: a header with completed/total counter, plus
+ * a per-URL list with status icons.
+ */
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Loader2, XCircle, Globe } from 'lucide-react';
+import type { ExtractionProgress } from '@/components/ResearchAgent/hooks/useChat/types';
+import { cn } from '@/lib/utils';
+
+interface ExtractionProgressPanelProps {
+  progress: ExtractionProgress;
+  active: boolean;
+}
+
+const formatHost = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+};
+
+const ExtractionProgressPanel = ({ progress, active }: ExtractionProgressPanelProps) => {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (!active || progress.endedAt) return;
+    const id = setInterval(() => setNow(Date.now()), 250);
+    return () => clearInterval(id);
+  }, [active, progress.endedAt]);
+
+  const elapsedMs = (progress.endedAt ?? now) - progress.startedAt;
+  const elapsedSec = Math.max(0, Math.floor(elapsedMs / 1000));
+  const capSec = progress.capSeconds || 0;
+  const remainingSec = capSec > 0 ? Math.max(0, capSec - elapsedSec) : null;
+  const isRunning = active && !progress.endedAt;
+
+  return (
+    <div className="my-4 bg-secondary/40 rounded-xl border border-border overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-2">
+        {isRunning ? (
+          <Loader2 size={16} className="animate-spin text-accent-foreground" />
+        ) : (
+          <CheckCircle2 size={16} className="text-emerald-500" />
+        )}
+        <p className="font-medium text-sm text-foreground/90">
+          {isRunning ? 'Extracting sources…' : 'Extracted sources'}
+        </p>
+        <span className="ml-auto text-xs text-muted-foreground tabular-nums">
+          {progress.completed}/{progress.total} URLs
+          {' · '}
+          {elapsedSec}s
+          {remainingSec !== null && isRunning ? ` (cap ${capSec}s)` : ''}
+        </span>
+      </div>
+
+      <ul className="border-t border-border bg-muted/40 divide-y divide-border/60">
+        {progress.urls.map((u) => (
+          <li key={u.url} className="flex items-center gap-2 px-4 py-1.5 text-xs">
+            {u.status === 'pending' && (
+              <Loader2 size={12} className="animate-spin text-muted-foreground flex-shrink-0" />
+            )}
+            {u.status === 'success' && (
+              <CheckCircle2 size={12} className="text-emerald-500 flex-shrink-0" />
+            )}
+            {u.status === 'failed' && (
+              <XCircle size={12} className="text-rose-500 flex-shrink-0" />
+            )}
+            <Globe size={12} className="text-muted-foreground flex-shrink-0" />
+            <span className="text-muted-foreground flex-shrink-0">{formatHost(u.url)}</span>
+            <span
+              className={cn(
+                'truncate text-foreground/80',
+                u.status === 'failed' && 'line-through text-muted-foreground',
+              )}
+              title={u.title || u.url}
+            >
+              {u.title || u.url}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ExtractionProgressPanel;

--- a/apps/qwksearch-web/components/ResearchAgent/FileUpload/FileUploadDropdown.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/FileUpload/FileUploadDropdown.tsx
@@ -4,7 +4,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Upload, CloudIcon, FolderOpen, Loader2, Clock } from 'lucide-react';
+import { Upload, CloudIcon, FolderOpen, Loader2, Clock, Timer } from 'lucide-react';
 import grab from 'grab-url';
 import {
   DropdownMenu,
@@ -34,6 +34,15 @@ const THINKING_OPTIONS = [
   { label: '15s', value: 15 },
   { label: '30s', value: 30 },
   { label: '45s', value: 45 },
+  { label: '60s', value: 60 },
+  { label: 'Unlimited', value: 0 },
+];
+
+const EXTRACT_OPTIONS = [
+  { label: '5s', value: 5 },
+  { label: '10s', value: 10 },
+  { label: '20s', value: 20 },
+  { label: '30s', value: 30 },
   { label: '60s', value: 60 },
   { label: 'Unlimited', value: 0 },
 ];
@@ -72,6 +81,11 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
     const n = Number(localStorage.getItem('thinkingTimeLimit') ?? '0');
     return Number.isFinite(n) ? n : 0;
   });
+  const [extractTimeLimit, setExtractTimeLimit] = useState<number>(() => {
+    if (typeof window === 'undefined') return 20;
+    const n = Number(localStorage.getItem('extractTimeLimit') ?? '20');
+    return Number.isFinite(n) ? n : 20;
+  });
 
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const { openPicker } = useGooglePicker();
@@ -92,6 +106,12 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
   const handleThinkingTimeLimit = (value: number) => {
     setThinkingTimeLimit(value);
     localStorage.setItem('thinkingTimeLimit', String(value));
+  };
+
+  const handleExtractTimeLimit = (value: number) => {
+    setExtractTimeLimit(value);
+    localStorage.setItem('extractTimeLimit', String(value));
+    window.dispatchEvent(new Event('client-config-changed'));
   };
 
   const handleLocalFileUpload = async () => {
@@ -237,6 +257,7 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
   };
 
   const currentThinkingLabel = THINKING_OPTIONS.find((o) => o.value === thinkingTimeLimit)?.label ?? 'Unlimited';
+  const currentExtractLabel = EXTRACT_OPTIONS.find((o) => o.value === extractTimeLimit)?.label ?? `${extractTimeLimit}s`;
 
   return (
     <>
@@ -304,6 +325,31 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
                   >
                     <span>{opt.label}</span>
                     {thinkingTimeLimit === opt.value && (
+                      <svg className="w-3 h-3 text-primary" fill="none" viewBox="0 0 10 10">
+                        <path d="M1.5 5l2.5 2.5 4.5-4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            {/* Extract Time flyout submenu — caps URL extraction from top sources */}
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="gap-2">
+                <Timer className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+                <span>Extract Time</span>
+                <span className="ml-auto text-xs text-muted-foreground">{currentExtractLabel}</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-36">
+                {EXTRACT_OPTIONS.map((opt) => (
+                  <DropdownMenuItem
+                    key={opt.value}
+                    onSelect={() => handleExtractTimeLimit(opt.value)}
+                    className={cn('justify-between', extractTimeLimit === opt.value && 'bg-secondary')}
+                  >
+                    <span>{opt.label}</span>
+                    {extractTimeLimit === opt.value && (
                       <svg className="w-3 h-3 text-primary" fill="none" viewBox="0 0 10 10">
                         <path d="M1.5 5l2.5 2.5 4.5-4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                       </svg>

--- a/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/ChatContext.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/ChatContext.tsx
@@ -9,7 +9,7 @@
 
 import { createContext, useContext } from 'react';
 import { ChatTurn, Message } from '@/components/ResearchAgent/ChatConversation/ChatWindow';
-import { ChatFile, ChatModelProvider, Section } from './types';
+import { ChatFile, ChatModelProvider, ExtractionProgress, Section } from './types';
 
 /**
  * The value provided by the ChatContext.
@@ -52,6 +52,11 @@ export interface ChatContextValue {
   hasError: boolean;
   /** Current AI model provider configuration */
   chatModelProvider: ChatModelProvider;
+  /**
+   * Per-question URL extraction progress, keyed by the assistant message ID.
+   * Populated as the server streams "extraction" SSE frames.
+   */
+  extractionByMessageId: Record<string, ExtractionProgress>;
 
   // ============ Actions ============
 
@@ -165,6 +170,7 @@ export const chatContext = createContext<ChatContextValue>({
   notFound: false,
   optimizationMode: '',
   chatModelProvider: { key: '', providerId: '' },
+  extractionByMessageId: {},
   // Default no-op actions
   rewrite: () => { },
   sendMessage: async () => { },

--- a/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/ChatProvider.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/ChatProvider.tsx
@@ -224,6 +224,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
           setMessageAppeared: setters.setMessageAppeared,
           setMessages: setters.setMessages,
           setChatHistory: setters.setChatHistory,
+          setExtractionByMessageId: setters.setExtractionByMessageId,
         },
       );
     },
@@ -327,6 +328,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     notFound: state.notFound,
     optimizationMode: state.optimizationMode,
     chatModelProvider: state.chatModelProvider,
+    extractionByMessageId: state.extractionByMessageId,
     incognito,
     // Actions
     setFileIds: setters.setFileIds,

--- a/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/sendMessage.ts
+++ b/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/sendMessage.ts
@@ -12,7 +12,7 @@ import {
 } from "@/components/ResearchAgent/ChatConversation/ChatWindow";
 import { getSuggestions } from "@/lib/server-actions";
 import { getAutoMediaSearch } from "@/lib/config/serverRegistry";
-import { ChatModelProvider } from "./types";
+import { ChatModelProvider, ExtractionProgress } from "./types";
 
 const SOURCE_EXTRACTION_KEY = "sourceExtractionEnabled";
 
@@ -66,6 +66,10 @@ export interface SendMessageDeps {
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   /** Setter for chat history */
   setChatHistory: React.Dispatch<React.SetStateAction<[string, string][]>>;
+  /** Setter for the per-message extraction-progress map */
+  setExtractionByMessageId: React.Dispatch<
+    React.SetStateAction<Record<string, ExtractionProgress>>
+  >;
 }
 
 /**
@@ -120,10 +124,15 @@ export async function sendMessage(
     setMessageAppeared,
     setMessages,
     setChatHistory,
+    setExtractionByMessageId,
   } = deps;
   const sourceExtractionEnabled =
     typeof window !== "undefined" &&
     localStorage.getItem(SOURCE_EXTRACTION_KEY) === "true";
+  const extractTimeLimit =
+    typeof window !== "undefined"
+      ? Number(localStorage.getItem("extractTimeLimit") ?? "20") || 0
+      : 0;
 
   // Prevent duplicate sends or empty messages
   if (loading || !message) return;
@@ -170,6 +179,61 @@ export async function sendMessage(
     if (data.type === "error") {
       toast.error(data.data);
       setLoading(false);
+      return;
+    }
+
+    // Handle URL extraction progress from the research agent.
+    // The server emits one "start" frame, one "progress" frame per URL, and a final "end" frame.
+    // Keyed by the user message ID so the section can find its progress entry
+    // before the assistant/source messages have arrived.
+    if (data.type === "extraction") {
+      const id = messageId;
+      setExtractionByMessageId((prev) => {
+        const existing = prev[id];
+        if (data.phase === "start") {
+          return {
+            ...prev,
+            [id]: {
+              total: data.total ?? 0,
+              completed: 0,
+              capSeconds: data.capSeconds ?? 0,
+              startedAt: Date.now(),
+              urls: (data.urls ?? []).map((u: any) => ({
+                url: u.url,
+                title: u.title,
+                status: "pending",
+              })),
+            },
+          };
+        }
+        if (!existing) return prev;
+        if (data.phase === "progress") {
+          return {
+            ...prev,
+            [id]: {
+              ...existing,
+              completed: data.completed ?? existing.completed,
+              urls: existing.urls.map((u) =>
+                u.url === data.url ? { ...u, status: data.status ?? u.status } : u,
+              ),
+            },
+          };
+        }
+        if (data.phase === "end") {
+          return {
+            ...prev,
+            [id]: {
+              ...existing,
+              completed: data.completed ?? existing.completed,
+              endedAt: Date.now(),
+              urls: existing.urls.map((u) =>
+                u.status === "pending" ? { ...u, status: "failed" } : u,
+              ),
+            },
+          };
+        }
+        return prev;
+      });
       return;
     }
 
@@ -290,6 +354,7 @@ export async function sendMessage(
           providerId: chatModelProvider.providerId,
         },
         sourceExtractionEnabled,
+        extractTimeLimit,
         systemInstructions: localStorage.getItem("systemInstructions"),
       }),
     });

--- a/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/types.ts
+++ b/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/types.ts
@@ -35,6 +35,19 @@ export type Section = {
 };
 
 /**
+ * Per-message URL extraction progress, mirroring the events emitted by the
+ * research-agent during the source-extraction phase.
+ */
+export interface ExtractionProgress {
+  total: number;
+  completed: number;
+  capSeconds: number;
+  startedAt: number;
+  endedAt?: number;
+  urls: { url: string; title?: string; status: "pending" | "success" | "failed" }[];
+}
+
+/**
  * Represents an uploaded file attached to a chat.
  */
 export interface ChatFile {

--- a/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/useChatState.ts
+++ b/apps/qwksearch-web/components/ResearchAgent/hooks/useChat/useChatState.ts
@@ -12,7 +12,7 @@ import {
   ChatTurn,
   Message,
 } from "@/components/ResearchAgent/ChatConversation/ChatWindow";
-import { ChatFile, ChatModelProvider, Section } from "./types";
+import { ChatFile, ChatModelProvider, ExtractionProgress, Section } from "./types";
 import { buildSections } from "./buildSections";
 
 /**
@@ -54,6 +54,8 @@ export interface ChatState {
   hasError: boolean;
   /** Whether the chat system is fully ready for use */
   isReady: boolean;
+  /** Per-question URL extraction progress keyed by assistant messageId */
+  extractionByMessageId: Record<string, ExtractionProgress>;
 }
 
 /**
@@ -95,6 +97,10 @@ export interface ChatStateSetters {
   setHasError: (hasError: boolean) => void;
   /** Sets the ready state */
   setIsReady: (ready: boolean) => void;
+  /** Updates the extraction-progress map (supports functional updates) */
+  setExtractionByMessageId: React.Dispatch<
+    React.SetStateAction<Record<string, ExtractionProgress>>
+  >;
 }
 
 /**
@@ -153,6 +159,9 @@ export function useChatState(initialChatId?: string): UseChatStateReturn {
   // ============ Message State ============
   const [chatHistory, setChatHistory] = useState<[string, string][]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
+  const [extractionByMessageId, setExtractionByMessageId] = useState<
+    Record<string, ExtractionProgress>
+  >({});
 
   // ============ File State ============
   const [files, setFiles] = useState<ChatFile[]>([]);
@@ -211,6 +220,7 @@ export function useChatState(initialChatId?: string): UseChatStateReturn {
       isConfigReady,
       hasError,
       isReady,
+      extractionByMessageId,
     },
     setters: {
       setChatId,
@@ -230,6 +240,7 @@ export function useChatState(initialChatId?: string): UseChatStateReturn {
       setIsConfigReady,
       setHasError,
       setIsReady,
+      setExtractionByMessageId,
     },
     messagesRef,
     chatTurns,

--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -195,6 +195,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       body.systemInstructions as string,
       body.category,
       body.sourceExtractionEnabled,
+      body.extractTimeLimit,
     );
 
     // --- Set up the SSE response stream ---

--- a/apps/qwksearch-web/lib/chat/schemas.ts
+++ b/apps/qwksearch-web/lib/chat/schemas.ts
@@ -73,6 +73,11 @@ export const bodySchema = z.object({
   chatModel: chatModelSchema,
   /** Whether to extract and return source content alongside results. */
   sourceExtractionEnabled: z.boolean().optional().default(false),
+  /**
+   * Max seconds to spend extracting URL contents from top sources.
+   * 0 = unlimited (use server default). Drives the per-question extraction time cap.
+   */
+  extractTimeLimit: z.number().nonnegative().optional().default(0),
   /** Custom system instructions to prepend to the prompt. */
   systemInstructions: z.string().nullable().optional().default(""),
 });

--- a/apps/qwksearch-web/lib/chat/stream-handler.ts
+++ b/apps/qwksearch-web/lib/chat/stream-handler.ts
@@ -17,8 +17,17 @@ import { messages as messagesSchema } from "@/lib/database/schema";
  * @property {string | Document[]}    data - The payload; text chunk or source list.
  */
 interface StreamEvent {
-  type: "response" | "sources";
-  data: string | Document[];
+  type: "response" | "sources" | "extraction";
+  data?: string | Document[];
+  // extraction-event fields
+  phase?: "start" | "progress" | "end";
+  total?: number;
+  completed?: number;
+  capSeconds?: number;
+  url?: string;
+  status?: "pending" | "success" | "failed";
+  urls?: { url: string; title?: string; status: string }[];
+  elapsedMs?: number;
 }
 
 /**
@@ -35,9 +44,17 @@ interface StreamEvent {
  * | `"error"`     | Error description     | _absent_      |
  */
 interface SSEMessage {
-  type: "message" | "sources" | "messageEnd" | "error";
+  type: "message" | "sources" | "messageEnd" | "error" | "extraction";
   data?: string | Document[];
   messageId?: string;
+  phase?: "start" | "progress" | "end";
+  total?: number;
+  completed?: number;
+  capSeconds?: number;
+  url?: string;
+  status?: "pending" | "success" | "failed";
+  urls?: { url: string; title?: string; status: string }[];
+  elapsedMs?: number;
 }
 
 /**
@@ -112,6 +129,19 @@ export const handleEmitterEvents = async (
       });
 
       receivedMessage += parsedData.data;
+    } else if (parsedData.type === "extraction") {
+      writeSSE({
+        type: "extraction",
+        messageId: aiMessageId,
+        phase: parsedData.phase,
+        total: parsedData.total,
+        completed: parsedData.completed,
+        capSeconds: parsedData.capSeconds,
+        url: parsedData.url,
+        status: parsedData.status,
+        urls: parsedData.urls,
+        elapsedMs: parsedData.elapsedMs,
+      });
     } else if (parsedData.type === "sources") {
       writeSSE({
         type: "sources",

--- a/packages/research-agent/src/search/meta-search-types.ts
+++ b/packages/research-agent/src/search/meta-search-types.ts
@@ -16,6 +16,7 @@ export interface MetaSearchAgentType {
     systemInstructions: string,
     category?: string,
     sourceExtractionEnabled?: boolean,
+    extractTimeLimit?: number,
   ) => Promise<EventEmitter>;
 }
 

--- a/packages/research-agent/src/search/metaSearchAgent.ts
+++ b/packages/research-agent/src/search/metaSearchAgent.ts
@@ -71,6 +71,8 @@ class MetaSearchAgent implements MetaSearchAgentType {
     llm: BaseChatModel,
     category: string = "general",
     sourceExtractionEnabled = false,
+    extractTimeLimit = 0,
+    progressEmitter?: EventEmitter,
   ) {
     (llm as unknown as ChatOpenAI).temperature = 0;
 
@@ -163,16 +165,38 @@ class MetaSearchAgent implements MetaSearchAgentType {
         }
 
         const scrapeCount = sourceExtractionEnabled ? 3 : 0;
-        const scrapeTimeout = Math.max(1, getSourceScrapeTimeout());
+        const perURLTimeout = Math.max(1, getSourceScrapeTimeout());
 
         if (scrapeCount > 0) {
-          const extractionTasks = documents.slice(0, scrapeCount).map(async (doc, idx) => {
-            const url = doc.metadata?.url;
-            if (!url) return;
+          const targets = documents
+            .slice(0, scrapeCount)
+            .map((doc, idx) => ({ doc, idx, url: doc.metadata?.url as string | undefined }))
+            .filter((t) => t.url);
+
+          const startedAt = Date.now();
+          const overallCapMs = extractTimeLimit > 0 ? extractTimeLimit * 1000 : 0;
+
+          progressEmitter?.emit(
+            "data",
+            JSON.stringify({
+              type: "extraction",
+              phase: "start",
+              total: targets.length,
+              completed: 0,
+              capSeconds: extractTimeLimit,
+              urls: targets.map((t) => ({ url: t.url, title: t.doc.metadata?.title, status: "pending" })),
+            }),
+          );
+
+          let completed = 0;
+          const extractionTasks = targets.map(async ({ url, idx }) => {
             try {
+              const remainingMs = overallCapMs > 0 ? overallCapMs - (Date.now() - startedAt) : Infinity;
+              if (remainingMs <= 0) throw new Error("extract-time-cap-exceeded");
+              const taskTimeout = Math.min(perURLTimeout * 1000 + 1500, remainingMs);
               const result = await waitWithTimeout(
-                scrapeURL(url, { timeout: scrapeTimeout }),
-                scrapeTimeout * 1000 + 1500,
+                scrapeURL(url!, { timeout: perURLTimeout }),
+                taskTimeout,
               );
               if (typeof result === "string" && result.length > 100) {
                 const text = htmlToText(result)
@@ -184,12 +208,53 @@ class MetaSearchAgent implements MetaSearchAgentType {
                   documents[idx].pageContent = text;
                 }
               }
+              completed += 1;
+              progressEmitter?.emit(
+                "data",
+                JSON.stringify({
+                  type: "extraction",
+                  phase: "progress",
+                  total: targets.length,
+                  completed,
+                  url,
+                  status: "success",
+                }),
+              );
             } catch {
-              // Keep original snippet on scraping failure or timeout
+              completed += 1;
+              progressEmitter?.emit(
+                "data",
+                JSON.stringify({
+                  type: "extraction",
+                  phase: "progress",
+                  total: targets.length,
+                  completed,
+                  url,
+                  status: "failed",
+                }),
+              );
             }
           });
 
-          await Promise.allSettled(extractionTasks);
+          if (overallCapMs > 0) {
+            await Promise.race([
+              Promise.allSettled(extractionTasks),
+              new Promise<void>((resolve) => setTimeout(resolve, overallCapMs)),
+            ]);
+          } else {
+            await Promise.allSettled(extractionTasks);
+          }
+
+          progressEmitter?.emit(
+            "data",
+            JSON.stringify({
+              type: "extraction",
+              phase: "end",
+              total: targets.length,
+              completed,
+              elapsedMs: Date.now() - startedAt,
+            }),
+          );
         }
 
         return { query: question, docs: documents };
@@ -204,6 +269,8 @@ class MetaSearchAgent implements MetaSearchAgentType {
     systemInstructions: string,
     category: string = "general",
     sourceExtractionEnabled = false,
+    extractTimeLimit = 0,
+    progressEmitter?: EventEmitter,
   ) {
     return RunnableSequence.from([
       RunnableMap.from({
@@ -222,6 +289,8 @@ class MetaSearchAgent implements MetaSearchAgentType {
               llm,
               category,
               sourceExtractionEnabled,
+              extractTimeLimit,
+              progressEmitter,
             );
             const result = await searchRetrieverChain.invoke({
               chat_history: processedHistory,
@@ -256,6 +325,7 @@ class MetaSearchAgent implements MetaSearchAgentType {
     systemInstructions: string,
     category: string = "general",
     sourceExtractionEnabled = false,
+    extractTimeLimit = 0,
   ) {
     const emitter = new EventEmitter();
 
@@ -266,6 +336,8 @@ class MetaSearchAgent implements MetaSearchAgentType {
       systemInstructions,
       category,
       sourceExtractionEnabled,
+      extractTimeLimit,
+      emitter,
     );
 
     const stream = answeringChain.streamEvents(


### PR DESCRIPTION
## Summary
This PR adds configurable time limits and real-time progress tracking for the URL extraction phase of the research agent. Users can now cap how long the agent spends extracting content from top search results, and see live progress updates as sources are processed.

## Key Changes

- **Extraction Time Limit Control**: Added a new "Extract Time" dropdown menu in the file upload panel with preset options (5s, 10s, 20s, 30s, 60s, unlimited) that persists to localStorage
- **Progress Tracking UI**: Created `ExtractionProgressPanel` component that displays:
  - Overall progress counter (completed/total URLs)
  - Elapsed time and remaining time cap
  - Per-URL status indicators (pending, success, failed) with hostname and page title
  - Animated spinner while extraction is active
- **Server-side Time Capping**: Modified `MetaSearchAgent.searchRetriever()` to:
  - Accept `extractTimeLimit` and `progressEmitter` parameters
  - Emit structured "extraction" events at start, per-URL progress, and completion
  - Enforce overall time cap using `Promise.race()` to interrupt long-running extractions
  - Track per-URL timeout separately from overall cap
- **SSE Event Streaming**: Extended stream handler to forward extraction events with phase, progress counts, per-URL status, and timing metadata
- **Type Definitions**: Added `ExtractionProgress` interface to track extraction state across message lifecycle
- **State Management**: Integrated extraction progress into chat state and context, keyed by message ID for proper association with user questions

## Implementation Details

- Extraction events flow through the same EventEmitter/SSE pipeline as existing response and source events
- Progress updates are keyed by the user message ID so the UI can display progress before assistant messages arrive
- The time cap is enforced at the overall level (all URLs combined) while respecting individual URL timeouts
- Failed/pending URLs are marked appropriately when the time cap is exceeded
- The progress panel only displays when extraction is active on the most recent message

https://claude.ai/code/session_01F63RQCdiwTsNJkRfttxZ82