### PR TITLE
Move Footer component from Home page to ChatHomepage

### DIFF
--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -1,6 +1,10 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=Montserrat:wght@400;500;600;700&family=Nunito:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&family=Oswald:wght@400;500;600;700&family=Playfair+Display:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=PT+Sans:wght@400;700&family=Raleway:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500;700&family=Roboto+Slab:wght@400;500;700&family=Source+Code+Pro:wght@400;500;700&family=Source+Sans+3:wght@400;500;600;700&family=Ubuntu:wght@400;500;700&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
+/* Workspace packages aren't covered by Tailwind's automatic source detection,
+   so their responsive utilities (e.g. md:hidden on the mobile dock) must be
+   registered explicitly. */
+@source "../../../packages/shadcn-app-dock/src";
 
 @custom-variant dark (&:is(.dark *));
 /* @plugin "@tailwindcss/typography"; */

--- a/apps/qwksearch-web/app/page.tsx
+++ b/apps/qwksearch-web/app/page.tsx
@@ -1,17 +1,9 @@
 'use client';
 
 import ChatWindow from '@/components/ResearchAgent/components/ChatConversation/ChatWindow';
-import Footer from '@/components/layout/Footer';
-import * as config from '@/lib/config/site';
-const { listFooterLinks } = config;
 
 const Home = () => {
-  return (
-    <div className="relative min-h-screen">
-      <ChatWindow />
-      <Footer listFooterLinks={listFooterLinks} />
-    </div>
-  );
+  return <ChatWindow />;
 };
 
 export default Home;

--- a/apps/qwksearch-web/components/ResearchAgent/components/ChatConversation/ChatHomepage.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/components/ChatConversation/ChatHomepage.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { GradientBlur } from '@/components/ui/gradient-blur';
 import ChatInputBox from '../MessageComposer/ChatInputBox';
 import RecentHistoryChips from './RecentHistoryChips';
+import Footer from '@/components/layout/Footer';
 import { useChat } from '@/components/ResearchAgent/hooks/useChat';
 import { getBackgroundArtwork } from './background-art';
 import * as config from '@/lib/config/site';
@@ -105,6 +106,7 @@ export default function ChatHomepage() {
         </div>
       </div>
 
+      <Footer listFooterLinks={config.listFooterLinks} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the layout structure by relocating the Footer component from the root Home page to the ChatHomepage component, simplifying the Home page to only render ChatWindow.

## Key Changes
- **Removed Footer from Home page** (`app/page.tsx`): Eliminated the Footer component and its associated imports/config from the root page layout
- **Added Footer to ChatHomepage** (`components/ResearchAgent/components/ChatConversation/ChatHomepage.tsx`): Integrated the Footer component directly into ChatHomepage with the same `listFooterLinks` configuration
- **Updated Tailwind CSS configuration** (`app/globals.css`): Added explicit source detection for the shadcn-app-dock workspace package to ensure responsive utilities are properly registered

## Implementation Details
- The Footer component now renders within ChatHomepage's layout structure rather than wrapping it at the root level
- This change maintains the same footer functionality while improving component encapsulation
- The Tailwind CSS update ensures that responsive utilities from workspace packages are properly compiled, addressing potential styling issues with components like the mobile dock

https://claude.ai/code/session_01M4sGLL6oB152vYdeNsv7Ft