### PR TITLE
Update icon paths from icons2 to icons directory

### DIFF
--- a/apps/qwksearch-web/components/ResearchAgent/SearchResults/MessageSources.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/SearchResults/MessageSources.tsx
@@ -17,32 +17,32 @@ import type { CategoryTab, SearchCategory, SearchParams, SearchResult } from '..
 const CATEGORY_TABS: CategoryTab[] = [
   {
     code: 'general',
-    icon: '/icons2/categories/icon-search-web.svg',
+    icon: '/icons/categories/icon-search-web.svg',
     name: 'Web',
   },
   {
     code: 'news',
-    icon: '/icons2/categories/icon-search-news.svg',
+    icon: '/icons/categories/icon-search-news.svg',
     name: 'News',
   },
   {
     code: 'videos',
-    icon: '/icons2/categories/icon-search-videos.svg',
+    icon: '/icons/categories/icon-search-videos.svg',
     name: 'Videos',
   },
   {
     code: 'images',
-    icon: '/icons2/categories/icon-search-images.svg',
+    icon: '/icons/categories/icon-search-images.svg',
     name: 'Images',
   },
   {
     code: 'science',
-    icon: '/icons2/categories/icon-search-academic.svg',
+    icon: '/icons/categories/icon-search-academic.svg',
     name: 'Academic',
   },
   {
     code: 'files',
-    icon: '/icons2/categories/icon-search-files.svg',
+    icon: '/icons/categories/icon-search-files.svg',
     name: 'Files',
   },
 ];


### PR DESCRIPTION
## Summary
Updated all category tab icon paths to use the correct `icons` directory instead of the deprecated `icons2` directory.

## Changes
- Updated icon paths for all 6 category tabs (Web, News, Videos, Images, Academic, Files)
- Changed path prefix from `/icons2/categories/` to `/icons/categories/`
- All icon filenames remain unchanged

## Details
This change ensures that the search category icons reference the correct asset directory. The icon files themselves are not modified, only the paths used to reference them in the component configuration.

https://claude.ai/code/session_018JREKenkRbwD2rg9sU9UnR