### PR TITLE
Enable FedCM for Google One Tap authentication

### DIFF
--- a/apps/qwksearch-web/lib/auth/client.ts
+++ b/apps/qwksearch-web/lib/auth/client.ts
@@ -15,8 +15,13 @@ export const authClient = createAuthClient({
   plugins: [
     oneTapClient({
       clientId: NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+      // FedCM must stay enabled: with it opted out, Chrome's third-party
+      // cookie blocking makes the gsi/status check fail (CORS), so the One
+      // Tap prompt renders but Google never issues the ID-token credential.
+      // The /one-tap/callback then never runs and no session cookie is set,
+      // which is why sign-in appeared to work but didn't survive a refresh.
       additionalOptions: {
-        use_fedcm_for_prompt: false,
+        use_fedcm_for_prompt: true,
       },
     }),
     magicLinkClient(),


### PR DESCRIPTION
## Summary
Fixed Google One Tap authentication to properly persist user sessions across page refreshes by enabling the Federated Credential Management (FedCM) API.

## Key Changes
- Changed `use_fedcm_for_prompt` from `false` to `true` in the Google One Tap client configuration
- Added detailed comment explaining why FedCM must remain enabled to avoid CORS failures with Chrome's third-party cookie blocking

## Implementation Details
The issue occurred because disabling FedCM caused Chrome's third-party cookie blocking to interfere with the `gsi/status` check, resulting in CORS errors. This prevented Google from issuing the ID-token credential, causing the `/one-tap/callback` to never execute and the session cookie to never be set. While sign-in appeared to work initially, the session would not survive a page refresh.

Enabling FedCM resolves this by using the proper credential management flow, ensuring the authentication callback completes successfully and the session persists.

https://claude.ai/code/session_011H4c4geVk6kqFrn6FUyumb