### PR TITLE
Enhance free keys admin page with detailed diagnostics and model testing

### DIFF
--- a/apps/qwksearch-web/app/admin/freekeys/page.tsx
+++ b/apps/qwksearch-web/app/admin/freekeys/page.tsx
@@ -18,7 +18,17 @@ interface LiveTest {
   reason?: string;
 }
 
+interface KeySourceReport {
+  set: boolean;
+  masked: string | null;
+  sources: {
+    cloudflareEnv: boolean;
+    processEnv: boolean;
+  };
+}
+
 interface ProviderData {
+  key: KeySourceReport;
   keyConfigured: boolean;
   keyMasked: string | null;
   baseUrl: string;
@@ -27,9 +37,29 @@ interface ProviderData {
   liveTest: LiveTest;
 }
 
+interface ModelTestResult {
+  model: string;
+  ok: boolean;
+  status?: number;
+  error?: string;
+  ms: number;
+  existsUpstream?: boolean;
+}
+
+interface TestAllResult {
+  upstreamModelsFetched?: boolean;
+  results?: ModelTestResult[];
+  error?: string;
+}
+
 interface FreeKeysData {
   nvidia: ProviderData;
   openrouter: ProviderData;
+  guestProviders: {
+    note: string;
+    providers: { name: string; type: string; modelCount: number }[];
+    error: string | null;
+  };
   guestLogic: {
     note: string;
     openrouterKeySet: boolean;
@@ -38,11 +68,19 @@ interface FreeKeysData {
   };
   auth: {
     betterAuthSecretSet: boolean;
+    googleOAuthConfigured: boolean;
+    baseUrlEnv: string | null;
+    session: {
+      signedIn: boolean;
+      email?: string;
+      userId?: string;
+      error?: string;
+    };
     note: string;
   };
 }
 
-function StatusBadge({ ok }: { ok: boolean }) {
+function StatusBadge({ ok, label }: { ok: boolean; label?: string }) {
   return (
     <span
       className={`inline-block px-2 py-0.5 rounded text-xs font-semibold ${
@@ -51,19 +89,38 @@ function StatusBadge({ ok }: { ok: boolean }) {
           : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
       }`}
     >
-      {ok ? "OK" : "FAIL"}
+      {label ?? (ok ? "OK" : "FAIL")}
     </span>
   );
 }
 
 function ProviderCard({
   name,
+  slug,
   data,
 }: {
   name: string;
+  slug: "nvidia" | "openrouter";
   data: ProviderData;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResults, setTestResults] = useState<TestAllResult | null>(null);
+
+  async function runTestAll() {
+    setTesting(true);
+    setTestResults(null);
+    try {
+      const res = await fetch(`/api/admin/freekeys?testAll=${slug}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setTestResults(json[slug] ?? { error: "no data returned" });
+    } catch (e: any) {
+      setTestResults({ error: e.message });
+    } finally {
+      setTesting(false);
+    }
+  }
 
   return (
     <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3">
@@ -82,6 +139,26 @@ function ProviderCard({
           ) : (
             <span className="text-red-500">not set</span>
           )}
+        </div>
+
+        <div className="text-gray-500 dark:text-gray-400">
+          Visible via cloudflare:workers env
+        </div>
+        <div>
+          <StatusBadge
+            ok={data.key?.sources?.cloudflareEnv ?? false}
+            label={data.key?.sources?.cloudflareEnv ? "YES" : "NO"}
+          />
+        </div>
+
+        <div className="text-gray-500 dark:text-gray-400">
+          Visible via process.env
+        </div>
+        <div>
+          <StatusBadge
+            ok={data.key?.sources?.processEnv ?? false}
+            label={data.key?.sources?.processEnv ? "YES" : "NO"}
+          />
         </div>
 
         <div className="text-gray-500 dark:text-gray-400">Base URL</div>
@@ -114,43 +191,113 @@ function ProviderCard({
         </div>
       </div>
 
-      <div>
+      <div className="flex items-center gap-4">
         <button
           onClick={() => setExpanded((v) => !v)}
           className="text-sm text-blue-500 hover:underline"
         >
           {expanded ? "Hide" : "Show"} {data.freeModelCount} free models
         </button>
-        {expanded && (
-          <table className="mt-2 w-full text-xs border-collapse">
+        <button
+          onClick={runTestAll}
+          disabled={testing || !data.keyConfigured}
+          className="text-sm px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          title={
+            data.keyConfigured
+              ? "Send a 1-token test prompt to every free model"
+              : "Set the API key first"
+          }
+        >
+          {testing ? "Testing all models…" : "Test all models"}
+        </button>
+      </div>
+
+      {testResults?.error && (
+        <div className="text-red-500 text-xs font-mono bg-red-50 dark:bg-red-950 p-2 rounded">
+          {testResults.error}
+        </div>
+      )}
+
+      {testResults?.results && (
+        <div>
+          <div className="text-xs text-gray-500 mb-1">
+            {testResults.results.filter((r) => r.ok).length} /{" "}
+            {testResults.results.length} models responded OK
+            {testResults.upstreamModelsFetched === false &&
+              " (provider /models list unavailable — upstream check skipped)"}
+          </div>
+          <table className="w-full text-xs border-collapse">
             <thead>
               <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
                 <th className="py-1 pr-2">Model ID</th>
-                <th className="py-1 pr-2">Name</th>
-                <th className="py-1">Context</th>
+                <th className="py-1 pr-2">Result</th>
+                <th className="py-1 pr-2">Listed upstream</th>
+                <th className="py-1 pr-2">Time</th>
+                <th className="py-1">Error</th>
               </tr>
             </thead>
             <tbody>
-              {data.freeModels.map((m) => (
+              {testResults.results.map((r) => (
                 <tr
-                  key={m.id}
+                  key={r.model}
                   className="border-b border-gray-100 dark:border-gray-800"
                 >
                   <td className="py-1 pr-2 font-mono text-gray-700 dark:text-gray-300">
-                    {m.id}
+                    {r.model}
                   </td>
-                  <td className="py-1 pr-2 text-gray-600 dark:text-gray-400">
-                    {m.name}
+                  <td className="py-1 pr-2">
+                    <StatusBadge ok={r.ok} />
+                    {r.status ? (
+                      <span className="ml-1 text-gray-400">HTTP {r.status}</span>
+                    ) : null}
                   </td>
-                  <td className="py-1 text-gray-500">
-                    {m.contextLength?.toLocaleString()}
+                  <td className="py-1 pr-2">
+                    {r.existsUpstream === undefined
+                      ? "—"
+                      : r.existsUpstream
+                        ? "yes"
+                        : "NO"}
+                  </td>
+                  <td className="py-1 pr-2 text-gray-500">{r.ms}ms</td>
+                  <td className="py-1 text-red-500 font-mono break-all">
+                    {r.error?.slice(0, 120)}
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
-        )}
-      </div>
+        </div>
+      )}
+
+      {expanded && (
+        <table className="mt-2 w-full text-xs border-collapse">
+          <thead>
+            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+              <th className="py-1 pr-2">Model ID</th>
+              <th className="py-1 pr-2">Name</th>
+              <th className="py-1">Context</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.freeModels.map((m) => (
+              <tr
+                key={m.id}
+                className="border-b border-gray-100 dark:border-gray-800"
+              >
+                <td className="py-1 pr-2 font-mono text-gray-700 dark:text-gray-300">
+                  {m.id}
+                </td>
+                <td className="py-1 pr-2 text-gray-600 dark:text-gray-400">
+                  {m.name}
+                </td>
+                <td className="py-1 text-gray-500">
+                  {m.contextLength?.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }
@@ -203,8 +350,46 @@ export default function FreeKeysPage() {
 
       {data && (
         <div className="space-y-4">
-          <ProviderCard name="NVIDIA" data={data.nvidia} />
-          <ProviderCard name="OpenRouter" data={data.openrouter} />
+          {/* What guests actually see — ground truth from the providers API */}
+          <div
+            className={`border rounded-lg p-4 text-sm space-y-2 ${
+              data.guestProviders.providers.length > 0
+                ? "border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950"
+                : "border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950"
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold">
+                Providers loaded for guests ({data.guestProviders.providers.length})
+              </h2>
+              <StatusBadge ok={data.guestProviders.providers.length > 0} />
+            </div>
+            {data.guestProviders.providers.length > 0 ? (
+              <ul className="text-xs space-y-1">
+                {data.guestProviders.providers.map((p) => (
+                  <li key={p.name} className="font-mono">
+                    {p.name} ({p.type}) — {p.modelCount} models
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-xs text-red-600 dark:text-red-400">
+                No providers loaded — guests see an empty model list. Check the
+                per-provider key visibility below.
+              </p>
+            )}
+            {data.guestProviders.error && (
+              <p className="text-xs text-red-500 font-mono">
+                {data.guestProviders.error}
+              </p>
+            )}
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {data.guestProviders.note}
+            </p>
+          </div>
+
+          <ProviderCard name="NVIDIA" slug="nvidia" data={data.nvidia} />
+          <ProviderCard name="OpenRouter" slug="openrouter" data={data.openrouter} />
 
           <div className="border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 bg-yellow-50 dark:bg-yellow-950 text-sm space-y-2">
             <h2 className="font-semibold text-yellow-800 dark:text-yellow-200">
@@ -223,14 +408,63 @@ export default function FreeKeysPage() {
             </p>
           </div>
 
-          <div className={`border rounded-lg p-4 text-sm space-y-2 ${data.auth.betterAuthSecretSet ? "border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950" : "border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950"}`}>
+          <div
+            className={`border rounded-lg p-4 text-sm space-y-2 ${
+              data.auth.betterAuthSecretSet
+                ? "border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950"
+                : "border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950"
+            }`}
+          >
             <div className="flex items-center justify-between">
-              <h2 className={`font-semibold ${data.auth.betterAuthSecretSet ? "text-green-800 dark:text-green-200" : "text-red-800 dark:text-red-200"}`}>
-                Auth Secret (BETTER_AUTH_SECRET)
+              <h2
+                className={`font-semibold ${
+                  data.auth.betterAuthSecretSet
+                    ? "text-green-800 dark:text-green-200"
+                    : "text-red-800 dark:text-red-200"
+                }`}
+              >
+                Auth
               </h2>
               <StatusBadge ok={data.auth.betterAuthSecretSet} />
             </div>
-            <p className={`text-xs mt-1 ${data.auth.betterAuthSecretSet ? "text-green-700 dark:text-green-300" : "text-red-700 dark:text-red-300"}`}>
+            <div className="grid grid-cols-2 gap-1 text-xs">
+              <span className="text-gray-600 dark:text-gray-400">
+                BETTER_AUTH_SECRET set
+              </span>
+              <StatusBadge ok={data.auth.betterAuthSecretSet} />
+              <span className="text-gray-600 dark:text-gray-400">
+                Google OAuth configured
+              </span>
+              <StatusBadge ok={data.auth.googleOAuthConfigured} />
+              <span className="text-gray-600 dark:text-gray-400">
+                NEXT_PUBLIC_BASE_URL
+              </span>
+              <span className="font-mono">{data.auth.baseUrlEnv ?? "not set"}</span>
+              <span className="text-gray-600 dark:text-gray-400">
+                This request's session
+              </span>
+              <span>
+                <StatusBadge
+                  ok={data.auth.session.signedIn}
+                  label={data.auth.session.signedIn ? "SIGNED IN" : "GUEST"}
+                />
+                {data.auth.session.email && (
+                  <span className="ml-2 font-mono">{data.auth.session.email}</span>
+                )}
+              </span>
+            </div>
+            {data.auth.session.error && (
+              <p className="text-xs text-red-500 font-mono">
+                session error: {data.auth.session.error}
+              </p>
+            )}
+            <p
+              className={`text-xs mt-1 ${
+                data.auth.betterAuthSecretSet
+                  ? "text-green-700 dark:text-green-300"
+                  : "text-red-700 dark:text-red-300"
+              }`}
+            >
               {data.auth.note}
             </p>
             {!data.auth.betterAuthSecretSet && (

--- a/apps/qwksearch-web/app/api/admin/freekeys/route.ts
+++ b/apps/qwksearch-web/app/api/admin/freekeys/route.ts
@@ -1,23 +1,80 @@
 /**
  * API endpoint to debug free model availability for NVIDIA and OpenRouter
- * GET /api/admin/freekeys
  *
- * Returns:
- * - Whether API keys are configured in env
- * - Free models listed in the database for each provider
- * - Live test of a quick prompt to verify keys actually work
+ * GET /api/admin/freekeys
+ *   - Whether API keys are visible via each env source (cloudflare:workers
+ *     bindings vs process.env) — the app reads keys through both, so a key
+ *     "set in the CF dashboard" that only shows in one source explains
+ *     providers not loading.
+ *   - The actual provider list guests receive (same code path as
+ *     /api/agent/providers).
+ *   - Free models listed in the database for each provider.
+ *   - A quick live chat-completion test of one model per provider.
+ *   - Auth diagnostics: BETTER_AUTH_SECRET, Google OAuth config, and the
+ *     current request's session (to debug "unauthorized after login").
+ *
+ * GET /api/admin/freekeys?testAll=nvidia|openrouter|all
+ *   - Live-tests every free model for the provider(s) and cross-checks each
+ *     model ID against the provider's live /models endpoint.
  */
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { LANGUAGE_MODELS } from "chat-agent-toolkit/config/language-models-database";
+import { getEnv } from "chat-agent-toolkit/config/environment-variables";
+import ModelRegistry from "chat-agent-toolkit/models/registry";
+import { getSession } from "@/lib/auth/session";
 
 export const runtime = "nodejs";
-export const maxDuration = 60;
+export const maxDuration = 300;
 
-async function testKey(
+/** Reads a key from the cloudflare:workers env binding only (no fallback). */
+function getCfEnv(key: string): string | undefined {
+  try {
+    // @ts-ignore - cloudflare:workers is a virtual module provided by @cloudflare/vite-plugin
+    const cfWorkers = require("cloudflare:workers");
+    return cfWorkers.env?.[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function mask(key: string): string {
+  if (!key) return "";
+  return key.length <= 12 ? `${key.slice(0, 4)}...` : `${key.slice(0, 8)}...${key.slice(-4)}`;
+}
+
+/**
+ * Reports where an env var is visible. `effective` is what the app's shared
+ * getEnv() accessor resolves (cloudflare:workers first, then process.env).
+ */
+function envSourceReport(key: string) {
+  const cf = getCfEnv(key) ?? "";
+  const proc = process.env[key] ?? "";
+  const effective = getEnv(key) ?? "";
+  return {
+    set: !!effective,
+    masked: effective ? mask(effective) : null,
+    sources: {
+      cloudflareEnv: !!cf,
+      processEnv: !!proc,
+    },
+  };
+}
+
+interface LiveTestResult {
+  model: string;
+  ok: boolean;
+  status?: number;
+  error?: string;
+  ms: number;
+  existsUpstream?: boolean;
+}
+
+async function testChatCompletion(
   provider: "nvidia" | "openrouter",
   apiKey: string,
   baseUrl: string,
-  modelId: string
+  modelId: string,
+  timeoutMs = 15000
 ): Promise<{ ok: boolean; status?: number; error?: string; ms: number }> {
   const start = Date.now();
   try {
@@ -36,7 +93,7 @@ async function testKey(
         max_tokens: 5,
         stream: false,
       }),
-      signal: AbortSignal.timeout(15000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     const ms = Date.now() - start;
     if (res.ok) return { ok: true, status: res.status, ms };
@@ -47,25 +104,107 @@ async function testKey(
   }
 }
 
-export async function GET() {
-  const nvidiaKey = process.env.NVIDIA_API_KEY ?? "";
+/** Fetches the provider's live model ID list from its /models endpoint. */
+async function fetchUpstreamModelIds(
+  apiKey: string,
+  baseUrl: string
+): Promise<Set<string> | null> {
+  try {
+    const res = await fetch(`${baseUrl}/models`, {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) return null;
+    const json: any = await res.json();
+    const ids = (json?.data ?? []).map((m: any) => m.id).filter(Boolean);
+    return ids.length ? new Set<string>(ids) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Runs an async mapper over items with a small concurrency cap. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function getFreeModels(providerName: "nvidia" | "openrouter") {
+  const entry = LANGUAGE_MODELS.find(
+    (p) => p.provider.toLowerCase() === providerName
+  );
+  return (
+    entry?.models.filter((m: any) => m.free && m.type === "text-generation") ?? []
+  );
+}
+
+async function testAllFreeModels(
+  provider: "nvidia" | "openrouter",
+  apiKey: string,
+  baseUrl: string
+): Promise<{ upstreamModelsFetched: boolean; results: LiveTestResult[] }> {
+  const freeModels = getFreeModels(provider);
+  const upstream = apiKey ? await fetchUpstreamModelIds(apiKey, baseUrl) : null;
+
+  const results = await mapWithConcurrency(freeModels, 3, async (m) => {
+    const existsUpstream = upstream ? upstream.has(m.id) : undefined;
+    // Skip the live call for models the provider no longer lists — it would
+    // only produce a 404 and waste rate limit.
+    if (existsUpstream === false) {
+      return {
+        model: m.id,
+        ok: false,
+        error: "model not listed by provider /models endpoint",
+        ms: 0,
+        existsUpstream,
+      } as LiveTestResult;
+    }
+    const test = await testChatCompletion(provider, apiKey, baseUrl, m.id);
+    return { model: m.id, ...test, existsUpstream } as LiveTestResult;
+  });
+
+  return { upstreamModelsFetched: !!upstream, results };
+}
+
+export async function GET(req: NextRequest) {
+  const nvidiaKey = getEnv("NVIDIA_API_KEY") ?? "";
   const nvidiaBase =
-    process.env.NVIDIA_BASE_URL ?? "https://integrate.api.nvidia.com/v1";
-  const orKey = process.env.OPENROUTER_API_KEY ?? "";
-  const orBase =
-    process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1";
+    getEnv("NVIDIA_BASE_URL") ?? "https://integrate.api.nvidia.com/v1";
+  const orKey = getEnv("OPENROUTER_API_KEY") ?? "";
+  const orBase = getEnv("OPENROUTER_BASE_URL") ?? "https://openrouter.ai/api/v1";
 
-  const nvidiaProvider = LANGUAGE_MODELS.find(
-    (p) => p.provider.toUpperCase() === "NVIDIA"
-  );
-  const orProvider = LANGUAGE_MODELS.find(
-    (p) => p.provider.toLowerCase() === "openrouter"
-  );
+  // --- Full test mode: live-test every free model ---------------------------
+  const testAll = req.nextUrl.searchParams.get("testAll");
+  if (testAll) {
+    const out: Record<string, any> = {};
+    if (testAll === "nvidia" || testAll === "all") {
+      out.nvidia = nvidiaKey
+        ? await testAllFreeModels("nvidia", nvidiaKey, nvidiaBase)
+        : { error: "NVIDIA_API_KEY not set" };
+    }
+    if (testAll === "openrouter" || testAll === "all") {
+      out.openrouter = orKey
+        ? await testAllFreeModels("openrouter", orKey, orBase)
+        : { error: "OPENROUTER_API_KEY not set" };
+    }
+    return NextResponse.json(out);
+  }
 
-  const nvidiaFreeModels =
-    nvidiaProvider?.models.filter((m) => m.free && m.type === "text-generation") ?? [];
-  const orFreeModels =
-    orProvider?.models.filter((m) => m.free && m.type === "text-generation") ?? [];
+  // --- Summary mode ----------------------------------------------------------
+  const nvidiaFreeModels = getFreeModels("nvidia");
+  const orFreeModels = getFreeModels("openrouter");
 
   // Test one representative model per provider if key is present
   const nvidiaTestModel = nvidiaFreeModels[0]?.id ?? "";
@@ -75,17 +214,46 @@ export async function GET() {
 
   const [nvidiaTest, orTest] = await Promise.all([
     nvidiaKey && nvidiaTestModel
-      ? testKey("nvidia", nvidiaKey, nvidiaBase, nvidiaTestModel)
+      ? testChatCompletion("nvidia", nvidiaKey, nvidiaBase, nvidiaTestModel)
       : Promise.resolve(null),
     orKey && orTestModel
-      ? testKey("openrouter", orKey, orBase, orTestModel)
+      ? testChatCompletion("openrouter", orKey, orBase, orTestModel)
       : Promise.resolve(null),
   ]);
 
+  // Ground truth: the exact provider list /api/agent/providers gives guests.
+  let guestProviders: { name: string; type: string; modelCount: number }[] = [];
+  let guestProvidersError: string | null = null;
+  try {
+    const registry = new ModelRegistry();
+    const active = await registry.getActiveProviders();
+    guestProviders = active.map((p) => ({
+      name: p.name,
+      type: p.type,
+      modelCount: p.chatModels.length,
+    }));
+  } catch (e: any) {
+    guestProvidersError = e.message;
+  }
+
+  // Session state of THIS request — debugs "logged in but still unauthorized".
+  let session: { signedIn: boolean; email?: string; userId?: string; error?: string } = {
+    signedIn: false,
+  };
+  try {
+    const s = await getSession();
+    if (s) {
+      session = { signedIn: true, email: s.user.email, userId: s.user.id };
+    }
+  } catch (e: any) {
+    session = { signedIn: false, error: e.message };
+  }
+
   return NextResponse.json({
     nvidia: {
+      key: envSourceReport("NVIDIA_API_KEY"),
       keyConfigured: !!nvidiaKey,
-      keyMasked: nvidiaKey ? `${nvidiaKey.slice(0, 8)}...${nvidiaKey.slice(-4)}` : null,
+      keyMasked: nvidiaKey ? mask(nvidiaKey) : null,
       baseUrl: nvidiaBase,
       freeModelCount: nvidiaFreeModels.length,
       freeModels: nvidiaFreeModels.map((m) => ({
@@ -98,8 +266,9 @@ export async function GET() {
         : { skipped: true, reason: nvidiaKey ? "no free model found" : "no API key" },
     },
     openrouter: {
+      key: envSourceReport("OPENROUTER_API_KEY"),
       keyConfigured: !!orKey,
-      keyMasked: orKey ? `${orKey.slice(0, 8)}...${orKey.slice(-4)}` : null,
+      keyMasked: orKey ? mask(orKey) : null,
       baseUrl: orBase,
       freeModelCount: orFreeModels.length,
       freeModels: orFreeModels.map((m) => ({
@@ -111,6 +280,11 @@ export async function GET() {
         ? { model: orTestModel, ...orTest }
         : { skipped: true, reason: orKey ? "no free model found" : "no API key" },
     },
+    guestProviders: {
+      note: "Exactly what /api/agent/providers returns to guests. If a provider is missing here, its required env vars are not visible to the worker.",
+      providers: guestProviders,
+      error: guestProvidersError,
+    },
     guestLogic: {
       note: "All configured providers are loaded for guests. Both NVIDIA and OpenRouter load independently when their API keys are set.",
       openrouterKeySet: !!orKey,
@@ -118,8 +292,12 @@ export async function GET() {
       openrouterWillBeLoaded: !!orKey,
     },
     auth: {
-      betterAuthSecretSet: !!process.env.BETTER_AUTH_SECRET,
-      note: !process.env.BETTER_AUTH_SECRET
+      betterAuthSecretSet: !!getEnv("BETTER_AUTH_SECRET"),
+      googleOAuthConfigured:
+        !!getEnv("GOOGLE_CLIENT_ID") && !!getEnv("GOOGLE_CLIENT_SECRET"),
+      baseUrlEnv: getEnv("NEXT_PUBLIC_BASE_URL") ?? null,
+      session,
+      note: !getEnv("BETTER_AUTH_SECRET")
         ? "BETTER_AUTH_SECRET is not set. CF Workers restarts generate a new random signing key each time, invalidating all sessions. Add BETTER_AUTH_SECRET to your CF Workers environment variables."
         : "BETTER_AUTH_SECRET is set. Sessions will survive worker restarts.",
     },

--- a/apps/qwksearch-web/wrangler.jsonc
+++ b/apps/qwksearch-web/wrangler.jsonc
@@ -4,6 +4,10 @@
   "main": "./worker/index.ts",
   "compatibility_date": "2026-03-10",
   "compatibility_flags": ["nodejs_compat"],
+  // Without keep_vars, every `wrangler deploy` deletes plaintext Variables
+  // entered in the CF dashboard (API keys, BETTER_AUTH_SECRET, …) because
+  // this config defines no `vars`. Secrets survive either way.
+  "keep_vars": true,
   "upload_source_maps": true,
   "assets": {
     "directory": "dist/client",


### PR DESCRIPTION
## Summary
This PR significantly expands the free keys admin diagnostic page with comprehensive environment variable visibility reporting, live model testing capabilities, and improved auth/provider status visibility.

## Key Changes

### Environment Variable Diagnostics
- Added `KeySourceReport` interface to track where API keys are visible (cloudflare:workers env vs process.env)
- New `envSourceReport()` function distinguishes between CF dashboard bindings and process.env sources
- Display key visibility sources in provider cards to help debug "key set but not loading" issues
- Added `getCfEnv()` helper to read cloudflare:workers bindings directly

### Live Model Testing
- Added "Test all models" button to each provider card that runs live chat-completion tests against every free model
- New `testAllFreeModels()` function with concurrency-limited testing (3 concurrent requests)
- Cross-references test results against provider's live `/models` endpoint to identify stale model IDs
- Displays per-model results: response status, upstream availability, latency, and error messages
- Extended API timeout from 60s to 300s to accommodate full test suite

### Provider Visibility
- New "Providers loaded for guests" section showing exact provider list returned to unauthenticated users
- Matches the code path used by `/api/agent/providers` for ground-truth verification
- Displays model count per provider and any loading errors

### Auth Diagnostics
- Expanded auth section with Google OAuth configuration status
- Shows `NEXT_PUBLIC_BASE_URL` environment variable
- Displays current request's session state (signed in/guest, email, user ID)
- Includes session error reporting for debugging "unauthorized after login" issues

### Code Organization
- Extracted `getFreeModels()` helper to reduce duplication
- Added `mapWithConcurrency()` utility for rate-limited async operations
- Refactored `testKey()` to `testChatCompletion()` with configurable timeout
- Updated all env var reads to use shared `getEnv()` accessor instead of direct `process.env`

### UI Improvements
- `StatusBadge` component now accepts optional custom labels
- Reorganized provider cards with separate sections for key visibility, test results, and model list
- Added visual feedback for testing state (disabled button, loading text)
- Improved error display with monospace formatting and truncation

### Configuration
- Updated `wrangler.jsonc` with `keep_vars` flag to prevent accidental deletion of plaintext environment variables during deployments

## Implementation Details
- Key masking shows first 8 and last 4 characters (or first 4 if ≤12 chars) for security
- Model testing skips live calls for models not listed upstream to avoid wasting rate limits
- Upstream model list fetching is optional and gracefully degrades if provider's `/models` endpoint is unavailable
- Session diagnostics use the same auth flow as the application to catch configuration issues

https://claude.ai/code/session_01KUJcZ9S9ozcM4it4s7Mwcj