### PR TITLE
Add Cloudflare Puppeteer scraper + Tavily fallback for article extraction

### DIFF
--- a/apps/qwksearch-web/app/api/doc/article/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/doc/article/__tests__/route.test.ts
@@ -4,6 +4,7 @@
 import { GET, POST } from "../route";
 import { NextRequest } from "next/server";
 import { extractContent } from "ai-research-agent/extractor/url-to-content/url-to-content";
+import { extractArticleViaScraper, extractViaTavily } from "@/lib/scraper";
 import { getDB } from "@/lib/database";
 import { articleCache, articleQA } from "@/lib/database/schema";
 
@@ -12,12 +13,31 @@ jest.mock("ai-research-agent/extractor/url-to-content/url-to-content", () => ({
   extractContent: jest.fn(),
 }));
 
+// Mock the Cloudflare Puppeteer scraper + Tavily fallback so tests never hit
+// the network. By default both "fail" (return an error) so the route falls
+// through to the in-process extractContent path exercised by most tests.
+jest.mock("@/lib/scraper", () => ({
+  extractArticleViaScraper: jest.fn(),
+  extractViaTavily: jest.fn(),
+}));
+
+// getTavilyApiKey is read by the route to pass a key into extractViaTavily.
+jest.mock("@/lib/config/serverRegistry", () => ({
+  getTavilyApiKey: jest.fn(() => ""),
+}));
+
 jest.mock("@/lib/database", () => ({
   getDB: jest.fn(),
 }));
 
 const mockExtractContent = extractContent as jest.MockedFunction<
   typeof extractContent
+>;
+const mockExtractViaScraper = extractArticleViaScraper as jest.MockedFunction<
+  typeof extractArticleViaScraper
+>;
+const mockExtractViaTavily = extractViaTavily as jest.MockedFunction<
+  typeof extractViaTavily
 >;
 const mockGetDB = getDB as jest.MockedFunction<typeof getDB>;
 
@@ -34,6 +54,16 @@ const mockDbValues = jest.fn();
 describe("GET /api/doc/article", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // By default the scraper and Tavily both "fail" so tests exercise the
+    // extractContent fallback path. Individual tests override these to test the
+    // scraper and Tavily tiers.
+    mockExtractViaScraper.mockResolvedValue({
+      error: "scraper unavailable in test",
+    });
+    mockExtractViaTavily.mockResolvedValue({
+      error: "tavily unavailable in test",
+    });
 
     // Setup default mock DB chain
     mockDbLimit.mockReturnValue([]);
@@ -158,7 +188,7 @@ describe("GET /api/doc/article", () => {
     ]);
   });
 
