### PR TITLE
Centralize stale-session guard in getSession and revoke orphaned KV sessions

### DIFF
--- a/apps/qwksearch-web/lib/auth/session.ts
+++ b/apps/qwksearch-web/lib/auth/session.ts
@@ -1,5 +1,8 @@
+import { eq } from "drizzle-orm";
 import { initAuth } from "./index";
 import { headers } from "next/headers";
+import { getDB } from "../database";
+import { user as userSchema } from "../database/schema";
 
 export interface AuthSession {
   session: {
@@ -22,9 +25,35 @@ export interface AuthSession {
 export async function getSession(): Promise<AuthSession | null> {
   try {
     const auth = await initAuth();
+    const requestHeaders = await headers();
     const session = await auth.api.getSession({
-      headers: await headers(),
+      headers: requestHeaders,
     });
+    if (!session) return null;
+
+    // Sessions are stored in KV (better-auth-cloudflare secondaryStorage) and
+    // can outlive their user row when the D1 database is recreated. Every
+    // userId column with FOREIGN KEY REFERENCES user(id) rejects writes for
+    // such stale sessions, so verify the user row exists before trusting the
+    // session anywhere.
+    const db = getDB();
+    const userRow = await db.query.user.findFirst({
+      where: eq(userSchema.id, session.user.id),
+      columns: { id: true },
+    });
+    if (!userRow) {
+      console.warn(
+        `[auth] session user ${session.user.id} has no user row; revoking stale session`,
+      );
+      try {
+        // Delete the orphaned session from KV so the client's own
+        // better-auth get-session calls stop reporting it as signed in.
+        await auth.api.signOut({ headers: requestHeaders });
+      } catch (signOutError) {
+        console.error("[auth] failed to revoke stale session:", signOutError);
+      }
+      return null;
+    }
 
     return session;
   } catch (error) {

--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -5,9 +5,7 @@
 
 import crypto from "crypto";
 import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
-import { eq } from "drizzle-orm";
 import { getDB } from "@/lib/database";
-import { user as userSchema } from "@/lib/database/schema";
 import { searchHandlers } from "ai-research-agent/search";
 import ModelRegistry from "ai-research-agent/models/registry";
 import { getUserId } from "@/lib/auth/session";
@@ -119,7 +117,10 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
   const t0 = Date.now();
   console.log("[POST /api/agent/chat] request received");
   try {
-    let userId = await getUserId();
+    // getUserId validates the session's user row against the current database
+    // (stale KV sessions are revoked and reported as guest), so a non-null
+    // userId here is always safe for FK-bound writes.
+    const userId = await getUserId();
     console.log("[POST /api/agent/chat] userId:", userId ?? "(guest)");
 
     // DB is only needed to persist history for authenticated users.
@@ -128,22 +129,6 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
     let db: ReturnType<typeof getDB> | undefined;
     if (userId) {
       db = getDB();
-
-      // A session can outlive its user row (e.g. sessions cached in KV that
-      // reference a user from a previous database). The chats/messages tables
-      // enforce FOREIGN KEY (userId) REFERENCES user(id), so persisting with a
-      // stale userId aborts the insert. Downgrade such sessions to guest.
-      const userRow = await db.query.user.findFirst({
-        where: eq(userSchema.id, userId),
-        columns: { id: true },
-      });
-      if (!userRow) {
-        console.warn(
-          `[POST /api/agent/chat] session userId ${userId} has no user row; treating as guest`,
-        );
-        userId = null;
-        db = undefined;
-      }
     }
 
     /** @type {Body} Raw request body before validation. */


### PR DESCRIPTION
# Problem

The `insert into "chats"` failure on `POST /api/agent/chat` (log `a1606440ff1feb2a`, 19:03 UTC) was verified against the production D1 database: the session's userId has **no row in the `user` table**, so the FK `chats.userId → user.id` rejects the insert. Sessions are stored in KV (`better-auth-cloudflare` secondaryStorage) and survived the switch to the `qwksearch-new` D1 database, while the user rows did not.

PR #34 fixed this for the chat handler only, and left the stale KV session alive, which had two gaps:

1. **Affected users stayed "signed in" forever** — the client's own better-auth `get-session` still reported a session, but every chat silently saved no history.
2. **Other FK-bound routes remained exposed.** Production DDL enforces `REFERENCES user(id)` on `favorites`, `chats`, `messages`, `session`, and `account`, so e.g. `POST /api/doc/favorites` would 500 the same way for these users.

# Fix

- **`lib/auth/session.ts`** — `getSession()` now verifies the session's user row exists in the current database. If missing, it revokes the orphaned session via `auth.api.signOut` (deletes it from KV, so the client's next `get-session` reports signed-out and the user can re-authenticate cleanly) and returns `null`. This covers every route that uses `getUserId` / `requireUserId` / `requireSession`, including chat and favorites.
- **`lib/chat/handler.ts`** — removed the now-redundant per-route user-row check from #34; the best-effort try/catch around `handleHistorySave` stays as defense in depth.

# Verification

- Queried production D1 directly: erroring userId `wRovBM…` absent from `user` (42 rows), `chats` table has 0 rows ever inserted, and the `session` table has no row for that user — confirming the KV-session/recreated-DB diagnosis.
- Confirmed `auth.api.signOut` in the installed better-auth 1.6.23 deletes the session through the internal adapter (KV secondary storage included) and does not throw when no session cookie is present.
- `tsc --noEmit`: no new errors in the touched files (repo has pre-existing errors elsewhere, unchanged).

Cost note: this adds one indexed PK lookup (~0.5 ms measured) per session resolution.

⚠️ Reminder: deploys are manual (`vinext deploy`) — the error in the log came from a worker version that predates #34, so both that fix and this one need a deploy to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWWFCkU7RAHYCGpbDXwVA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWWFCkU7RAHYCGpbDXwVA5)_