### PR TITLE
Refactor vinext patching to scan all JS files instead of specific ones

### DIFF
--- a/scripts/patch-vinext.js
+++ b/scripts/patch-vinext.js
@@ -77,17 +77,6 @@ function getVinextDistDirs() {
   return candidates.filter((candidatePath) => fs.existsSync(candidatePath));
 }
 
-function patchReportJs(vinextDist) {
-  const reportJsPath = path.join(vinextDist, 'build/report.js');
-
-  if (!fs.existsSync(reportJsPath)) {
-    console.log('vinext report.js not found, skipping parseSync patch');
-    return;
-  }
-
-  return candidates.filter((dist) => fs.existsSync(dist));
-}
-
 // Recursively collect *.js files under a directory.
 function collectJsFiles(dir) {
   const out = [];
@@ -146,12 +135,12 @@ function parseSync(filename, code, options) {
 }`,
   );
 
-  fs.writeFileSync(reportJsPath, patched);
-  console.log(`✓ patched ${path.relative(repoRoot, reportJsPath)} to use @babel/parser`);
+  fs.writeFileSync(filePath, patched);
+  return true;
 }
 
-function patchIndexJs(vinextDist) {
-  const indexJsPath = path.join(vinextDist, 'index.js');
+function patchTransformWithOxc(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
 
   if (content.includes('transformWithOxcShim')) return false; // already patched
   if (!content.includes('transformWithOxc')) return false;
@@ -189,8 +178,8 @@ async function transformWithOxcShim(code, id, options) {
   // Re-point call sites at the shim.
   patched = patched.replace(/\btransformWithOxc\(/g, 'transformWithOxcShim(');
 
-  fs.writeFileSync(indexJsPath, patched);
-  console.log(`✓ patched ${path.relative(repoRoot, indexJsPath)} to use transformWithEsbuild`);
+  fs.writeFileSync(filePath, patched);
+  return true;
 }
 
 const vinextDistDirs = getVinextDistDirs();
@@ -200,7 +189,17 @@ if (vinextDistDirs.length === 0) {
   process.exit(0);
 }
 
+let parseSyncPatched = 0;
+let oxcPatched = 0;
+
 for (const vinextDist of vinextDistDirs) {
-  patchReportJs(vinextDist);
-  patchIndexJs(vinextDist);
+  for (const file of collectJsFiles(vinextDist)) {
+    if (patchParseSync(file)) parseSyncPatched++;
+    if (patchTransformWithOxc(file)) oxcPatched++;
+  }
 }
+
+console.log(
+  `✓ patched vinext in ${vinextDistDirs.length} location(s): ` +
+    `${parseSyncPatched} parseSync, ${oxcPatched} transformWithOxc file(s)`,
+);


### PR DESCRIPTION
## Summary
Refactored the vinext patching script to use a more flexible, file-scanning approach instead of targeting specific hardcoded files. This makes the patching logic more robust and maintainable.

## Key Changes
- Removed `patchReportJs()` function that had a logic bug (returned filtered candidates instead of patching)
- Renamed `patchIndexJs()` to `patchTransformWithOxc()` and made it generic to accept any file path
- Renamed `patchParseSync()` (formerly embedded in report.js patching) to be a standalone function accepting file paths
- Changed main patching loop to iterate through all `.js` files in vinext dist directories using `collectJsFiles()`
- Both patch functions now return boolean indicating success instead of logging directly
- Added counters to track total files patched for each type
- Improved final console output to show summary statistics across all locations

## Implementation Details
- The refactored approach scans all JavaScript files in the vinext distribution and applies patches where applicable
- Each patch function checks if the target code pattern exists before attempting to patch
- Functions return `false` if already patched or pattern not found, `true` if successfully patched
- This allows the same patch logic to be applied across multiple files if needed

https://claude.ai/code/session_01Lt9yDMS34G7ZmC3UAkXNKi