-  it("should extract content if not cached", async () => {
+  it("should extract content if not cached (extractContent fallback)", async () => {
     mockDbLimit.mockReturnValueOnce([]); // No cache
 
     const extractedArticle = {
@@ -191,6 +221,75 @@ describe("GET /api/doc/article", () => {
     expect(mockExtractContent).toHaveBeenCalledWith(
       "https://example.com/new-article"
     );
+    expect(mockDbInsert).toHaveBeenCalled();
+  });
+
+  it("should extract content via the Cloudflare scraper when available", async () => {
+    mockDbLimit.mockReturnValueOnce([]); // No cache
+
+    const scrapedArticle = {
+      url: "https://example.com/scraped-article",
+      title: "Scraped Article",
+      html: "<p>Rendered by puppeteer-cloudflare</p>",
+      author: "Ada Lovelace",
+      author_cite: "Lovelace, A.",
+      source: "example.com",
+      word_count: 5,
+      cite: "Lovelace, A. <b>Scraped Article</b>.",
+    };
+
+    mockExtractViaScraper.mockResolvedValueOnce(scrapedArticle);
+
+    const req = new NextRequest(
+      "http://localhost:3000/api/doc/article?url=https://example.com/scraped-article"
+    );
+    const response = await GET(req);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(false);
+    expect(data.article.title).toBe("Scraped Article");
+    expect(data.article.html).toBe("<p>Rendered by puppeteer-cloudflare</p>");
+    // Scraper produced content, so the direct extractContent fallback is skipped.
+    expect(mockExtractViaScraper).toHaveBeenCalledWith(
+      "https://example.com/scraped-article"
+    );
+    expect(mockExtractContent).not.toHaveBeenCalled();
+    expect(mockDbInsert).toHaveBeenCalled();
+  });
+
+  it("should fall back to Tavily when the scraper fails", async () => {
+    mockDbLimit.mockReturnValueOnce([]); // No cache
+
+    // Scraper fails (default), Tavily succeeds.
+    const tavilyArticle = {
+      url: "https://apnews.com/article/example",
+      title: "AP Article",
+      html: "<p>Extracted by Tavily</p>",
+      source: "apnews.com",
+      word_count: 3,
+      via: "tavily",
+      cite: "apnews.com. <b>AP Article</b>.",
+    };
+    mockExtractViaTavily.mockResolvedValueOnce(tavilyArticle);
+
+    const req = new NextRequest(
+      "http://localhost:3000/api/doc/article?url=https://apnews.com/article/example"
+    );
+    const response = await GET(req);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(false);
+    expect(data.article.title).toBe("AP Article");
+    expect(data.article.html).toBe("<p>Extracted by Tavily</p>");
+    expect(mockExtractViaScraper).toHaveBeenCalled();
+    expect(mockExtractViaTavily).toHaveBeenCalledWith(
+      "https://apnews.com/article/example",
+      ""
+    );
+    // Tavily produced content, so the direct extractContent fallback is skipped.
+    expect(mockExtractContent).not.toHaveBeenCalled();
     expect(mockDbInsert).toHaveBeenCalled();
   });
 

--- a/apps/qwksearch-web/app/api/doc/article/route.ts
+++ b/apps/qwksearch-web/app/api/doc/article/route.ts
@@ -1,7 +1,8 @@
 /**
- * @fileoverview Article extraction and caching API. GET fetches an article
- * by URL with database caching and hit-count tracking, falling back to
- * in-process extraction via ai-research-agent. POST stores Q&A pairs and
+ * @fileoverview Article extraction and caching API. GET fetches an article by
+ * URL with database caching and hit-count tracking. Fresh extraction uses a
+ * bounded fallback chain: Cloudflare Puppeteer scraper (8s deadline) → Tavily
+ * extract → in-process ai-research-agent extraction. POST stores Q&A pairs and
  * follow-up questions for cached articles.
  */
 import { NextRequest, NextResponse } from "next/server";
@@ -9,6 +10,8 @@ import { getDB } from "@/lib/database";
 import { articleCache, articleQA } from "@/lib/database/schema";
 import { eq, sql } from "drizzle-orm";
 import { extractContent } from "ai-research-agent/extractor/url-to-content/url-to-content";
+import { extractArticleViaScraper, extractViaTavily } from "@/lib/scraper";
+import { getTavilyApiKey } from "@/lib/config/serverRegistry";
 
 interface Article {
   html?: string;
@@ -149,27 +152,89 @@ export async function GET(req: NextRequest) {
       });
     }
 
-    // If not in cache (or cached row was empty), extract in-process
-    console.log("[article] cache miss — extracting in-process", { url });
-    let extracted;
+    // If not in cache (or cached row was empty), extract fresh via a bounded
+    // fallback chain:
+    //   1. Cloudflare Puppeteer scraper (proxy.qwksearch.com), 8s deadline —
+    //      renders JavaScript + lightly bot-protected pages, then readability.
+    //   2. Tavily extract API — used when the scraper times out or returns a
+    //      challenge page (e.g. AP News serves a Datadome/Cloudflare block).
+    //   3. Direct in-process extraction (plain fetch + readability) as a last
+    //      resort if Tavily is unavailable/unconfigured.
+    // Each helper returns `{ error }` instead of throwing so we can decide
+    // cleanly whether to advance to the next tier.
+    console.log("[article] cache miss — extracting fresh", { url });
+
+    let scraped;
     try {
-      extracted = await extractContent(url);
-    } catch (extractError) {
-      const err = extractError as Error;
-      console.error("[article] extractContent threw exception", {
+      scraped = await extractArticleViaScraper(url);
+    } catch (scraperError) {
+      const serr = scraperError as Error;
+      console.warn("[article] scraper path threw unexpectedly", {
         url,
-        message: err?.message,
-        stack: err?.stack,
-        cause: err?.cause,
+        message: serr?.message,
       });
-      return NextResponse.json(
-        {
-          error: "Article extraction failed",
-          url,
-          detail: err?.message || String(extractError),
-        },
-        { status: 502 },
+      scraped = { error: serr?.message || "Scraper threw" };
+    }
+
+    let extracted;
+    if (scraped && scraped.html && !scraped.error) {
+      console.log("[article] Cloudflare scraper extraction succeeded", {
+        url,
+        htmlLength: scraped.html.length,
+        title: scraped.title,
+      });
+      extracted = scraped;
+    } else {
+      // Tier 2: Tavily extract fallback (scraper timed out / returned no HTML).
+      console.log(
+        "[article] scraper unusable — falling back to Tavily extract",
+        { url, reason: scraped?.error },
       );
+      let tavily;
+      try {
+        tavily = await extractViaTavily(url, getTavilyApiKey());
+      } catch (tavilyError) {
+        const terr = tavilyError as Error;
+        console.warn("[article] Tavily path threw unexpectedly", {
+          url,
+          message: terr?.message,
+        });
+        tavily = { error: terr?.message || "Tavily threw" };
+      }
+
+      if (tavily && tavily.html && !tavily.error) {
+        console.log("[article] Tavily extraction succeeded", {
+          url,
+          htmlLength: tavily.html.length,
+          title: tavily.title,
+        });
+        extracted = tavily;
+      } else {
+        // Tier 3: direct in-process extraction (plain fetch + readability).
+        console.log(
+          "[article] Tavily unusable — falling back to in-process extraction",
+          { url, reason: tavily?.error },
+        );
+        try {
+          extracted = await extractContent(url);
+        } catch (extractError) {
+          const err = extractError as Error;
+          console.error("[article] extractContent threw exception", {
+            url,
+            message: err?.message,
+            stack: err?.stack,
+            cause: err?.cause,
+          });
+          return NextResponse.json(
+            {
+              error: "Article extraction failed",
+              url,
+              detail: err?.message || String(extractError),
+            },
+            { status: 502 },
+          );
+        }
+      }
     }
     const article: Article = extracted as Article;
     console.log("[article] extractContent result", {

--- a/apps/qwksearch-web/lib/scraper/cloudflare-scraper-client.ts
+++ b/apps/qwksearch-web/lib/scraper/cloudflare-scraper-client.ts
@@ -37,6 +37,8 @@ export interface ScraperOptions {
   maxRetries?: number;
   /** 2Captcha API key for solving */
   twoCaptchaKey?: string;
+  /** Abort signal to bound the request (e.g. an 8s deadline). */
+  signal?: AbortSignal;
 }
 
 export interface ScraperJsonResponse {
@@ -68,7 +70,7 @@ export interface ScraperConfig {
 const DEFAULT_CONFIG: ScraperConfig = {
   baseURL: typeof process !== 'undefined' && process?.env?.SCRAPER_URL
     ? process.env.SCRAPER_URL
-    : 'https://scraper.qwksearch.workers.dev',
+    : 'https://proxy.qwksearch.com',
   apiKey: typeof process !== 'undefined' && process?.env?.SCRAPER_API_KEY
     ? process.env.SCRAPER_API_KEY
     : undefined,
@@ -109,9 +111,11 @@ export async function renderWithCloudflare(
   const mergedConfig = { ...DEFAULT_CONFIG, ...config };
   const apiKey = options.apiKey || mergedConfig.apiKey;
 
+  // The deployed scraper worker (proxy.qwksearch.com) accepts GET requests
+  // with query-string parameters on `/` and `/api/render`.
   const url = new URL('/api/render', mergedConfig.baseURL);
 
-  const body = {
+  const params: Record<string, string | number | boolean | undefined> = {
     url: options.url,
     wait: options.wait ?? 0,
     blockImages: options.blockImages ?? false,
@@ -119,7 +123,6 @@ export async function renderWithCloudflare(
     timeout: options.timeout ?? 30000,
     waitUntil: options.waitUntil ?? 'networkidle2',
     format: options.format ?? 'html',
-    headers: options.headers ?? {},
     proxyUrl: options.proxyUrl,
     proxyUser: options.proxyUser,
     proxyPass: options.proxyPass,
@@ -129,18 +132,22 @@ export async function renderWithCloudflare(
     twoCaptchaKey: options.twoCaptchaKey,
   };
 
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const headers: Record<string, string> = { ...(options.headers ?? {}) };
 
   if (apiKey) {
     headers['Authorization'] = `Bearer ${apiKey}`;
   }
 
   const response = await fetch(url.toString(), {
-    method: 'POST',
+    method: 'GET',
     headers,
-    body: JSON.stringify(body),
+    signal: options.signal,
   });
 
   if (!response.ok) {

--- a/apps/qwksearch-web/lib/scraper/index.ts
+++ b/apps/qwksearch-web/lib/scraper/index.ts
@@ -11,3 +11,11 @@ export {
   type ScraperJsonResponse,
   type ScraperConfig,
 } from './cloudflare-scraper-client';
+
+export {
+  scrapeUrl,
+  extractArticleViaScraper,
+  extractViaTavily,
+  SCRAPER_DEADLINE_MS,
+  type ScrapedArticle,
+} from './scrape-url';

--- a/apps/qwksearch-web/lib/scraper/scrape-url.ts
+++ b/apps/qwksearch-web/lib/scraper/scrape-url.ts
@@ -1,0 +1,315 @@
+/**
+ * @fileoverview scrape-url helper for qwksearch-web.
+ *
+ * Renders a webpage through the Cloudflare Puppeteer scraper worker
+ * (default `https://proxy.qwksearch.com`) and extracts the main article
+ * content + citation metadata from the fully-rendered HTML.
+ *
+ * This is the JavaScript-aware extraction path: unlike a plain `fetch`, the
+ * scraper runs a real headless Chromium (puppeteer-cloudflare) so that
+ * client-rendered pages and lightly bot-protected sites still yield usable
+ * HTML before we run readability extraction over it.
+ *
+ * The scraper path is bounded to {@link SCRAPER_DEADLINE_MS} (8s). Heavily
+ * bot-protected sites (e.g. AP News, which serves a Datadome/Cloudflare
+ * challenge) can otherwise stall for 60–100s inside the worker's challenge
+ * retry loop, so when the scraper does not return usable content in time we
+ * fall back to the Tavily extract API.
+ */
+
+import { renderUrlWithMetadata } from "./cloudflare-scraper-client";
+import { extractContent } from "ai-research-agent/extractor/url-to-content/url-to-content";
+
+/** Hard deadline for the Cloudflare scraper path before falling back. */
+export const SCRAPER_DEADLINE_MS = 8000;
+
+export interface ScrapedArticle {
+  html?: string;
+  cite?: string;
+  title?: string;
+  url?: string;
+  author?: string;
+  author_cite?: string;
+  author_short?: string;
+  author_type?: string;
+  date?: string;
+  source?: string;
+  word_count?: number;
+  /** Which path produced this article: "scraper" | "tavily". */
+  via?: string;
+  error?: string;
+}
+
+/** Phrases that indicate the scraper hit an interstitial challenge page. */
+const CHALLENGE_MARKERS = [
+  "Just a moment...",
+  "Verifying you are human",
+  "Please verify you are a human",
+  "Enable JavaScript and cookies to continue",
+  "Checking your browser before accessing",
+  "Please complete the security check to access",
+  "Attention Required! | Cloudflare",
+  "Page unavailable | AP News",
+];
+
+/**
+ * Returns true when the rendered HTML looks like a bot-detection / challenge
+ * interstitial rather than the real page content.
+ */
+function looksLikeChallenge(html: string): boolean {
+  if (!html || typeof html !== "string") return true;
+  return CHALLENGE_MARKERS.some((marker) => html.includes(marker));
+}
+
+function hostnameOf(url: string): string | undefined {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function countWords(html?: string): number {
+  return html
+    ? html.replace(/<[^>]*>/g, " ").split(/\s+/).filter(Boolean).length
+    : 0;
+}
+
+/** Build an APA-ish citation string mirroring the extractor's URL branch. */
+function buildCite(article: ScrapedArticle, url: string): string {
+  const source = article.source || "";
+  const year = new Date(article.date || "").getFullYear();
+  const apaDate =
+    year > 1971
+      ? ` (${year}, ${new Date(article.date as string).toLocaleDateString(
+          "en-US",
+          { month: "short", day: "numeric" },
+        )})`
+      : "";
+  return `${article.author_cite || source || " "}${apaDate}. <b>${
+    article.title || ""
+  }</b>. <i>${source}</i>. <a href="${url}" target="_blank">${url}</a>`;
+}
+
+/**
+ * Fetch fully-rendered HTML for a URL through the Cloudflare Puppeteer scraper.
+ *
+ * @param url - The webpage URL to render.
+ * @param options - Optional scraper overrides + an AbortSignal deadline.
+ * @returns The rendered HTML string.
+ * @throws If the scraper request fails, aborts, or returns no HTML.
+ *
+ * @example
+ * const html = await scrapeUrl("https://en.wikipedia.org/wiki/Marginalia");
+ */
+export async function scrapeUrl(
+  url: string,
+  options: {
+    blockImages?: boolean;
+    waitUntil?: "domcontentloaded" | "load" | "networkidle0" | "networkidle2";
+    wait?: number;
+    timeout?: number;
+    maxRetries?: number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<string> {
+  console.log("[scrapeUrl] rendering via Cloudflare Puppeteer scraper", { url });
+
+  const result = await renderUrlWithMetadata(url, {
+    blockImages: options.blockImages ?? true,
+    waitUntil: options.waitUntil ?? "domcontentloaded",
+    wait: options.wait ?? 0,
+    timeout: options.timeout ?? 15000,
+    // Cap the worker's challenge retry loop so a single bot-check can't stall
+    // the request; the 8s client deadline is the real bound.
+    maxRetries: options.maxRetries ?? 1,
+    signal: options.signal,
+  });
+
+  const html = result?.html;
+  if (!html || typeof html !== "string") {
+    throw new Error("Scraper returned no HTML");
+  }
+  return html;
+}
+
+/**
+ * Scrape a URL through the Cloudflare Puppeteer scraper and extract the main
+ * article content, bounded to {@link SCRAPER_DEADLINE_MS}.
+ *
+ * Never throws — returns `{ error }` (with the raw HTML omitted) when the
+ * scraper is unavailable, exceeds the deadline, or returns a challenge page,
+ * so callers can cleanly decide whether to fall back to Tavily.
+ *
+ * @param url - The webpage URL to extract.
+ * @param timeoutMs - Deadline before giving up on the scraper (default 8s).
+ */
+export async function extractArticleViaScraper(
+  url: string,
+  timeoutMs: number = SCRAPER_DEADLINE_MS,
+): Promise<ScrapedArticle> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = Date.now();
+
+  try {
+    const rendered = await renderUrlWithMetadata(url, {
+      blockImages: true,
+      waitUntil: "domcontentloaded",
+      timeout: Math.max(timeoutMs - 1000, 4000),
+      maxRetries: 1,
+      signal: controller.signal,
+    });
+
+    const html = rendered?.html;
+    if (!html || looksLikeChallenge(html)) {
+      console.warn("[extractArticleViaScraper] no usable HTML from scraper", {
+        url,
+        hasHtml: !!html,
+        challenge: html ? looksLikeChallenge(html) : false,
+        ms: Date.now() - startedAt,
+      });
+      return { error: "Scraper returned a challenge page or no content" };
+    }
+
+    // Readability + citation extraction over the rendered HTML.
+    const extracted = (await extractContent(html, { url })) as ScrapedArticle;
+    if (!extracted || extracted.error || !extracted.html) {
+      return { error: extracted?.error || "Extraction produced no content" };
+    }
+
+    const source = extracted.source || hostnameOf(rendered.url || url);
+    const enriched: ScrapedArticle = {
+      ...extracted,
+      url: rendered.url || url,
+      source,
+      word_count: extracted.word_count ?? countWords(extracted.html),
+      via: "scraper",
+    };
+    enriched.cite = extracted.cite || buildCite(enriched, url);
+    console.log("[extractArticleViaScraper] scraper extraction succeeded", {
+      url,
+      title: enriched.title,
+      words: enriched.word_count,
+      ms: Date.now() - startedAt,
+    });
+    return enriched;
+  } catch (err) {
+    const e = err as Error;
+    const aborted = e?.name === "AbortError" || controller.signal.aborted;
+    console.warn("[extractArticleViaScraper] scraper path failed", {
+      url,
+      aborted,
+      message: e?.message,
+      ms: Date.now() - startedAt,
+    });
+    return {
+      error: aborted
+        ? `Scraper exceeded ${timeoutMs}ms deadline`
+        : e?.message || "Scraper request failed",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Resolve the Tavily API key from env or configured site default. */
+function resolveTavilyKey(explicit?: string): string | undefined {
+  if (explicit) return explicit;
+  if (typeof process !== "undefined" && process?.env?.TAVILY_API_KEY) {
+    return process.env.TAVILY_API_KEY;
+  }
+  return undefined;
+}
+
+/** Minimal markdown → HTML conversion for Tavily's `raw_content`. */
+function rawContentToHtml(raw: string): string {
+  const esc = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return raw
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const heading = block.match(/^(#{1,6})\s+(.*)$/);
+      if (heading) {
+        const level = heading[1].length;
+        return `<h${level}>${esc(heading[2])}</h${level}>`;
+      }
+      // inline markdown links [text](url)
+      const withLinks = esc(block).replace(
+        /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+        '<a href="$2" target="_blank">$1</a>',
+      );
+      return `<p>${withLinks.replace(/\n/g, "<br/>")}</p>`;
+    })
+    .join("\n");
+}
+
+/**
+ * Fallback extraction via the Tavily extract API. Used when the Cloudflare
+ * scraper cannot return usable content within the deadline (e.g. AP News).
+ *
+ * @param url - The webpage URL to extract.
+ * @param apiKey - Optional explicit Tavily key; falls back to `TAVILY_API_KEY`.
+ * @returns Extracted article, or `{ error }` if Tavily is unavailable/failed.
+ */
+export async function extractViaTavily(
+  url: string,
+  apiKey?: string,
+): Promise<ScrapedArticle> {
+  const key = resolveTavilyKey(apiKey);
+  if (!key) {
+    return { error: "No Tavily API key configured" };
+  }
+
+  const startedAt = Date.now();
+  let res: Response;
+  try {
+    res = await fetch("https://api.tavily.com/extract", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({ urls: [url], extract_depth: "advanced" }),
+      signal: AbortSignal.timeout(20000),
+    });
+  } catch (err) {
+    const e = err as Error;
+    console.error("[extractViaTavily] request failed", { url, message: e?.message });
+    return { error: e?.message || "Tavily request failed" };
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    console.error("[extractViaTavily] non-OK response", { url, status: res.status });
+    return { error: `Tavily extract failed (${res.status}): ${body.slice(0, 200)}` };
+  }
+
+  const data = (await res.json().catch(() => null)) as {
+    results?: Array<{ url?: string; raw_content?: string; title?: string }>;
+  } | null;
+  const result = data?.results?.[0];
+  if (!result?.raw_content) {
+    return { error: "Tavily returned no content" };
+  }
+
+  const html = rawContentToHtml(result.raw_content);
+  const source = hostnameOf(result.url || url);
+  const article: ScrapedArticle = {
+    url: result.url || url,
+    title: result.title || undefined,
+    html,
+    source,
+    word_count: countWords(html),
+    via: "tavily",
+  };
+  article.cite = buildCite(article, url);
+  console.log("[extractViaTavily] Tavily extraction succeeded", {
+    url,
+    words: article.word_count,
+    ms: Date.now() - startedAt,
+  });
+  return article;
+}

--- a/packages/extract-webpage/src/url-to-content/url-to-html.ts
+++ b/packages/extract-webpage/src/url-to-content/url-to-html.ts
@@ -169,38 +169,40 @@ async function scrapeCloudflare(url: string, options: { proxy?: string | null, b
 
   const scraperUrl = typeof process !== 'undefined' && process?.env?.SCRAPER_URL
     ? process.env.SCRAPER_URL
-    : 'https://scraper.qwksearch.workers.dev';
+    : 'https://proxy.qwksearch.com';
 
   const apiKey = typeof process !== 'undefined' && process?.env?.SCRAPER_API_KEY
     ? process.env.SCRAPER_API_KEY
     : undefined;
 
   try {
-    const requestBody = {
+    // The deployed scraper worker accepts GET with query-string params.
+    const renderUrl = new URL('/api/render', scraperUrl);
+    const params: Record<string, string> = {
       url,
-      wait: 1000,
-      blockImages: false,
+      wait: '1000',
+      blockImages: 'false',
       sessionId: 'default',
-      timeout: 30000,
+      timeout: '30000',
       waitUntil: 'networkidle2',
       format: 'json',
-      bypassCaptcha: options.bypassCaptcha ?? true,
-      maxRetries: 10,
-      ...(options.proxy && { proxyUrl: options.proxy }),
+      bypassCaptcha: String(options.bypassCaptcha ?? true),
+      maxRetries: '10',
+      ...(options.proxy ? { proxyUrl: options.proxy } : {}),
     };
+    for (const [key, value] of Object.entries(params)) {
+      renderUrl.searchParams.set(key, value);
+    }
 
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
+    const headers: Record<string, string> = {};
 
     if (apiKey) {
       headers['Authorization'] = `Bearer ${apiKey}`;
     }
 
-    const response = await fetch(`${scraperUrl}/api/render`, {
-      method: 'POST',
+    const response = await fetch(renderUrl.toString(), {
+      method: 'GET',
       headers,
-      body: JSON.stringify(requestBody),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Implements a bounded fallback chain for article extraction that prioritizes JavaScript-aware rendering over plain HTTP fetching. The new extraction pipeline uses the Cloudflare Puppeteer scraper (8s deadline) as the primary path, falls back to Tavily extract API when the scraper times out or returns challenge pages, and finally falls back to direct in-process extraction as a last resort.

## Key Changes

- **New `scrape-url.ts` module**: Provides two main extraction functions:
  - `extractArticleViaScraper()`: Renders URLs through the Cloudflare Puppeteer scraper worker with an 8-second deadline, detects bot-challenge interstitials (Cloudflare, Datadome, AP News), and extracts content via readability. Never throws—returns `{ error }` on failure.
  - `extractViaTavily()`: Fallback extraction via Tavily's extract API when the scraper is unavailable or times out. Converts Tavily's markdown-like `raw_content` to HTML and builds APA-style citations.

- **Updated `/api/doc/article` route**: Implements the three-tier extraction fallback:
  1. Cloudflare Puppeteer scraper (8s deadline)
  2. Tavily extract API (when scraper fails/times out)
  3. Direct in-process `extractContent()` (last resort)
  
  Each tier logs its decision and reason for advancing to the next tier, enabling observability of which extraction path succeeds.

- **Updated scraper client configuration**: Changed default scraper endpoint from `https://scraper.qwksearch.workers.dev` to `https://proxy.qwksearch.com` and added `AbortSignal` support for deadline enforcement.

- **Updated `url-to-html.ts`**: Migrated scraper requests from POST with JSON body to GET with query-string parameters to match the deployed worker's API.

- **Enhanced test coverage**: Added tests for scraper and Tavily extraction paths, with mocks that default to "unavailable" so existing tests exercise the `extractContent` fallback.

## Notable Implementation Details

- **Challenge page detection**: Checks rendered HTML for markers like "Just a moment...", "Verifying you are human", and "Attention Required! | Cloudflare" to identify bot-protection interstitials and trigger fallback.
- **Word count calculation**: Strips HTML tags and counts whitespace-separated tokens for consistent word count across all extraction paths.
- **Citation building**: Generates APA-style citations with author, date, title, source, and URL, mirroring the format used by the in-process extractor.
- **Graceful degradation**: All extraction functions return `{ error }` instead of throwing, allowing the route to cleanly decide whether to advance to the next tier without try-catch complexity.

https://claude.ai/code/session_01PZnQTSy6fHh8Y6naPkxYrC