### PR TITLE
Fix web build import mismatches

### DIFF
--- a/apps/qwksearch-web/components/ResearchAgent/components/ChatConversation/ChatHomepage.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/components/ChatConversation/ChatHomepage.tsx
@@ -9,7 +9,7 @@ import ChatInputBox from '../MessageComposer/ChatInputBox';
 import RecentHistoryChips from './RecentHistoryChips';
 import { useChat } from '@/components/ResearchAgent/hooks/useChat';
 import { getBackgroundArtwork } from './background-art';
-import config from '@/lib/config/site';
+import * as config from '@/lib/config/site';
 // import QuantumWaveOrbital from 'quantum-sphere-loading-icon/react';
 
 import QuantumWaveOrbital from 'grab-url/icons/quantum-sphere' ///loading-animations'

--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "open-ready vinext dev",
-    "prebuild": "bun --cwd ../../packages/shadcn-app-dock run build",
+    "prebuild": "cd ../../packages/shadcn-app-dock && bun run build",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "vinext start",

--- a/packages/shadcn-app-dock/src/index.ts
+++ b/packages/shadcn-app-dock/src/index.ts
@@ -17,3 +17,4 @@ export {
 // Primitives re-exported so consumers can build `menu.renderContent` without
 // re-importing shadcn components.
 export { Dock, DockIcon, DockItem, DockLabel, dockVariants } from "./components/dock"
+export { DropdownMenuItem, DropdownMenuSeparator } from "./components/dropdown-menu"


### PR DESCRIPTION
### Motivation
- Resolve build-time failures caused by incorrect imports/exports between `qwksearch-web` and the `shadcn-app-dock` package and an unreliable `prebuild` script invocation.

### Description
- Re-export `DropdownMenuItem` and `DropdownMenuSeparator` from `packages/shadcn-app-dock/src/index.ts` so the consumer can import these primitives from the package barrel via `shadcn-app-dock`.
- Update `apps/qwksearch-web/components/ResearchAgent/components/ChatConversation/ChatHomepage.tsx` to use a namespace import `import * as config from '@/lib/config/site';` to match the named exports provided by the site config module.
- Modify `apps/qwksearch-web/package.json` `prebuild` script to `cd ../../packages/shadcn-app-dock && bun run build` to avoid Bun `--cwd` parsing issues in the CI/build environment.

### Testing
- Ran `cd apps/qwksearch-web && bun run build`, which reached the prebuild step but failed because `vite` was not available in the package environment (script exited with `vite: command not found`).
- Ran `bun install` to install dependencies, which failed due to registry `403` errors blocking package resolution in this environment, so a full successful build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4a69040c832d8f1457db92dfce7c)