### PR TITLE
Replace Vite with rolldown-vite in package overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:editor": "turbo build --filter=reason-editor"
   },
   "overrides": {
-    "@vitejs/plugin-react": "5.2.0"
+    "@vitejs/plugin-react": "5.2.0",
+    "vite": "npm:rolldown-vite@latest"
   },
   "devDependencies": {
     "turbo": "^2.9.9"


### PR DESCRIPTION
## Summary
Updated the package.json overrides to use rolldown-vite as the Vite implementation instead of the default Vite package.

## Changes
- Added `"vite": "npm:rolldown-vite@latest"` to the overrides section in package.json
- This ensures rolldown-vite (the latest version) is used as the Vite dependency across the monorepo

## Details
This change leverages npm's package alias feature to transparently replace the standard Vite package with rolldown-vite, which is a Vite-compatible build tool. This allows the project to benefit from rolldown's performance improvements while maintaining compatibility with existing Vite-based configurations and plugins.

https://claude.ai/code/session_01KiRi6TEyhqtDAUjsyMvUGb