### PR TITLE
Fix vinext parseSync error by using @babel/parser

### DIFF
--- a/.patches/vinext-babel-parser.patch
+++ b/.patches/vinext-babel-parser.patch
@@ -1,0 +1,30 @@
+--- a/node_modules/vinext/dist/build/report.js
++++ b/node_modules/vinext/dist/build/report.js
+@@ -1,6 +1,22 @@
+ import { findDir } from "../utils/project.js";
+ import fs from "node:fs";
+-import { parseSync } from "vite";
++import { parse as babelParse } from "@babel/parser";
++
++function parseSync(filename, code, options) {
++	try {
++		const program = babelParse(code, {
++			sourceType: "module",
++			plugins: ["typescript", "jsx"],
++			errorRecovery: true
++		});
++		return {
++			program,
++			errors: program.errors || []
++		};
++	} catch (err) {
++		return {
++			program: null,
++			errors: [{
++				severity: "Error",
++				message: err.message
++			}]
++		};
++	}
++}
+ //#region src/build/report.ts

--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -152,6 +152,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@babel/parser": "^7.23.0",
     "@cloudflare/vite-plugin": "^1.40.2",
     "@libsql/client": "^0.17.3",
     "@next/bundle-analyzer": "^16.2.9",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "turbo build",
     "build:web": "turbo build --filter=qwksearch-web",
     "dev:editor": "turbo dev --filter=reason-editor",
-    "build:editor": "turbo build --filter=reason-editor"
+    "build:editor": "turbo build --filter=reason-editor",
+    "postinstall": "node scripts/patch-vinext.js"
   },
   "devDependencies": {
     "turbo": "^2.9.9"

--- a/scripts/patch-vinext.js
+++ b/scripts/patch-vinext.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Patch vinext to use @babel/parser instead of non-existent vite.parseSync
+ * This fixes: "SyntaxError: The requested module vite does not provide an export named parseSync"
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const reportJsPath = path.join(__dirname, '../node_modules/vinext/dist/build/report.js');
+
+if (!fs.existsSync(reportJsPath)) {
+  console.log('vinext not yet installed, skipping patch');
+  process.exit(0);
+}
+
+const content = fs.readFileSync(reportJsPath, 'utf-8');
+
+// Check if already patched
+if (content.includes('babelParse')) {
+  console.log('vinext already patched');
+  process.exit(0);
+}
+
+// Check if it has the old import
+if (!content.includes('import { parseSync } from "vite"')) {
+  console.log('vinext does not have the expected parseSync import, skipping patch');
+  process.exit(0);
+}
+
+const patchedContent = content.replace(
+  'import { parseSync } from "vite";',
+  `import { parse as babelParse } from "@babel/parser";
+
+function parseSync(filename, code, options) {
+	try {
+		const program = babelParse(code, {
+			sourceType: "module",
+			plugins: ["typescript", "jsx"],
+			errorRecovery: true
+		});
+		return {
+			program,
+			errors: program.errors || []
+		};
+	} catch (err) {
+		return {
+			program: null,
+			errors: [{
+				severity: "Error",
+				message: err.message
+			}]
+		};
+	}
+}`
+);
+
+fs.writeFileSync(reportJsPath, patchedContent);
+console.log('✓ patched vinext to use @babel/parser');


### PR DESCRIPTION
## Summary
Fixes the build error: `SyntaxError: The requested module vite does not provide an export named parseSync`

## Problem
The `vinext` package incorrectly tries to import `parseSync` from the `vite` module, but this export doesn't exist in vite. This causes build failures when running `vinext build`.

## Solution
- Replace the non-existent `vite.parseSync` with `@babel/parser` which provides proper AST parsing capabilities
- Add an automatic postinstall script that patches vinext on fresh installs
- Add `@babel/parser` as an explicit devDependency to ensure availability

## Changes
- `scripts/patch-vinext.js` - Postinstall script that applies the babel parser fix
- `.patches/vinext-babel-parser.patch` - Patch file documenting the change
- `apps/qwksearch-web/package.json` - Added @babel/parser devDependency
- `package.json` - Added postinstall script hook

The fix allows vinext to properly analyze Next.js route segments during the build process.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXcyarn6RW87oGzU1f7bNF)_