### PR TITLE
Remove dock auto-hide functionality and simplify layout

### DIFF
--- a/apps/qwksearch-web/components/ResearchAgent/ChatConversation/ChatHomepage.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/ChatConversation/ChatHomepage.tsx
@@ -9,8 +9,6 @@ import ChatInputBox from '../MessageComposer/ChatInputBox';
 import RecentHistoryChips from './RecentHistoryChips';
 import { useChat } from '@/components/ResearchAgent/hooks/useChat';
 import { getBackgroundArtwork } from './background-art';
-import { useCategoryDockVisibility } from '@/components/layout/category-dock-context';
-import { cn } from '@/lib/utils';
 const { listFooterLinks } = config;
 
 /**
@@ -22,8 +20,6 @@ export default function ChatHomepage() {
   const { sendMessage } = useChat();
   const [backgroundUrl, setBackgroundUrl] = useState<string | null>(null);
   const [deviceInfo, setDeviceInfo] = useState({ os: '' });
-  const { dockHidden } = useCategoryDockVisibility();
-
   useEffect(() => {
     const showBg = localStorage.getItem('showBackgroundArt');
     if (showBg !== 'false') {
@@ -42,12 +38,6 @@ export default function ChatHomepage() {
   }, []);
 
   const isVideo = backgroundUrl && (backgroundUrl.endsWith('.webm') || backgroundUrl.endsWith('.mp4'));
-
-  // On mobile: dock is fixed bottom-0 at ~64px height. Lift input above it when dock is visible.
-  // On desktop (md+): dock is at top-left, input stays at bottom-0.
-  const inputBottomClass = dockHidden
-    ? 'bottom-0'
-    : 'bottom-0 md:bottom-0 max-md:bottom-16';
 
   return (
     <div className="relative min-h-screen w-full">
@@ -77,8 +67,8 @@ export default function ChatHomepage() {
         <div className="absolute w-full flex flex-row items-center justify-end pr-5 pt-2 sm:pt-5">
           <SettingsButtonMobile />
         </div>
-        {/* Centered content above the fixed input */}
-        <div className="flex flex-col items-center justify-center min-h-screen pb-48 max-w-screen-sm mx-auto p-2">
+        {/* Centered content with input in the middle of the page */}
+        <div className="flex flex-col items-center justify-center min-h-screen max-w-screen-sm mx-auto p-2">
           <MessageBoxLoading />
           <p className="text-lg text-gray-500 text-center justify-center mt-4">
             <a
