### PR TITLE
Fix property naming and type exports

### DIFF
--- a/packages/agent-toolkit/src/tools/search/doc-utils.ts
+++ b/packages/agent-toolkit/src/tools/search/doc-utils.ts
@@ -67,13 +67,13 @@ export async function rerankDocs(
     return docs;
   }
 
-  let filesData: { fileName: string; content: string }[] = [];
+  let filesData: { title: string; content: string }[] = [];
 
   if (fileIds.length > 0 && r2Credentials) {
     const results = await Promise.all(
       fileIds.map((fileId) => downloadExtractedContent(fileId, r2Credentials))
     );
-    filesData = results.filter((r) => r !== null) as { fileName: string; content: string }[];
+    filesData = results.filter((r) => r !== null);
   }
 
   if (query.toLocaleLowerCase() === "summarize") {
@@ -86,7 +86,7 @@ export async function rerankDocs(
 
   const fileDocs: Document[] = filesData.map((fileData) => ({
     pageContent: fileData.content,
-    metadata: { title: fileData.fileName, url: "File" },
+    metadata: { title: fileData.title, url: "File" },
   }));
 
   // Combine file docs with web results, cap at 15

--- a/packages/write-language/package.json
+++ b/packages/write-language/package.json
@@ -16,7 +16,7 @@
   "types": "./dist/types.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "react-server": "./dist/write-language.es.js",
       "import": "./dist/write-language.es.js",
       "require": "./dist/write-language.cjs.js"


### PR DESCRIPTION
## Summary
This PR fixes two issues: a property naming inconsistency in the document reranking utility and an incorrect type export path in the write-language package.

## Key Changes
- **doc-utils.ts**: Renamed `fileName` property to `title` for consistency
  - Updated the `filesData` type definition from `{ fileName: string; content: string }[]` to `{ title: string; content: string }[]`
  - Updated the metadata assignment to use `fileData.title` instead of `fileData.fileName`
  - Removed redundant type assertion in the filter operation
  
- **write-language/package.json**: Fixed TypeScript types export path
  - Changed types export from `./dist/index.d.ts` to `./src/index.ts` to point to the correct source file

## Implementation Details
The property naming change in `rerankDocs` ensures that the file data structure uses a consistent `title` field throughout the codebase, improving code clarity and reducing confusion between file names and document titles.

https://claude.ai/code/session_01XvJx5APDnWH1oypa89zHYV