### PR TITLE
Make chat history persistence resilient to stale sessions

### DIFF
--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -5,7 +5,9 @@
 
 import crypto from "crypto";
 import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
+import { eq } from "drizzle-orm";
 import { getDB } from "@/lib/database";
+import { user as userSchema } from "@/lib/database/schema";
 import { searchHandlers } from "ai-research-agent/search";
 import ModelRegistry from "ai-research-agent/models/registry";
 import { getUserId } from "@/lib/auth/session";
@@ -117,7 +119,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
   const t0 = Date.now();
   console.log("[POST /api/agent/chat] request received");
   try {
-    const userId = await getUserId();
+    let userId = await getUserId();
     console.log("[POST /api/agent/chat] userId:", userId ?? "(guest)");
 
     // DB is only needed to persist history for authenticated users.
@@ -126,6 +128,22 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
     let db: ReturnType<typeof getDB> | undefined;
     if (userId) {
       db = getDB();
+
+      // A session can outlive its user row (e.g. sessions cached in KV that
+      // reference a user from a previous database). The chats/messages tables
+      // enforce FOREIGN KEY (userId) REFERENCES user(id), so persisting with a
+      // stale userId aborts the insert. Downgrade such sessions to guest.
+      const userRow = await db.query.user.findFirst({
+        where: eq(userSchema.id, userId),
+        columns: { id: true },
+      });
+      if (!userRow) {
+        console.warn(
+          `[POST /api/agent/chat] session userId ${userId} has no user row; treating as guest`,
+        );
+        userId = null;
+        db = undefined;
+      }
     }
 
     /** @type {Body} Raw request body before validation. */
@@ -273,15 +291,24 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       message.chatId,
     );
     if (userId && db) {
-      await handleHistorySave(
-        message,
-        humanMessageId,
-        body.focusMode,
-        body.files,
-        userId,
-        db,
-        body.thinkingTimeLimit,
-      );
+      try {
+        await handleHistorySave(
+          message,
+          humanMessageId,
+          body.focusMode,
+          body.files,
+          userId,
+          db,
+          body.thinkingTimeLimit,
+        );
+      } catch (err) {
+        // History persistence is best-effort: the answer stream is already
+        // set up, so a failed save must not turn the request into a 500.
+        console.error(
+          "[POST /api/agent/chat] handleHistorySave failed (continuing without history):",
+          err,
+        );
+      }
     }
     console.log(
       `[POST /api/agent/chat] history saved, returning stream (setup took ${Date.now() - t0}ms)`,

--- a/apps/qwksearch-web/lib/chat/stream-handler.ts
+++ b/apps/qwksearch-web/lib/chat/stream-handler.ts
@@ -139,7 +139,13 @@ export const handleEmitterEvents = async (
             sources: parsedData.data as Document[],
             createdAt: new Date().toString(),
           })
-          .execute();
+          .execute()
+          .catch((err) => {
+            console.error(
+              "[handleEmitterEvents] failed to save source message:",
+              err,
+            );
+          });
       }
     }
   });
@@ -159,7 +165,13 @@ export const handleEmitterEvents = async (
           role: "assistant",
           createdAt: new Date().toString(),
         })
-        .execute();
+        .execute()
+        .catch((err) => {
+          console.error(
+            "[handleEmitterEvents] failed to save assistant message:",
+            err,
+          );
+        });
     }
   });
 


### PR DESCRIPTION
## Summary
This PR improves the resilience of chat history persistence by handling edge cases where sessions reference users that no longer exist in the database, and by making history saves non-blocking to prevent request failures.

## Key Changes
- **Stale session detection**: Added validation to check if a user row exists in the database before attempting to persist chat history. If a user row is missing (e.g., due to cached sessions outliving their user records), the session is downgraded to guest mode to avoid foreign key constraint violations.
- **Non-blocking history saves**: Wrapped `handleHistorySave` call in a try-catch block to prevent failed history persistence from causing request failures. History saves are now best-effort operations that log errors without affecting the response stream.
- **Error handling in stream handlers**: Added `.catch()` handlers to database insert operations in `handleEmitterEvents` for both source and assistant messages to gracefully handle persistence failures without interrupting the message stream.

## Implementation Details
- The user row validation uses a simple existence check (`findFirst` with only the `id` column) to minimize database overhead
- Error messages are logged with context to aid debugging of persistence issues
- All database operations remain non-blocking to maintain stream responsiveness

https://claude.ai/code/session_01BT2PKzRKmEw5DDjzTvFk82