@@ -100,14 +90,10 @@ export default function ChatHomepage() {
             >
             </a>
           </p>
-        </div>
-      </div>
-
-      {/* Fixed bottom input — sits above app dock when visible */}
-      <div className={cn('fixed left-0 right-0 z-40 px-2 pb-2', inputBottomClass)}>
-        <div className="max-w-2xl mx-auto space-y-2">
-          <RecentHistoryChips />
-          <ChatInputBox />
+          <div className="w-full max-w-2xl mt-8 space-y-2">
+            <RecentHistoryChips />
+            <ChatInputBox />
+          </div>
         </div>
       </div>
 

--- a/apps/qwksearch-web/components/layout/CategoryDock.tsx
+++ b/apps/qwksearch-web/components/layout/CategoryDock.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import Image from "next/image"
 import { usePathname, useRouter } from "next/navigation"
-import { UserCircle2, Moon, Sun, Palette, Settings, ChevronDown, ChevronUp } from "lucide-react"
+import { UserCircle2, Moon, Sun, Palette, Settings } from "lucide-react"
 import { AnimatePresence } from "framer-motion"
 import SettingsDialogue from "@/components/Settings/SettingsDialogue"
 import { useTheme } from "next-themes"
@@ -283,38 +283,6 @@ function DockInstance({
 export function CategoryDock() {
   const pathname = usePathname()
   const router = useRouter()
-  const [dockVisible, setDockVisible] = useState(true)
-  const desktopDockRef = useRef<HTMLDivElement>(null)
-  const mobileDockRef = useRef<HTMLDivElement>(null)
-  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const cancelHide = () => {
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current)
-      hideTimerRef.current = null
-    }
-  }
-
-  // Click-outside handler: wait 1s before hiding so dropdown menu items can register
-  useEffect(() => {
-    const handleMouseDown = (e: MouseEvent) => {
-      const inDesktop = desktopDockRef.current?.contains(e.target as Node)
-      const inMobile = mobileDockRef.current?.contains(e.target as Node)
-      // Also treat Radix dropdown portals (rendered outside the dock div) as "inside"
-      const inPortal = (e.target as Element)?.closest?.('[data-radix-popper-content-wrapper]')
-      if (inDesktop || inMobile || inPortal) {
-        cancelHide()
-      } else {
-        cancelHide()
-        hideTimerRef.current = setTimeout(() => setDockVisible(false), 1000)
-      }
-    }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => {
-      document.removeEventListener('mousedown', handleMouseDown)
-      cancelHide()
-    }
-  }, [])
 
   // Keyboard shortcuts: Alt+1 through Alt+3 for navigation items
   useEffect(() => {
@@ -345,43 +313,21 @@ export function CategoryDock() {
   return (
     <>
       {/* Desktop: top-left corner */}
-      <div className="hidden md:block fixed top-0 left-2 z-50" ref={desktopDockRef}>
-        {dockVisible ? (
-          <DockInstance
-            dockClassName="h-[52px] shrink-0 !mt-0 !mx-0"
-            side="bottom"
-            allItems={allItems}
-          />
-        ) : (
-          <button
-            onClick={() => { cancelHide(); setDockVisible(true) }}
-            className="bg-background border border-border border-t-0 rounded-b-lg px-3 py-1 flex items-center gap-1 shadow-md hover:bg-accent transition-colors text-muted-foreground"
-            aria-label="Show dock"
-          >
-            <ChevronDown className="h-4 w-4" />
-          </button>
-        )}
+      <div className="hidden md:block fixed top-0 left-2 z-50">
+        <DockInstance
+          dockClassName="h-[52px] shrink-0 !mt-0 !mx-0"
+          side="bottom"
+          allItems={allItems}
+        />
       </div>
 
       {/* Mobile: fixed bottom bar */}
-      <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 pb-safe" ref={mobileDockRef}>
-        {dockVisible ? (
-          <DockInstance
-            dockClassName="h-[52px] shrink-0 !mt-0 mx-auto w-max mb-2 !gap-1 !p-1"
-            side="top"
-            allItems={allItems}
-          />
-        ) : (
-          <div className="flex justify-center">
-            <button
-              onClick={() => { cancelHide(); setDockVisible(true) }}
-              className="bg-background border border-border border-b-0 rounded-t-lg px-4 py-1.5 flex items-center gap-1 shadow-md hover:bg-accent transition-colors text-muted-foreground"
-              aria-label="Show dock"
-            >
-              <ChevronUp className="h-4 w-4" />
-            </button>
-          </div>
-        )}
+      <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 pb-safe">
+        <DockInstance
+          dockClassName="h-[52px] shrink-0 !mt-0 mx-auto w-max mb-2 !gap-1 !p-1"
+          side="top"
+          allItems={allItems}
+        />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
This PR removes the auto-hide functionality from the CategoryDock component and simplifies the ChatHomepage layout. The dock is now always visible, eliminating the need for click-outside detection and visibility state management.

## Key Changes

- **CategoryDock.tsx**
  - Removed `dockVisible` state and related refs (`desktopDockRef`, `mobileDockRef`, `hideTimerRef`)
  - Removed click-outside event listener that triggered dock hiding after 1 second delay
  - Removed conditional rendering logic that showed/hid the dock with chevron toggle buttons
  - Removed unused imports: `useRef`, `ChevronDown`, `ChevronUp`
  - Dock is now always rendered on both desktop and mobile viewports

- **ChatHomepage.tsx**
  - Removed `useCategoryDockVisibility` hook and related context dependency
  - Removed dynamic `inputBottomClass` calculation that adjusted input position based on dock visibility
  - Simplified layout by moving chat input from fixed bottom positioning into the main content flow
  - Removed `pb-48` padding that was compensating for fixed input positioning
  - Removed unused `cn` utility import
  - Input box and recent history chips now render as part of the centered content section

## Implementation Details
The dock is now permanently visible, simplifying the component hierarchy and removing the need for visibility state synchronization between components. The chat input is repositioned as part of the natural document flow within the centered content area, eliminating the complexity of managing fixed positioning relative to the dock's visibility state.

https://claude.ai/code/session_01SDpSTd62tZ3zsfLZAp889D