### PR TITLE
Reposition DynamicIslandTOC from bottom to top of editor

### DIFF
--- a/packages/reason-editor/src/search/DynamicIslandTOC.tsx
+++ b/packages/reason-editor/src/search/DynamicIslandTOC.tsx
@@ -153,10 +153,10 @@ export function DynamicIslandTOC({ headings, onNavigate, editorRef }: DynamicIsl
       </AnimatePresence>
 
       <motion.div
-        initial={{ y: 50, opacity: 0 }}
+        initial={{ y: -50, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ type: "spring", stiffness: 300, damping: 25 }}
-        className="fixed bottom-[30px] left-1/2 z-[9999] flex -translate-x-1/2 flex-col items-center"
+        className="fixed top-[44px] left-1/2 z-[9999] flex -translate-x-1/2 flex-col items-center"
       >
         <motion.div
           onClick={() => { if (!isExpanded) setIsExpanded(true); }}


### PR DESCRIPTION
## Summary
Repositioned the Dynamic Island Table of Contents component from the bottom of the editor to the top, adjusting both its animation and layout positioning.

## Key Changes
- Changed initial animation from `y: 50` to `y: -50` to animate downward from above instead of upward from below
- Moved component positioning from `bottom-[30px]` to `top-[44px]` to place it at the top of the editor interface

## Implementation Details
The component now appears at the top of the editor with a smooth spring animation that slides down into place. This repositioning maintains the same centered horizontal alignment and z-index layering while changing the vertical placement and corresponding animation direction.

https://claude.ai/code/session_01QgoXWq67A77MSNuDbkan3r