### PR TITLE
Add support for multiple AI SDK providers

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -32,8 +32,13 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "^3.0.0",
+    "@ai-sdk/anthropic": "^2.0.0",
+    "@ai-sdk/google": "^2.0.0",
+    "@ai-sdk/google-vertex": "^3.0.0",
     "@ai-sdk/groq": "^2.0.0",
     "@ai-sdk/openai": "^4.0.8",
+    "@ai-sdk/xai": "^2.0.0",
     "@floating-ui/react": "^0.27.19",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "@openrouter/ai-sdk-provider": "^2.10.0",


### PR DESCRIPTION
## Summary
Expanded AI provider support by adding multiple new AI SDK integrations to the qwksearch-web application.

## Key Changes
- Added Amazon Bedrock provider (`@ai-sdk/amazon-bedrock`)
- Added Anthropic provider (`@ai-sdk/anthropic`)
- Added Google provider (`@ai-sdk/google`)
- Added Google Vertex AI provider (`@ai-sdk/google-vertex`)
- Added xAI provider (`@ai-sdk/xai`)

## Details
This change extends the application's LLM capabilities by integrating five new AI providers alongside the existing Groq and OpenAI integrations. This allows users to choose from a broader range of AI models and services for their search queries.

https://claude.ai/code/session_01NcEapp6XwjkH3Znv5hduVv