### PR TITLE
Fix npm publish workflow by neutralizing stray husky hooks

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,20 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # We don't use husky in this repo, but some dependencies ship a broken
+      # `prepare: "husky install"` in their published package.json (e.g.
+      # fuse.js). When npm reconciles bun's linked node_modules store it runs
+      # that prepare hook, which dies with "husky: not found" (exit 127) — and
+      # npm's --ignore-scripts does NOT suppress it for bun-linked packages.
+      # Put a no-op `husky` on PATH for every later step so any stray husky
+      # hook becomes a harmless no-op instead of failing the publish run.
+      - name: Neutralize unused husky hooks
+        run: |
+          mkdir -p "$RUNNER_TEMP/husky-shim"
+          printf '#!/bin/sh\nexit 0\n' > "$RUNNER_TEMP/husky-shim/husky"
+          chmod +x "$RUNNER_TEMP/husky-shim/husky"
+          echo "$RUNNER_TEMP/husky-shim" >> "$GITHUB_PATH"
+
       # Install the whole workspace once with bun (the repo's package manager).
       # bun understands the "workspace:*" protocol and links local packages, so
       # every package gets its devDependencies (e.g. vite) and can be built.


### PR DESCRIPTION
## Summary
Added a workaround to the npm publish workflow to prevent broken `husky install` prepare hooks in dependencies from failing the publish step.

## Key Changes
- Created a no-op `husky` shim script and added it to the PATH before dependency installation
- The shim allows stray husky hooks from transitive dependencies (like fuse.js) to execute harmlessly instead of failing with "husky: not found"
- This addresses a limitation where npm's `--ignore-scripts` flag does not suppress prepare hooks for bun-linked packages

## Implementation Details
The solution creates a minimal shell script that simply exits with code 0, making any invocation of the `husky` command a no-op. This is placed in a temporary directory that is prepended to the GitHub Actions PATH, ensuring it takes precedence over any missing husky installation. This approach is non-invasive and doesn't require changes to dependency configurations.

https://claude.ai/code/session_01G4HV8J81ttCrLW2xsv8p7L