### PR TITLE
Improve session validation error handling and resilience

### DIFF
--- a/apps/qwksearch-web/lib/auth/session.ts
+++ b/apps/qwksearch-web/lib/auth/session.ts
@@ -23,19 +23,28 @@ export interface AuthSession {
  * Returns null if not authenticated
  */
 export async function getSession(): Promise<AuthSession | null> {
+  let session;
   try {
     const auth = await initAuth();
     const requestHeaders = await headers();
-    const session = await auth.api.getSession({
+    session = await auth.api.getSession({
       headers: requestHeaders,
     });
     if (!session) return null;
+  } catch (error) {
+    console.error("Session retrieval error:", error);
+    return null;
+  }
 
-    // Sessions are stored in KV (better-auth-cloudflare secondaryStorage) and
-    // can outlive their user row when the D1 database is recreated. Every
-    // userId column with FOREIGN KEY REFERENCES user(id) rejects writes for
-    // such stale sessions, so verify the user row exists before trusting the
-    // session anywhere.
+  // Sessions are stored in KV (better-auth-cloudflare secondaryStorage) and
+  // can outlive their user row when the D1 database is recreated. Every
+  // userId column with FOREIGN KEY REFERENCES user(id) rejects writes for
+  // such stale sessions, so verify the user row exists before trusting the
+  // session anywhere. This check is best-effort: if the lookup itself fails
+  // (e.g. a transient D1 error), trust the session rather than revoking it —
+  // a query failure is not proof the user row is missing, and a fresh
+  // Google/One-Tap sign-in's D1 write may not yet be visible to this read.
+  try {
     const db = getDB();
     const userRow = await db.query.user.findFirst({
       where: eq(userSchema.id, session.user.id),
@@ -48,18 +57,19 @@ export async function getSession(): Promise<AuthSession | null> {
       try {
         // Delete the orphaned session from KV so the client's own
         // better-auth get-session calls stop reporting it as signed in.
+        const auth = await initAuth();
+        const requestHeaders = await headers();
         await auth.api.signOut({ headers: requestHeaders });
       } catch (signOutError) {
         console.error("[auth] failed to revoke stale session:", signOutError);
       }
       return null;
     }
-
-    return session;
   } catch (error) {
-    console.error("Session retrieval error:", error);
-    return null;
+    console.error("[auth] user row lookup failed; trusting session:", error);
   }
+
+  return session;
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactored the `getSession()` function to improve error handling and resilience when validating user sessions against the database. The changes separate concerns between session retrieval failures and user row lookup failures, with different handling strategies for each.

## Key Changes
- **Separated error handling**: Session retrieval errors now return null immediately, while user row lookup failures are treated as best-effort checks that trust the session rather than revoking it
- **Improved error messages**: Added contextual error logging to distinguish between different failure modes (`"Session retrieval error"` vs `"user row lookup failed; trusting session"`)
- **Enhanced comments**: Expanded documentation explaining why sessions can outlive their user rows and why transient database errors shouldn't trigger session revocation
- **Fixed variable scope**: Moved `session` declaration outside try block to ensure it's accessible in the final return statement
- **Reinitialize auth context**: Added re-initialization of `auth` and `requestHeaders` in the sign-out attempt to ensure fresh context for the revocation call

## Implementation Details
The logic now follows this flow:
1. Attempt to retrieve the session; return null if this fails
2. Attempt to verify the user row exists in the database
3. If the user row is missing, revoke the stale session from KV storage
4. If the user row lookup itself fails (transient error), trust the session anyway since a query failure doesn't prove the user row is missing
5. Return the session if all checks pass or if the verification check failed gracefully

This approach balances security (removing orphaned sessions) with availability (not breaking authentication due to transient database issues).

https://claude.ai/code/session_01GnTXTDy9xN2UzR1pwYS9Jv