### PR TITLE
Downgrade Vite from 8.0.16 to 7.0.0

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -176,7 +176,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
     "vinext": "latest",
-    "vite": "^8.0.16",
+    "vite": "^7.0.0",
     "wait-on": "^9.0.10",
     "wrangler": "^4.100.0"
   }


### PR DESCRIPTION
## Summary
Downgrade the Vite build tool dependency from version 8.0.16 to 7.0.0 in the qwksearch-web application.

## Changes
- Updated `vite` dependency in `package.json` from `^8.0.16` to `^7.0.0`

## Notes
This downgrade may be necessary to resolve compatibility issues with other dependencies or to maintain stability with the current project configuration. Please verify that all build and development processes continue to function correctly with Vite 7.0.0.

https://claude.ai/code/session_011D1F91EZ3NHRCm9x2KHjpN