### PR TITLE
Fix API routing and authentication issues in web app

### DIFF
--- a/apps/qwksearch-web/components/ResearchAgent/components/FileUpload/FileUploadDropdown.tsx
+++ b/apps/qwksearch-web/components/ResearchAgent/components/FileUpload/FileUploadDropdown.tsx
@@ -86,7 +86,7 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
 
   const checkGoogleDriveConnection = async () => {
     try {
-      const data = await grab('doc/google-docs/auth/status');
+      const data = await grab('/api/doc/google-docs/auth/status');
       setIsGoogleDriveConnected(data.isConnected || false);
     } catch {
       // silently ignore

--- a/apps/qwksearch-web/components/ResearchAgent/components/FileUpload/useFileHandling.ts
+++ b/apps/qwksearch-web/components/ResearchAgent/components/FileUpload/useFileHandling.ts
@@ -78,7 +78,7 @@ export function useFileHandling({
         const formData = new FormData();
         uploadable.forEach((f) => formData.append("files", f.file));
 
-        const data: { files: ChatFile[] } = await grab("/doc/uploads", {
+        const data: { files: ChatFile[] } = await grab("/api/doc/uploads", {
           method: "POST",
           body: formData,
         });

--- a/apps/qwksearch-web/lib/api/grab.ts
+++ b/apps/qwksearch-web/lib/api/grab.ts
@@ -7,6 +7,21 @@
  */
 
 /**
+ * Resolves bare relative paths against the API root. The original grab-url
+ * package resolved every path against a configured `/api/` base, and call
+ * sites throughout the app still pass paths like `"config"` or
+ * `"doc/article"` — resolving those against the current page URL would hit
+ * nonexistent routes (e.g. `/doc/article` instead of `/api/doc/article`).
+ * Absolute URLs and root-relative (`/...`) paths pass through unchanged.
+ */
+function resolveApiUrl(url: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith("/")) {
+    return url;
+  }
+  return url.startsWith("api/") ? `/${url}` : `/api/${url}`;
+}
+
+/**
  * Enhanced fetch function that includes credentials by default.
  * This ensures authentication cookies are sent with API requests.
  *
@@ -34,7 +49,7 @@ export default async function grab(
     delete (enhancedOptions as any).timeout;
     delete (enhancedOptions as any).responseType;
 
-    const response = await fetch(url, enhancedOptions);
+    const response = await fetch(resolveApiUrl(url), enhancedOptions);
     clearTimeout(timeoutId);
 
     if (!response.ok) {

--- a/apps/qwksearch-web/lib/auth/index.ts
+++ b/apps/qwksearch-web/lib/auth/index.ts
@@ -51,6 +51,19 @@ async function authBuilder() {
       },
       {
         baseURL: NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
+        // better-auth rejects credentialed POSTs (e.g. /sign-in/social) with
+        // 403 INVALID_ORIGIN when the Origin header isn't in trustedOrigins,
+        // which defaults to only [baseURL]. baseURL follows the
+        // NEXT_PUBLIC_BASE_URL env var, so a stale/localhost value on the
+        // deployed Worker silently locks every user out of login. Trust the
+        // production domains and local dev origins explicitly.
+        trustedOrigins: [
+          ...(NEXT_PUBLIC_BASE_URL ? [NEXT_PUBLIC_BASE_URL] : []),
+          "https://qwksearch.com",
+          "https://www.qwksearch.com",
+          "http://localhost:3000",
+          "http://localhost:8787",
+        ],
         database: drizzleAdapter(getDB(), {
           provider: "sqlite",
           schema,

--- a/apps/qwksearch-web/vite.config.ts
+++ b/apps/qwksearch-web/vite.config.ts
@@ -43,22 +43,15 @@ export default defineConfig(({ command }) => ({
     },
     rolldownOptions: {
       // Rolldown (Vite 8.x bundler) needs its own external list.
-      // AI SDK packages are server-only and must not be bundled into client code.
-      external: [
-        "fsevents",
-        "@mastra/core",
-        "@mastra/mcp",
-        "@composio/core",
-        "ai",
-        "@ai-sdk/openai",
-        "@ai-sdk/anthropic",
-        "@ai-sdk/groq",
-        "@ai-sdk/google",
-        "@ai-sdk/google-vertex",
-        "@ai-sdk/xai",
-        "@ai-sdk/amazon-bedrock",
-        "@openrouter/ai-sdk-provider",
-      ],
+      //
+      // Do NOT add `ai` / `@ai-sdk/*` here: this list applies to the server
+      // (rsc/ssr) environments too, and an externalized bare import in a
+      // Worker chunk fails at runtime with
+      //   No such module "_next/static/ai" imported from "_next/static/route-*.js"
+      // because workerd resolves bare specifiers relative to the chunk. The
+      // AI SDK packages never reach the final client bundle anyway (they are
+      // tree-shaken out), so they must simply be bundled server-side.
+      external: ["fsevents", "@mastra/core", "@mastra/mcp", "@composio/core"],
     },
   },
   ssr: {

--- a/packages/extract-webpage/src/suggest-next-words/autocomplete-search-engines.ts
+++ b/packages/extract-webpage/src/suggest-next-words/autocomplete-search-engines.ts
@@ -4,6 +4,12 @@
 
 import { parseHTML } from "linkedom";
 
+// Some suggest APIs (notably Google) return 403 Forbidden for requests
+// without a browser-like User-Agent, especially from datacenter/Cloudflare
+// egress IPs. Sent by default; per-backend headers can still override it.
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
 /**
  * Fetch wrapper compatible with grab-url interface
  */
@@ -15,7 +21,10 @@ async function grab(url: string, options: any = {}): Promise<any> {
   try {
     const response = await fetch(url, {
       ...options,
-      headers: options.headers,
+      headers: {
+        "User-Agent": DEFAULT_USER_AGENT,
+        ...options.headers,
+      },
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary
This PR fixes several routing and authentication issues in the qwksearch web application, primarily addressing API URL resolution, authentication origin validation, and HTTP header handling for external API requests.

## Key Changes

- **API URL Resolution**: Added `resolveApiUrl()` helper function in `lib/api/grab.ts` to properly resolve bare relative paths (like `"config"` or `"doc/article"`) against the `/api/` base path. This maintains compatibility with the original grab-url behavior while using native fetch.

- **Authentication Origin Validation**: Updated `lib/auth/index.ts` to explicitly configure `trustedOrigins` in better-auth, including production domains (`qwksearch.com`, `www.qwksearch.com`) and local dev origins. This prevents 403 INVALID_ORIGIN errors when the `NEXT_PUBLIC_BASE_URL` environment variable is stale or misconfigured on deployed Workers.

- **User-Agent Header for External APIs**: Added a default browser-like User-Agent header in `packages/extract-webpage/src/suggest-next-words/autocomplete-search-engines.ts` to work around 403 Forbidden responses from suggest APIs (notably Google) that reject requests without proper User-Agent headers, especially from datacenter/Cloudflare IPs.

- **Vite Configuration Cleanup**: Removed AI SDK packages (`ai`, `@ai-sdk/*`) from the Rolldown external list in `vite.config.ts`. These packages were causing runtime failures in Worker chunks due to bare import resolution issues. They are safely tree-shaken out and don't reach the final client bundle, so bundling them server-side is the correct approach.

- **Call Site Updates**: Updated two call sites in `FileUploadDropdown.tsx` and `useFileHandling.ts` to use explicit `/api/` prefixed paths, ensuring consistency with the new URL resolution logic.

## Notable Implementation Details

- The `resolveApiUrl()` function preserves absolute URLs and root-relative paths unchanged, only transforming bare relative paths
- The trusted origins configuration includes both environment-based and hardcoded production/local values for robustness
- The User-Agent header is set as a default that can be overridden by per-backend headers

https://claude.ai/code/session_01N1aVk9vX5o25qf78Z6PJgx