### PR TITLE
Migrate Google One Tap from better-auth plugin to native GSI

### DIFF
--- a/apps/qwksearch-web/components/layout/GoogleOneTap.tsx
+++ b/apps/qwksearch-web/components/layout/GoogleOneTap.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { authClient } from '@/lib/auth/client';
 import { useSession } from '@/components/ResearchAgent/hooks/useSession';
+import { NEXT_PUBLIC_GOOGLE_CLIENT_ID } from '@/lib/config/site';
 
 export default function GoogleOneTap() {
   const { isAuthenticated, isLoading } = useSession();
@@ -12,21 +12,63 @@ export default function GoogleOneTap() {
     if (isLoading || isAuthenticated || triggeredRef.current) return;
     triggeredRef.current = true;
 
-    authClient.oneTap({
-      callbackURL: '/',
-      onPromptNotification: (notification) => {
-        // Triggered when FedCM/One Tap can't be shown (origin not whitelisted,
-        // user dismissed, no Google session, etc.). Silently no-op — the user
-        // can still sign in via the standard buttons on /login.
+    const initOneTap = () => {
+      const g = window.google;
+      if (!g?.accounts?.id) return;
+
+      g.accounts.id.initialize({
+        client_id: NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+        // FedCM-only mode: disables the legacy /gsi/status XHR that is
+        // CORS-blocked when credentials mode is 'include'.
+        use_fedcm_for_prompt: true,
+        itp_support: true,
+        callback: async (response: { credential: string }) => {
+          try {
+            const res = await fetch('/api/auth/one-tap/callback', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ idToken: response.credential }),
+              credentials: 'include',
+            });
+            if (res.ok) {
+              window.location.href = '/';
+            }
+          } catch {
+            // Silent fail — user can sign in via the buttons on /login.
+          }
+        },
+      });
+
+      g.accounts.id.prompt((notification: any) => {
         if (process.env.NODE_ENV === 'development') {
-          console.warn('Google One Tap not displayed:', notification);
+          if (notification.isNotDisplayed?.() || notification.isSkippedMoment?.()) {
+            console.warn(
+              'Google One Tap not displayed:',
+              notification.getNotDisplayedReason?.() ?? notification.getSkippedReason?.(),
+            );
+          }
         }
-      },
-    }).catch((error) => {
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('Google One Tap failed:', error);
+      });
+    };
+
+    // Reuse an already-loaded GSI script if present, otherwise inject it.
+    if (window.google?.accounts?.id) {
+      initOneTap();
+    } else {
+      const existing = document.querySelector<HTMLScriptElement>(
+        'script[src*="accounts.google.com/gsi"]',
+      );
+      if (existing) {
+        existing.addEventListener('load', initOneTap);
+      } else {
+        const script = document.createElement('script');
+        script.src = 'https://accounts.google.com/gsi/client';
+        script.async = true;
+        script.defer = true;
+        script.onload = initOneTap;
+        document.head.appendChild(script);
       }
-    });
+    }
   }, [isLoading, isAuthenticated]);
 
   return null;

--- a/apps/qwksearch-web/lib/auth/client.ts
+++ b/apps/qwksearch-web/lib/auth/client.ts
@@ -1,11 +1,8 @@
 import { createAuthClient } from "better-auth/react";
-import { oneTapClient, magicLinkClient, anonymousClient } from "better-auth/client/plugins";
+import { magicLinkClient, anonymousClient } from "better-auth/client/plugins";
 import { cloudflareClient } from "better-auth-cloudflare/client";
 import { sentinelClient } from "@better-auth/infra/client";
-import {
-  NEXT_PUBLIC_BASE_URL,
-  NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-} from "../config/site";
+import { NEXT_PUBLIC_BASE_URL } from "../config/site";
 
 const getBaseURL = () => {
   if (typeof window !== "undefined") {
@@ -17,17 +14,6 @@ const getBaseURL = () => {
 export const authClient = createAuthClient({
   baseURL: getBaseURL(),
   plugins: [
-    oneTapClient({
-      clientId: NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
-      // better-auth's fedCM flag only covers sign-out; use_fedcm_for_prompt is required to skip the legacy /gsi/status XHR (CORS-blocks under credentials).
-      additionalOptions: {
-        use_fedcm_for_prompt: true,
-        itp_support: true,
-      },
-      promptOptions: {
-        fedCM: true,
-      },
-    }),
     magicLinkClient(),
     cloudflareClient(),
     anonymousClient(),

--- a/apps/qwksearch-web/lib/config/site.ts
+++ b/apps/qwksearch-web/lib/config/site.ts
@@ -28,7 +28,7 @@ import iconNewsTitle from "@/components/icons/icon-news-title.svg";
 
 export const /** App Name in title case */
   APP_NAME: string = "QwkSearch",
-  NEXT_PUBLIC_BASE_URL = "http://QwkSearch.com",
+  NEXT_PUBLIC_BASE_URL = "https://qwksearch.com",
   NEXT_PUBLIC_GOOGLE_CLIENT_ID =
     "644604561446-niuns88krqdrs260kptpf1ti10ecrfls.apps.googleusercontent.com",
   /** App Email for support */


### PR DESCRIPTION
## Summary
Migrated Google One Tap authentication from the better-auth `oneTapClient` plugin to a direct implementation using Google's Sign-In (GSI) library. This change provides better control over the authentication flow and resolves CORS issues with the legacy `/gsi/status` XHR request.

## Key Changes
- **Removed better-auth One Tap plugin**: Eliminated the `oneTapClient` plugin dependency from `authClient` configuration in `lib/auth/client.ts`
- **Implemented native GSI integration**: Added direct Google Accounts API initialization in `GoogleOneTap.tsx` component with:
  - Manual script injection for the Google GSI library (`accounts.google.com/gsi/client`)
  - Script reuse detection to avoid duplicate loading
  - Direct credential handling via `/api/auth/one-tap/callback` endpoint
  - FedCM-only mode (`use_fedcm_for_prompt: true`) to bypass CORS-blocked legacy XHR
- **Improved error handling**: Replaced generic error logging with notification-based debugging that checks `isNotDisplayed()` and `isSkippedMoment()` states
- **Fixed base URL**: Updated `NEXT_PUBLIC_BASE_URL` from `http://QwkSearch.com` to `https://qwksearch.com` for proper HTTPS protocol

## Implementation Details
- The component now manages the full GSI lifecycle: script loading, initialization, and prompt display
- Reuses existing GSI scripts if already loaded on the page to prevent duplicate initialization
- Silently fails if One Tap cannot be displayed, allowing users to fall back to standard login buttons
- Maintains the same user experience while providing more granular control over the authentication flow

https://claude.ai/code/session_01MjWgzLhc6CG9Xrmp76YF8n