### PR TITLE
Update package exports to use source files directly

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -68,6 +68,10 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.0",
+    "@ai-sdk/google": "^2.0.0",
+    "@ai-sdk/groq": "^2.0.0",
+    "@ai-sdk/openai": "^2.0.0",
     "@composio/core": "^0.10.0",
     "@mastra/core": "^0.1.0",
     "@mastra/mcp": "^0.1.0",

--- a/packages/write-language/package.json
+++ b/packages/write-language/package.json
@@ -16,9 +16,10 @@
   "types": "./dist/types.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
-      "import": "./dist/write-language.es.js",
-      "require": "./dist/write-language.cjs.js"
+      "types": "./src/index.ts",
+      "react-server": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
     },
     "./*": {
       "types": "./src/*.ts",


### PR DESCRIPTION
## Summary
Updated package export configurations to point directly to source TypeScript files instead of compiled distribution files, and added AI SDK provider dependencies to agent-toolkit.

## Key Changes

### write-language package
- Changed all export entry points (`.types`, `.import`, `.require`) to reference source files (`./src/index.ts`) instead of compiled distribution files (`./dist/`)
- Added `react-server` export condition pointing to source file
- This enables direct source consumption and better tree-shaking for consumers

### agent-toolkit package
- Added AI SDK provider dependencies:
  - `@ai-sdk/anthropic@^2.0.0`
  - `@ai-sdk/google@^2.0.0`
  - `@ai-sdk/groq@^2.0.0`
  - `@ai-sdk/openai@^2.0.0`
- These dependencies support multiple LLM providers for the agent toolkit

## Implementation Details
The write-language package now uses a source-first export strategy, which is beneficial for:
- Reducing bundle size through better tree-shaking
- Enabling direct TypeScript consumption without transpilation overhead
- Supporting modern bundler features like conditional exports

https://claude.ai/code/session_01X9BSUtMh8GhkuHL1p8UMwE