### PR TITLE
Add user file uploads with R2 storage and quota management

### DIFF
--- a/apps/qwksearch-web/app/api/doc/uploads/route.ts
+++ b/apps/qwksearch-web/app/api/doc/uploads/route.ts
@@ -1,16 +1,33 @@
 /**
- * @fileoverview File upload and management via Cloudflare R2. POST uploads
- * files (PDF, DOCX, TXT, HTML), extracts text content, and stores both
- * original and extracted data. GET retrieves extracted content by file ID.
- * DELETE removes uploaded files and their extracted data.
+ * @fileoverview File upload and management via Cloudflare R2.
+ *
+ * - `POST` (multipart) — uploads files (PDF, DOCX, TXT, MD, HTML), extracts
+ *   text content, stores both original and extracted data, and records the
+ *   upload for per-user quota accounting.
+ * - `POST` (JSON `{ url }` or `{ urls }`) — extracts typed-in URLs via
+ *   `extract-webpage` and stores them as attachable context files.
+ * - `GET ?fileId=` — retrieves extracted content for a file.
+ * - `GET` — lists the authenticated user's uploads with quota usage.
+ * - `DELETE ?fileId=` — removes uploads (comma-separate ids for batch).
+ * - `DELETE` (JSON `{ fileIds }`) — batch removes uploads.
+ * - `DELETE ?all=true` — removes all of the user's uploads.
  */
 import { NextResponse } from 'next/server';
 import crypto from 'crypto';
 
-import { uploadToR2, downloadFromR2, deleteFromR2 } from '@/lib/storage/r2-service';
-import { convertPDFToHTML } from 'extract-pdf';
-import { convertDOCXToHTML } from 'extract-webpage';
-import { checkUserStorageQuota, incrementUserStorageUsage, decrementUserStorageUsage } from '@/lib/storage/quota';
+import {
+  MAX_FILE_SIZE_BYTES,
+  MAX_FILES_PER_REQUEST,
+  SUPPORTED_UPLOAD_EXTENSIONS,
+  URL_UPLOAD_EXTENSION,
+  extractUploadText,
+  storeUpload,
+  getExtractedUpload,
+  getUserUploads,
+  getUserUploadQuota,
+  deleteUploadObjects,
+  deleteUploadRecords,
+} from '@/lib/uploads';
 import { getUserId } from '@/lib/auth/session';
 
 interface FileRes {
@@ -20,90 +37,187 @@ interface FileRes {
   sizeBytes: number;
 }
 
+const newFileId = () => crypto.randomBytes(16).toString('hex');
+
+/**
+ * Handles multipart file uploads: validates count/size/type limits,
+ * enforces the per-user quota, extracts text, and stores everything in R2.
+ */
+async function handleFileUpload(req: Request, userId: string | null) {
+  const formData = await req.formData();
+  const files = formData.getAll('files') as File[];
+
+  if (files.length === 0) {
+    return NextResponse.json(
+      { message: 'No files provided' },
+      { status: 400 },
+    );
+  }
+
+  if (files.length > MAX_FILES_PER_REQUEST) {
+    return NextResponse.json(
+      { message: `Too many files: maximum ${MAX_FILES_PER_REQUEST} files per upload` },
+      { status: 400 },
+    );
+  }
+
+  for (const file of files) {
+    const fileExtension = file.name.split('.').pop()?.toLowerCase();
+    if (
+      !fileExtension ||
+      !(SUPPORTED_UPLOAD_EXTENSIONS as readonly string[]).includes(fileExtension)
+    ) {
+      return NextResponse.json(
+        {
+          message: `File type not supported for "${file.name}". Supported types: ${SUPPORTED_UPLOAD_EXTENSIONS.join(', ')}`,
+        },
+        { status: 400 },
+      );
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json(
+        {
+          message: `File "${file.name}" is too large. Maximum size is ${Math.round(MAX_FILE_SIZE_BYTES / 1024 / 1024)} MB per file.`,
+        },
+        { status: 413 },
+      );
+    }
+  }
+
+  // Enforce the per-user storage quota for authenticated users.
+  if (userId) {
+    const totalSize = files.reduce((sum, f) => sum + f.size, 0);
+    const quota = await getUserUploadQuota(userId, totalSize);
+    if (!quota.allowed) {
+      return NextResponse.json(
+        {
+          message: `Storage quota exceeded. Used: ${Math.round(quota.used / 1024 / 1024)}MB / ${Math.round(quota.quota / 1024 / 1024)}MB`,
+          usage: quota,
+        },
+        { status: 413 },
+      );
+    }
+  }
+
+  const processedFiles: FileRes[] = [];
+
+  await Promise.all(
+    files.map(async (file: File) => {
+      const fileExtension = file.name.split('.').pop()!.toLowerCase();
+      const fileId = newFileId();
+      const buffer = Buffer.from(await file.arrayBuffer());
+
+      const content = await extractUploadText(buffer, file.name, fileExtension);
+
+      await storeUpload({
+        fileId,
+        fileName: file.name,
+        fileExtension,
+        size: file.size,
+        userId,
+        originalBuffer: buffer,
+        extracted: { title: file.name, content },
+      });
+
+      processedFiles.push({
+        fileName: file.name,
+        fileExtension,
+        fileId,
+        sizeBytes: file.size,
+      });
+    }),
+  );
+
+  return NextResponse.json({ files: processedFiles });
+}
+
+/**
+ * Handles JSON `{ url }` / `{ urls }` requests: extracts each URL's content
+ * with `extract-webpage` and stores it as an attachable context file.
+ */
+async function handleUrlExtraction(req: Request, userId: string | null) {
+  const body = (await req.json()) as { url?: string; urls?: string[] };
+  const urls = (body.urls ?? (body.url ? [body.url] : []))
+    .map((u) => String(u).trim())
+    .filter((u) => /^https?:\/\//i.test(u));
+
+  if (urls.length === 0) {
+    return NextResponse.json(
+      { message: 'Provide a "url" or "urls" field with http(s) URLs to extract' },
+      { status: 400 },
+    );
+  }
+
+  if (urls.length > MAX_FILES_PER_REQUEST) {
+    return NextResponse.json(
+      { message: `Too many URLs: maximum ${MAX_FILES_PER_REQUEST} per request` },
+      { status: 400 },
+    );
+  }
+
+  const { extractContent } = await import('extract-webpage');
+
+  const processedFiles: FileRes[] = [];
+  const errors: { url: string; message: string }[] = [];
+
+  await Promise.all(
+    urls.map(async (url) => {
+      try {
+        const article = await extractContent(url);
+        if (!article || article.error || !article.html) {
+          errors.push({
+            url,
+            message: `Could not extract content from ${url}`,
+          });
+          return;
+        }
+
+        const fileId = newFileId();
+        const title = article.title || url;
+        const content = article.html;
+        const size = Buffer.byteLength(content, 'utf-8');
+
+        await storeUpload({
+          fileId,
+          fileName: title,
+          fileExtension: URL_UPLOAD_EXTENSION,
+          size,
+          userId,
+          extracted: { title, content, url },
+        });
+
+        processedFiles.push({
+          fileName: title,
+          fileExtension: URL_UPLOAD_EXTENSION,
+          fileId,
+          sizeBytes: size,
+        });
+      } catch (error) {
+        console.error(`[POST /api/doc/uploads] URL extraction failed for ${url}:`, error);
+        errors.push({ url, message: `Could not extract content from ${url}` });
+      }
+    }),
+  );
+
+  if (processedFiles.length === 0) {
+    return NextResponse.json(
+      { message: errors[0]?.message ?? 'URL extraction failed', errors },
+      { status: 422 },
+    );
+  }
+
+  return NextResponse.json({ files: processedFiles, errors });
+}
+
 export async function POST(req: Request) {
   try {
     const userId = await getUserId();
+    const contentType = req.headers.get('content-type') ?? '';
 
-    // Only check quota for authenticated users
-    if (userId) {
-      const formData = await req.formData();
-      const files = formData.getAll('files') as File[];
-      const totalSize = files.reduce((sum, f) => sum + f.size, 0);
-
-      const quota = await checkUserStorageQuota(userId, totalSize);
-      if (!quota.allowed) {
-        return NextResponse.json(
-          { message: `Storage quota exceeded. Used: ${Math.round(quota.used / 1024 / 1024)}MB / ${Math.round(quota.quota / 1024 / 1024)}MB` },
-          { status: 413 },
-        );
-      }
+    if (contentType.includes('application/json')) {
+      return await handleUrlExtraction(req, userId);
     }
-
-    const formData = await req.formData();
-    const files = formData.getAll('files') as File[];
-
-    const processedFiles: FileRes[] = [];
-
-    await Promise.all(
-      files.map(async (file: File) => {
-        const fileExtension = file.name.split('.').pop()?.toLowerCase();
-        if (!fileExtension || !['pdf', 'docx', 'txt', 'html', 'htm'].includes(fileExtension)) {
-          return NextResponse.json(
-            { message: 'File type not supported' },
-            { status: 400 },
-          );
-        }
-
-        const fileId = crypto.randomBytes(16).toString('hex');
-        const uniqueFileName = `${fileId}.${fileExtension}`;
-        const buffer = Buffer.from(await file.arrayBuffer());
-
-        // Upload original file to R2
-        await uploadToR2(uniqueFileName, buffer);
-
-        // Extract text content based on file type
-        let fullText = '';
-        try {
-          if (fileExtension === 'pdf') {
-            const pdfResult = await convertPDFToHTML(buffer, { addCitation: true });
-            if (!pdfResult.error) {
-              fullText = pdfResult.html || pdfResult.text || '';
-            }
-          } else if (fileExtension === 'docx') {
-            fullText = await convertDOCXToHTML(buffer);
-          } else if (fileExtension === 'txt' || fileExtension === 'html' || fileExtension === 'htm') {
-            fullText = buffer.toString('utf-8');
-          }
-        } catch (extractError) {
-          console.error(`[POST /api/doc/uploads] Content extraction failed for ${file.name}:`, extractError);
-          // Continue without extraction - store empty content gracefully
-        }
-
-        // Upload extracted data as JSON to R2
-        const extractedData = JSON.stringify({
-          title: file.name,
-          content: fullText,
-        });
-        await uploadToR2(`${fileId}-extracted.json`, extractedData);
-
-        processedFiles.push({
-          fileName: file.name,
-          fileExtension: fileExtension,
-          fileId: fileId,
-          sizeBytes: file.size,
-        });
-      }),
-    );
-
-    // Track storage usage for authenticated users
-    if (userId && processedFiles.length > 0) {
-      const totalSize = processedFiles.reduce((sum, f) => sum + f.sizeBytes, 0);
-      await incrementUserStorageUsage(userId, totalSize);
-    }
-
-    return NextResponse.json({
-      files: processedFiles,
-    });
+    return await handleFileUpload(req, userId);
   } catch (error) {
     console.error('Error uploading file:', error);
     return NextResponse.json(
@@ -114,26 +228,57 @@ export async function POST(req: Request) {
 }
 
 export async function GET(req: Request) {
-  try {
-    const { searchParams } = new URL(req.url);
-    const fileId = searchParams.get('fileId');
+  const { searchParams } = new URL(req.url);
+  const fileId = searchParams.get('fileId');
 
-    if (!fileId) {
+  // Fetch extracted content for a specific file.
+  if (fileId) {
+    try {
+      const extracted = await getExtractedUpload(fileId);
+      if (!extracted) {
+        return NextResponse.json({ message: 'File not found' }, { status: 404 });
+      }
+      return NextResponse.json(extracted);
+    } catch (error) {
+      console.error('Error fetching file:', error);
+      return NextResponse.json({ message: 'File not found' }, { status: 404 });
+    }
+  }
+
+  // List the authenticated user's uploads with quota usage.
+  try {
+    const userId = await getUserId();
+    if (!userId) {
       return NextResponse.json(
-        { message: 'File ID is required' },
-        { status: 400 },
+        { message: 'Sign in to list your uploads' },
+        { status: 401 },
       );
     }
 
-    const extractedKey = `${fileId}-extracted.json`;
-    const content = await downloadFromR2(extractedKey);
+    const [files, usage] = await Promise.all([
+      getUserUploads(userId),
+      getUserUploadQuota(userId),
+    ]);
 
-    return NextResponse.json(JSON.parse(content));
+    return NextResponse.json({
+      files: files.map((f) => ({
+        fileId: f.fileId,
+        fileName: f.fileName,
+        fileExtension: f.fileExtension,
+        sizeBytes: f.size,
+        createdAt: f.createdAt,
+      })),
+      usage: {
+        used: usage.used,
+        quota: usage.quota,
+        remaining: usage.remaining,
+      },
+    });
   } catch (error) {
-    console.error('Error fetching file:', error);
+    console.error('Error listing uploads:', error);
     return NextResponse.json(
-      { message: 'File not found' },
-      { status: 404 },
+      { message: 'Failed to list uploads' },
+      { status: 500 },
     );
   }
 }
@@ -142,58 +287,60 @@ export async function DELETE(req: Request) {
   try {
     const userId = await getUserId();
     const { searchParams } = new URL(req.url);
-    const fileId = searchParams.get('fileId');
-    const fileExtension = searchParams.get('ext');
-    const sizeBytes = searchParams.get('sizeBytes') ? parseInt(searchParams.get('sizeBytes')!) : 0;
+    const fileIdParam = searchParams.get('fileId');
+    const deleteAll = searchParams.get('all') === 'true';
 
-    if (!fileId) {
-      return NextResponse.json(
-        { message: 'File ID is required' },
-        { status: 400 },
-      );
-    }
-
-    const results: { key: string; success: boolean }[] = [];
-
-    // Delete extracted JSON
-    try {
-      await deleteFromR2(`${fileId}-extracted.json`);
-      results.push({ key: `${fileId}-extracted.json`, success: true });
-    } catch (error) {
-      results.push({ key: `${fileId}-extracted.json`, success: false });
-    }
-
-    // Delete original file if extension provided
-    if (fileExtension) {
-      try {
-        await deleteFromR2(`${fileId}.${fileExtension}`);
-        results.push({ key: `${fileId}.${fileExtension}`, success: true });
-      } catch (error) {
-        results.push({ key: `${fileId}.${fileExtension}`, success: false });
+    // Resolve which fileIds to delete: ?all=true, JSON body batch, or ?fileId=.
+    let fileIds: string[] = [];
+    if (deleteAll) {
+      if (!userId) {
+        return NextResponse.json(
+          { message: 'Sign in to delete all uploads' },
+          { status: 401 },
+        );
       }
+    } else if (fileIdParam) {
+      fileIds = fileIdParam.split(',').map((id) => id.trim()).filter(Boolean);
     } else {
-      // Try common extensions if not provided
-      const extensions = ['pdf', 'docx', 'txt', 'html', 'htm'];
-      for (const ext of extensions) {
-        try {
-          await deleteFromR2(`${fileId}.${ext}`);
-          results.push({ key: `${fileId}.${ext}`, success: true });
-          break;
-        } catch {
-          // File with this extension doesn't exist, continue
-        }
+      const body = (await req.json().catch(() => null)) as
+        | { fileIds?: string[] }
+        | null;
+      fileIds = (body?.fileIds ?? []).map(String).filter(Boolean);
+      if (fileIds.length === 0) {
+        return NextResponse.json(
+          { message: 'Provide ?fileId=, ?all=true, or a JSON body with "fileIds"' },
+          { status: 400 },
+        );
       }
     }
 
-    // Decrement storage usage for authenticated users
-    if (userId && sizeBytes > 0) {
-      await decrementUserStorageUsage(userId, sizeBytes);
+    // Known extension per fileId, from quota records (authenticated) or the
+    // ?ext= hint (single-file guest deletes).
+    const extHint = searchParams.get('ext');
+    const extensions = new Map<string, string | null>();
+    fileIds.forEach((id) => extensions.set(id, extHint));
+
+    if (userId) {
+      const deletedRecords = await deleteUploadRecords(
+        userId,
+        deleteAll ? undefined : fileIds,
+      );
+      if (deleteAll) {
+        fileIds = deletedRecords.map((r) => r.fileId);
+      }
+      deletedRecords.forEach((r) => extensions.set(r.fileId, r.fileExtension));
     }
+
+    const results = await Promise.allSettled(
+      fileIds.map((id) => deleteUploadObjects(id, extensions.get(id))),
+    );
 
     return NextResponse.json({
       success: true,
-      fileId,
-      deleted: results,
+      deleted: fileIds.map((id, i) => ({
+        fileId: id,
+        success: results[i].status === 'fulfilled',
+      })),
     });
   } catch (error) {
     console.error('Error deleting file:', error);

--- a/apps/qwksearch-web/components/Settings/Sections/Uploads.tsx
+++ b/apps/qwksearch-web/components/Settings/Sections/Uploads.tsx
@@ -1,0 +1,250 @@
+/**
+ * Settings section for managing uploaded files stored in R2: shows storage
+ * usage against the per-user quota with a progress bar, lists uploads with
+ * sizes, and supports deleting individual files, a selection, or everything.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import grab from 'grab-url';
+import { toast } from 'sonner';
+import { File, Link, Loader2, RefreshCw, Trash2 } from 'lucide-react';
+import { cn } from '../../../lib/utils';
+
+interface UploadItem {
+  fileId: string;
+  fileName: string;
+  fileExtension: string;
+  sizeBytes: number;
+  createdAt?: string | number;
+}
+
+interface UploadUsage {
+  used: number;
+  quota: number;
+  remaining: number;
+}
+
+const formatBytes = (bytes: number): string => {
+  if (!bytes || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+  );
+  const value = bytes / Math.pow(1024, i);
+  return `${value >= 10 || i === 0 ? Math.round(value) : value.toFixed(1)} ${units[i]}`;
+};
+
+const formatDate = (createdAt?: string | number): string => {
+  if (!createdAt) return '';
+  const date = new Date(
+    typeof createdAt === 'number' && createdAt < 1e12
+      ? createdAt * 1000
+      : createdAt,
+  );
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString();
+};
+
+const Uploads = (_props: { fields?: any; values?: any }) => {
+  const [files, setFiles] = useState<UploadItem[]>([]);
+  const [usage, setUsage] = useState<UploadUsage | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSignedOut, setIsSignedOut] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchUploads = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await grab('doc/uploads');
+      if (data?.files) {
+        setFiles(data.files);
+        setUsage(data.usage ?? null);
+        setIsSignedOut(false);
+      } else if (data?.message === 'Sign in to list your uploads') {
+        setIsSignedOut(true);
+      } else {
+        throw new Error(data?.message ?? 'Failed to load uploads');
+      }
+    } catch (error) {
+      console.error('Error fetching uploads:', error);
+      toast.error('Failed to load uploads.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUploads();
+  }, [fetchUploads]);
+
+  const deleteFiles = async (fileIds: string[] | 'all') => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      const query =
+        fileIds === 'all'
+          ? 'doc/uploads?all=true'
+          : `doc/uploads?fileId=${encodeURIComponent(fileIds.join(','))}`;
+      const data = await grab(query, { method: 'DELETE' });
+      if (!data?.success) {
+        throw new Error(data?.message ?? 'Delete failed');
+      }
+      toast.success(
+        fileIds === 'all'
+          ? 'All uploads deleted.'
+          : `Deleted ${fileIds.length} file${fileIds.length === 1 ? '' : 's'}.`,
+      );
+      setSelected(new Set());
+      await fetchUploads();
+    } catch (error) {
+      console.error('Error deleting uploads:', error);
+      toast.error('Failed to delete uploads.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const toggleSelected = (fileId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(fileId)) next.delete(fileId);
+      else next.add(fileId);
+      return next;
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="animate-spin text-black/50 dark:text-white/50" size={20} />
+      </div>
+    );
+  }
+
+  if (isSignedOut) {
+    return (
+      <div className="px-6 py-4">
+        <p className="text-sm text-black/50 dark:text-white/50">
+          Sign in to view and manage your uploaded files.
+        </p>
+      </div>
+    );
+  }
+
+  const used = usage?.used ?? 0;
+  const quota = usage?.quota ?? 1;
+  const percentage = Math.min(100, Math.round((used / quota) * 100));
+
+  return (
+    <div className="px-6 py-4 flex flex-col space-y-5">
+      {/* Storage usage */}
+      <div className="flex flex-col space-y-2">
+        <div className="flex flex-row items-center justify-between">
+          <p className="text-sm font-medium text-black dark:text-white">
+            Storage used
+          </p>
+          <p className="text-xs text-black/50 dark:text-white/50">
+            {formatBytes(used)} of {formatBytes(quota)} ({percentage}%)
+          </p>
+        </div>
+        <div className="h-2 w-full rounded-full bg-light-200 dark:bg-dark-200 overflow-hidden">
+          <div
+            className={cn(
+              'h-full rounded-full transition-all duration-300',
+              percentage >= 90 ? 'bg-red-500' : 'bg-sky-500',
+            )}
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Bulk actions */}
+      <div className="flex flex-row items-center justify-between">
+        <p className="text-xs text-black/50 dark:text-white/50">
+          {files.length} file{files.length === 1 ? '' : 's'}
+          {selected.size > 0 ? ` · ${selected.size} selected` : ''}
+        </p>
+        <div className="flex flex-row items-center space-x-3">
+          <button
+            onClick={fetchUploads}
+            disabled={deleting}
+            className="flex flex-row items-center space-x-1 text-xs text-black/60 dark:text-white/60 hover:text-black dark:hover:text-white transition duration-200"
+          >
+            <RefreshCw size={13} />
+            <span>Refresh</span>
+          </button>
+          {selected.size > 0 && (
+            <button
+              onClick={() => deleteFiles(Array.from(selected))}
+              disabled={deleting}
+              className="flex flex-row items-center space-x-1 text-xs text-red-500 hover:text-red-600 transition duration-200"
+            >
+              <Trash2 size={13} />
+              <span>Delete selected</span>
+            </button>
+          )}
+          {files.length > 0 && (
+            <button
+              onClick={() => deleteFiles('all')}
+              disabled={deleting}
+              className="flex flex-row items-center space-x-1 text-xs text-red-500 hover:text-red-600 transition duration-200"
+            >
+              <Trash2 size={13} />
+              <span>Delete all</span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* File list */}
+      {files.length === 0 ? (
+        <p className="text-sm text-black/50 dark:text-white/50 py-4">
+          No uploads yet. Attach files or URLs in chat to add context.
+        </p>
+      ) : (
+        <div className="flex flex-col divide-y divide-light-200 dark:divide-dark-200 border border-light-200 dark:border-dark-200 rounded-lg overflow-hidden">
+          {files.map((file) => (
+            <div
+              key={file.fileId}
+              className="flex flex-row items-center space-x-3 px-3 py-2.5 hover:bg-light-secondary dark:hover:bg-dark-secondary transition duration-200"
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(file.fileId)}
+                onChange={() => toggleSelected(file.fileId)}
+                className="accent-sky-500"
+              />
+              {file.fileExtension === 'url' ? (
+                <Link size={16} className="shrink-0 text-black/50 dark:text-white/50" />
+              ) : (
+                <File size={16} className="shrink-0 text-black/50 dark:text-white/50" />
+              )}
+              <div className="flex flex-col min-w-0 flex-1">
+                <p className="text-sm text-black dark:text-white truncate">
+                  {file.fileName}
+                </p>
+                <p className="text-xs text-black/50 dark:text-white/50">
+                  {file.fileExtension.toUpperCase()} · {formatBytes(file.sizeBytes)}
+                  {formatDate(file.createdAt)
+                    ? ` · ${formatDate(file.createdAt)}`
+                    : ''}
+                </p>
+              </div>
+              <button
+                onClick={() => deleteFiles([file.fileId])}
+                disabled={deleting}
+                className="text-black/40 dark:text-white/40 hover:text-red-500 dark:hover:text-red-500 transition duration-200"
+                title="Delete file"
+              >
+                <Trash2 size={15} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Uploads;

--- a/apps/qwksearch-web/components/Settings/SettingsContent.tsx
+++ b/apps/qwksearch-web/components/Settings/SettingsContent.tsx
@@ -12,6 +12,7 @@ import {
   UserCircle,
   HardDrive,
   Wand2,
+  FileUp,
 } from 'lucide-react';
 import Preferences from './Sections/Preferences';
 import Account from './Sections/Account';
@@ -32,6 +33,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import Storage from './Sections/Storage';
+import Uploads from './Sections/Uploads';
 import RewritePrompts from './Sections/RewritePrompts';
 import FileSources from './Sections/FileSources';
 import AIRewriteModes from './Sections/AIRewriteModes';
@@ -84,6 +86,14 @@ const sections = [
     icon: Search,
     component: SearchEngines,
     dataAdd: 'searchEngines',
+  },
+  {
+    key: 'uploads',
+    name: 'Uploads',
+    description: 'Manage uploaded files and storage usage.',
+    icon: FileUp,
+    component: Uploads,
+    dataAdd: 'uploads',
   },
   {
     key: 'fileSources',

--- a/apps/qwksearch-web/drizzle/0003_brown_tarantula.sql
+++ b/apps/qwksearch-web/drizzle/0003_brown_tarantula.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `uploads` (
+	`fileId` text PRIMARY KEY NOT NULL,
+	`userId` text,
+	`fileName` text NOT NULL,
+	`fileExtension` text NOT NULL,
+	`size` integer DEFAULT 0 NOT NULL,
+	`createdAt` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_uploads_userId` ON `uploads` (`userId`);--> statement-breakpoint
+ALTER TABLE `user` ADD `storage_used_bytes` integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE `user` ADD `storage_quota_bytes` integer DEFAULT 1073741824;

--- a/apps/qwksearch-web/drizzle/meta/0003_snapshot.json
+++ b/apps/qwksearch-web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1308 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9e227009-bf67-4190-99bd-92e9c10b51c8",
+  "prevId": "c2ea0e2b-2edb-41bf-adac-9fed2476966b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articleCache": {
+      "name": "articleCache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cite": {
+          "name": "cite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_cite": {
+          "name": "author_cite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_short": {
+          "name": "author_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followUpQuestions": {
+          "name": "followUpQuestions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "hitCount": {
+          "name": "hitCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastAccessed": {
+          "name": "lastAccessed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articleCache_url_unique": {
+          "name": "articleCache_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articleQA": {
+      "name": "articleQA",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "articleUrl": {
+          "name": "articleUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articleQA_articleUrl_articleCache_url_fk": {
+          "name": "articleQA_articleUrl_articleCache_url_fk",
+          "tableFrom": "articleQA",
+          "tableTo": "articleCache",
+          "columnsFrom": [
+            "articleUrl"
+          ],
+          "columnsTo": [
+            "url"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "focusMode": {
+          "name": "focusMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "thinkingTimeLimit": {
+          "name": "thinkingTimeLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isExpanded": {
+          "name": "isExpanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "isFolder": {
+          "name": "isFolder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cite": {
+          "name": "cite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sharing": {
+          "name": "sharing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_documents_parentId": {
+          "name": "idx_documents_parentId",
+          "columns": [
+            "parentId"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_userId": {
+          "name": "idx_documents_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_createdAt": {
+          "name": "idx_documents_createdAt",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_parentId_documents_id_fk": {
+          "name": "documents_parentId_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cite": {
+          "name": "cite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_cite": {
+          "name": "author_cite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_userId_user_id_fk": {
+          "name": "favorites_userId_user_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "google_docs_sync": {
+      "name": "google_docs_sync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "googleDocId": {
+          "name": "googleDocId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_google_docs_sync_documentId": {
+          "name": "idx_google_docs_sync_documentId",
+          "columns": [
+            "documentId"
+          ],
+          "isUnique": false
+        },
+        "idx_google_docs_sync_googleDocId": {
+          "name": "idx_google_docs_sync_googleDocId",
+          "columns": [
+            "googleDocId"
+          ],
+          "isUnique": false
+        },
+        "google_docs_sync_documentId_googleDocId_unique": {
+          "name": "google_docs_sync_documentId_googleDocId_unique",
+          "columns": [
+            "documentId",
+            "googleDocId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "google_docs_sync_documentId_documents_id_fk": {
+          "name": "google_docs_sync_documentId_documents_id_fk",
+          "tableFrom": "google_docs_sync",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "documentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sources": {
+          "name": "sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "research_quotes": {
+      "name": "research_quotes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pageNumber": {
+          "name": "pageNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_research_quotes_documentId": {
+          "name": "idx_research_quotes_documentId",
+          "columns": [
+            "documentId"
+          ],
+          "isUnique": false
+        },
+        "idx_research_quotes_tags": {
+          "name": "idx_research_quotes_tags",
+          "columns": [
+            "tags"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "research_quotes_documentId_documents_id_fk": {
+          "name": "research_quotes_documentId_documents_id_fk",
+          "tableFrom": "research_quotes",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "documentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_tokens": {
+      "name": "share_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_tokens_documentId": {
+          "name": "idx_share_tokens_documentId",
+          "columns": [
+            "documentId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "share_tokens_documentId_documents_id_fk": {
+          "name": "share_tokens_documentId_documents_id_fk",
+          "tableFrom": "share_tokens",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "documentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fileExtension": {
+          "name": "fileExtension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_uploads_userId": {
+          "name": "idx_uploads_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trial_allowed": {
+          "name": "trial_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_used_bytes": {
+          "name": "storage_used_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_quota_bytes": {
+          "name": "storage_quota_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1073741824
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/qwksearch-web/drizzle/meta/_journal.json
+++ b/apps/qwksearch-web/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783398639834,
       "tag": "0002_charming_vulcan",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1784184684955,
+      "tag": "0003_brown_tarantula",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -14,6 +14,7 @@ import { safeValidateBody } from "./schemas";
 import type { Body } from "./schemas";
 import { handleEmitterEvents } from "./stream-handler";
 import { handleHistorySave } from "./history";
+import { ensureUploadFileLoaderRegistered } from "./upload-file-loader";
 
 /**
  * Converts a raw conversation history array into AI SDK chat messages.
@@ -114,6 +115,10 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
   const t0 = Date.now();
   console.log("[POST /api/agent/chat] request received");
   try {
+    // Let the search pipeline resolve uploaded fileIds to extracted content
+    // stored in R2 (instead of the local filesystem).
+    ensureUploadFileLoaderRegistered();
+
     // getUserId validates the session's user row against the current database
     // (stale KV sessions are revoked and reported as guest), so a non-null
     // userId here is always safe for FK-bound writes.

--- a/apps/qwksearch-web/lib/chat/index.ts
+++ b/apps/qwksearch-web/lib/chat/index.ts
@@ -32,6 +32,8 @@ export {
 
 export { handleEmitterEvents } from "./stream-handler";
 
+export { ensureUploadFileLoaderRegistered } from "./upload-file-loader";
+
 export { handleHistorySave } from "./history";
 
 export { handleChatRequest } from "./handler";

--- a/apps/qwksearch-web/lib/chat/upload-file-loader.ts
+++ b/apps/qwksearch-web/lib/chat/upload-file-loader.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Registers the upload file loader with the search pipeline.
+ *
+ * When a chat message references uploaded fileIds, the search pipeline's
+ * reranker resolves them to extracted content through this loader, which
+ * reads the `<fileId>-extracted.json` objects from R2 (native Workers
+ * binding, with S3-compatible API fallback) instead of the local
+ * filesystem.
+ */
+
+import { registerUploadFileLoader } from "extract-webpage/search";
+import { getExtractedUpload } from "@/lib/uploads";
+
+let registered = false;
+
+/**
+ * Registers the R2-backed upload loader with the search pipeline.
+ * Safe to call on every request; registration only happens once.
+ */
+export function ensureUploadFileLoaderRegistered(): void {
+  if (registered) return;
+  registered = true;
+
+  registerUploadFileLoader(async (fileId: string) => {
+    const extracted = await getExtractedUpload(fileId);
+    if (!extracted) return null;
+    return { title: extracted.title, content: extracted.content };
+  });
+}

--- a/apps/qwksearch-web/lib/database/schema.ts
+++ b/apps/qwksearch-web/lib/database/schema.ts
@@ -299,5 +299,28 @@ export const shareTokens = sqliteTable(
   },
 );
 
+export const uploads = sqliteTable(
+  "uploads",
+  {
+    fileId: text("fileId").primaryKey(),
+    userId: text("userId"),
+    fileName: text("fileName").notNull(),
+    fileExtension: text("fileExtension").notNull(),
+    size: integer("size").notNull().default(0),
+    createdAt: integer("createdAt", {
+      mode: "timestamp",
+    })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => {
+    return {
+      userIdIdx: index("idx_uploads_userId").on(table.userId),
+    };
+  },
+);
+
+export type Upload = typeof uploads.$inferSelect;
+
 // Export Document type from documents table
 export type Document = typeof documents.$inferSelect;

--- a/apps/qwksearch-web/lib/uploads/index.ts
+++ b/apps/qwksearch-web/lib/uploads/index.ts
@@ -1,0 +1,384 @@
+/**
+ * @fileoverview Centralized upload management for user-attached documents.
+ *
+ * Provides three groups of helpers used by the `/api/doc/uploads` endpoint,
+ * the settings UI, and the chat search pipeline:
+ *
+ * - **R2 storage access** — reads/writes/deletes objects in the uploads
+ *   bucket using the native Workers `R2` binding when available, falling
+ *   back to the S3-compatible API (via `manage-storage`) when running
+ *   outside the Workers runtime with `R2_*` credentials configured.
+ * - **Text extraction** — converts uploaded PDF, DOCX, TXT, MD, and HTML
+ *   files into plain text/HTML suitable for LLM context.
+ * - **Quota accounting** — tracks per-user upload records in the D1
+ *   `uploads` table and enforces the per-user storage quota.
+ *
+ * Object key layout in the bucket:
+ * - `<fileId>.<ext>` — the original uploaded file
+ * - `<fileId>-extracted.json` — `{ title, content, url? }` extracted text
+ */
+
+import { getCloudflareContext } from "@/lib/cloudflare-context";
+import { getDB } from "@/lib/database";
+import { uploads as uploadsTable, type Upload } from "@/lib/database/schema";
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+/** Maximum size of a single uploaded file (50 MB). */
+export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+/** Maximum number of files accepted in a single upload request. */
+export const MAX_FILES_PER_REQUEST = 10;
+
+/** Per-user storage quota across all uploads (1 GB). */
+export const USER_STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024;
+
+/** File extensions accepted for upload and text extraction. */
+export const SUPPORTED_UPLOAD_EXTENSIONS = [
+  "pdf",
+  "docx",
+  "txt",
+  "md",
+  "html",
+  "htm",
+] as const;
+
+/** Extension recorded for context files created from an extracted URL. */
+export const URL_UPLOAD_EXTENSION = "url";
+
+/** R2 object key of the original uploaded file. */
+export const originalObjectKey = (fileId: string, fileExtension: string) =>
+  `${fileId}.${fileExtension}`;
+
+/** R2 object key of the extracted `{ title, content }` JSON for a file. */
+export const extractedObjectKey = (fileId: string) =>
+  `${fileId}-extracted.json`;
+
+/** Extracted text payload stored alongside each upload. */
+export interface ExtractedUpload {
+  title: string;
+  content: string;
+  /** Set when the upload was created by extracting a typed-in URL. */
+  url?: string;
+}
+
+/** Per-user storage usage snapshot. */
+export interface UploadQuota {
+  /** Whether the additional bytes being checked still fit in the quota. */
+  allowed: boolean;
+  used: number;
+  quota: number;
+  remaining: number;
+}
+
+// ---------------------------------------------------------------------------
+// R2 storage access
+// ---------------------------------------------------------------------------
+
+function getR2Binding(): any | null {
+  try {
+    const { env } = getCloudflareContext();
+    if (env.R2 && typeof env.R2.put === "function") {
+      return env.R2;
+    }
+  } catch {
+    // Workers runtime unavailable (local dev) — fall through to S3 API.
+  }
+  return null;
+}
+
+function getS3Config() {
+  const accountId = process.env.R2_ACCOUNT_ID;
+  if (!accountId) return null;
+  return {
+    provider: "cloudflare" as const,
+    BUCKET_NAME: process.env.R2_UPLOADS_BUCKET || "qwksearch-uploads",
+    ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID || "",
+    SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY || "",
+    BUCKET_URL: `https://${accountId}.r2.cloudflarestorage.com`,
+  };
+}
+
+/**
+ * Writes an object to the uploads bucket via the native R2 binding, or the
+ * S3-compatible API when the binding is unavailable.
+ */
+export async function putUploadObject(
+  key: string,
+  body: Buffer | string,
+): Promise<void> {
+  const r2 = getR2Binding();
+  if (r2) {
+    await r2.put(key, body);
+    return;
+  }
+
+  const s3 = getS3Config();
+  if (!s3) {
+    throw new Error(
+      "R2 storage unavailable: no R2 binding and no R2_ACCOUNT_ID credentials",
+    );
+  }
+  const { manageStorage } = await import("manage-storage");
+  await manageStorage("upload", { ...s3, key, body });
+}
+
+/**
+ * Reads an object from the uploads bucket as text.
+ * Returns `null` when the object does not exist.
+ */
+export async function getUploadObjectText(key: string): Promise<string | null> {
+  const r2 = getR2Binding();
+  if (r2) {
+    const obj = await r2.get(key);
+    if (!obj) return null;
+    return await obj.text();
+  }
+
+  const s3 = getS3Config();
+  if (!s3) {
+    throw new Error(
+      "R2 storage unavailable: no R2 binding and no R2_ACCOUNT_ID credentials",
+    );
+  }
+  try {
+    const { manageStorage } = await import("manage-storage");
+    return await manageStorage("download", { ...s3, key });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deletes an object from the uploads bucket. Missing objects are ignored.
+ */
+export async function deleteUploadObject(key: string): Promise<void> {
+  const r2 = getR2Binding();
+  if (r2) {
+    await r2.delete(key);
+    return;
+  }
+
+  const s3 = getS3Config();
+  if (!s3) {
+    throw new Error(
+      "R2 storage unavailable: no R2 binding and no R2_ACCOUNT_ID credentials",
+    );
+  }
+  try {
+    const { manageStorage } = await import("manage-storage");
+    await manageStorage("delete", { ...s3, key });
+  } catch {
+    // Object already gone — deletion is idempotent.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Text extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts text/HTML content from an uploaded file buffer based on its
+ * extension. Returns an empty string when extraction fails so uploads can
+ * still be stored and listed.
+ */
+export async function extractUploadText(
+  buffer: Buffer,
+  fileName: string,
+  fileExtension: string,
+): Promise<string> {
+  try {
+    if (fileExtension === "pdf") {
+      const { convertPDFToHTML } = await import("extract-pdf");
+      const pdfResult = await convertPDFToHTML(buffer, { addCitation: true });
+      if (!pdfResult.error) {
+        return pdfResult.html || "";
+      }
+      return "";
+    }
+
+    if (fileExtension === "docx") {
+      const { convertDOCXToHTML } = await import("extract-webpage");
+      return (await convertDOCXToHTML(buffer)) || "";
+    }
+
+    if (fileExtension === "html" || fileExtension === "htm") {
+      const { extractContent } = await import("extract-webpage");
+      const html = buffer.toString("utf-8");
+      const article = await extractContent(html, { url: "" });
+      if (article && !article.error && article.html) {
+        return article.html;
+      }
+      return html;
+    }
+
+    // txt, md — already plain text.
+    return buffer.toString("utf-8");
+  } catch (error) {
+    console.error(
+      `[extractUploadText] Extraction failed for ${fileName}:`,
+      error,
+    );
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quota accounting (D1 `uploads` table)
+// ---------------------------------------------------------------------------
+
+/** Lists a user's uploads, most recent first. */
+export async function getUserUploads(userId: string): Promise<Upload[]> {
+  const db = getDB();
+  return await db
+    .select()
+    .from(uploadsTable)
+    .where(eq(uploadsTable.userId, userId))
+    .orderBy(desc(uploadsTable.createdAt));
+}
+
+/** Returns the user's current storage usage against the quota. */
+export async function getUserUploadQuota(
+  userId: string,
+  additionalBytes = 0,
+): Promise<UploadQuota> {
+  try {
+    const rows = await getUserUploads(userId);
+    const used = rows.reduce((sum, row) => sum + (row.size || 0), 0);
+    const remaining = Math.max(0, USER_STORAGE_QUOTA_BYTES - used);
+    return {
+      allowed: additionalBytes <= remaining,
+      used,
+      quota: USER_STORAGE_QUOTA_BYTES,
+      remaining,
+    };
+  } catch (error) {
+    console.error("[getUserUploadQuota] Error:", error);
+    return {
+      allowed: false,
+      used: 0,
+      quota: USER_STORAGE_QUOTA_BYTES,
+      remaining: 0,
+    };
+  }
+}
+
+/** Inserts an upload record for quota accounting and chat history metadata. */
+export async function recordUpload(record: {
+  fileId: string;
+  userId: string;
+  fileName: string;
+  fileExtension: string;
+  size: number;
+}): Promise<void> {
+  const db = getDB();
+  await db.insert(uploadsTable).values({
+    ...record,
+    createdAt: new Date(),
+  });
+}
+
+/**
+ * Deletes upload records owned by `userId` and returns the deleted rows so
+ * callers can clean up the corresponding R2 objects. Pass `fileIds` to
+ * delete a subset, or omit it to delete all of the user's records.
+ */
+export async function deleteUploadRecords(
+  userId: string,
+  fileIds?: string[],
+): Promise<Upload[]> {
+  const db = getDB();
+  const where =
+    fileIds && fileIds.length > 0
+      ? and(eq(uploadsTable.userId, userId), inArray(uploadsTable.fileId, fileIds))
+      : eq(uploadsTable.userId, userId);
+
+  const rows = await db.select().from(uploadsTable).where(where);
+  if (rows.length > 0) {
+    await db.delete(uploadsTable).where(where);
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// High-level operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Stores an upload: writes the original file (when provided) and the
+ * extracted JSON to R2, and records the upload in D1 for authenticated
+ * users.
+ */
+export async function storeUpload(options: {
+  fileId: string;
+  fileName: string;
+  fileExtension: string;
+  size: number;
+  userId: string | null;
+  originalBuffer?: Buffer;
+  extracted: ExtractedUpload;
+}): Promise<void> {
+  const { fileId, fileName, fileExtension, size, userId, originalBuffer, extracted } =
+    options;
+
+  if (originalBuffer) {
+    await putUploadObject(originalObjectKey(fileId, fileExtension), originalBuffer);
+  }
+  await putUploadObject(extractedObjectKey(fileId), JSON.stringify(extracted));
+
+  if (userId) {
+    try {
+      await recordUpload({ fileId, userId, fileName, fileExtension, size });
+    } catch (error) {
+      // Quota accounting is best-effort for resilience; the file itself is
+      // already stored and usable.
+      console.error(`[storeUpload] Failed to record upload ${fileId}:`, error);
+    }
+  }
+}
+
+/**
+ * Fetches the extracted `{ title, content }` JSON for an uploaded file.
+ * Returns `null` when the file does not exist or the payload is invalid.
+ */
+export async function getExtractedUpload(
+  fileId: string,
+): Promise<ExtractedUpload | null> {
+  try {
+    const raw = await getUploadObjectText(extractedObjectKey(fileId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return {
+      title: parsed.title || "Uploaded Document",
+      content: parsed.content || "",
+      ...(parsed.url ? { url: parsed.url } : {}),
+    };
+  } catch (error) {
+    console.error(`[getExtractedUpload] Failed for ${fileId}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Deletes an upload's R2 objects (original + extracted JSON). When the file
+ * extension is unknown, tries all supported extensions.
+ */
+export async function deleteUploadObjects(
+  fileId: string,
+  fileExtension?: string | null,
+): Promise<void> {
+  await deleteUploadObject(extractedObjectKey(fileId));
+
+  if (fileExtension && fileExtension !== URL_UPLOAD_EXTENSION) {
+    await deleteUploadObject(originalObjectKey(fileId, fileExtension));
+    return;
+  }
+  if (fileExtension === URL_UPLOAD_EXTENSION) {
+    // URL extractions store no original object.
+    return;
+  }
+  await Promise.all(
+    SUPPORTED_UPLOAD_EXTENSIONS.map((ext) =>
+      deleteUploadObject(originalObjectKey(fileId, ext)),
+    ),
+  );
+}

--- a/packages/agent-toolkit/src/tools/search/doc-utils.ts
+++ b/packages/agent-toolkit/src/tools/search/doc-utils.ts
@@ -36,6 +36,26 @@ export function normalizeSourcesOutput(output: unknown, query: string): Document
   return buildFallbackDocs(query);
 }
 
+/**
+ * Resolves an uploaded fileId to its extracted `{ title, content }` payload.
+ * Hosts register a loader (e.g. reading the native R2 binding) so the search
+ * pipeline does not depend on filesystem or credential-based access.
+ */
+export type UploadFileLoader = (
+  fileId: string,
+) => Promise<{ title: string; content: string } | null>;
+
+let uploadFileLoader: UploadFileLoader | null = null;
+
+/**
+ * Registers the loader used by {@link rerankDocs} to resolve uploaded
+ * fileIds to extracted content. The registered loader takes precedence over
+ * the S3-credentials fallback.
+ */
+export function registerUploadFileLoader(loader: UploadFileLoader): void {
+  uploadFileLoader = loader;
+}
+
 async function downloadExtractedContent(fileId: string, r2Credentials: R2CredentialsInput): Promise<{ title: string; content: string } | null> {
   try {
     const { manageStorage } = await import("manage-storage");
@@ -69,9 +89,25 @@ export async function rerankDocs(
 
   let filesData: { title: string; content: string }[] = [];
 
-  if (fileIds.length > 0 && r2Credentials) {
+  if (fileIds.length > 0) {
     const results = await Promise.all(
-      fileIds.map((fileId) => downloadExtractedContent(fileId, r2Credentials))
+      fileIds.map(async (fileId) => {
+        if (uploadFileLoader) {
+          try {
+            const loaded = await uploadFileLoader(fileId);
+            if (loaded) return loaded;
+          } catch (error) {
+            console.error(
+              `[rerankDocs] Registered upload loader failed for fileId ${fileId}:`,
+              error,
+            );
+          }
+        }
+        if (r2Credentials) {
+          return downloadExtractedContent(fileId, r2Credentials);
+        }
+        return null;
+      }),
     );
     filesData = results.filter((r) => r !== null);
   }

--- a/packages/agent-toolkit/src/tools/search/index.ts
+++ b/packages/agent-toolkit/src/tools/search/index.ts
@@ -10,4 +10,5 @@ export { default as generateSuggestions } from "./suggestionGeneratorAgent";
 export { groupAndSummarizeDocs } from "./link-summarizer";
 export type { Document } from "./document";
 export { splitTextIntoChunks } from "./document";
-export { buildFallbackDocs, rerankDocs, processDocs, normalizeSourcesOutput } from "./doc-utils";
+export { buildFallbackDocs, rerankDocs, processDocs, normalizeSourcesOutput, registerUploadFileLoader } from "./doc-utils";
+export type { UploadFileLoader } from "./doc-utils";

--- a/packages/extract-webpage/src/search/index.ts
+++ b/packages/extract-webpage/src/search/index.ts
@@ -27,6 +27,7 @@ export {
   rerankDocs,
   processDocs,
   normalizeSourcesOutput,
+  registerUploadFileLoader,
   splitTextIntoChunks,
   LineOutputParser,
   LineListOutputParser,
@@ -34,6 +35,7 @@ export {
 } from "chat-agent-toolkit";
 
 export type {
+  UploadFileLoader,
   MetaSearchAgentType,
   Config,
   ChatTurnMessage,

--- a/packages/research-agent-ui/src/components/FileUpload/CompactFileAttachmentButton.tsx
+++ b/packages/research-agent-ui/src/components/FileUpload/CompactFileAttachmentButton.tsx
@@ -20,6 +20,7 @@ import { useRef, useState } from 'react';
 import { File as FileType } from '../ChatConversation/ChatWindow';
 import { useChat } from '../../hooks/useChat';
 import grab from 'grab-url';
+import { toast } from 'sonner';
 
 const AttachSmall = () => {
   const { files, setFiles, setFileIds, fileIds } = useChat();
@@ -35,14 +36,30 @@ const AttachSmall = () => {
       data.append('files', e.target.files![i]);
     }
 
-    const resData = await grab(`doc/uploads`, {
-      method: 'POST',
-      body: data,
-    });
+    try {
+      const resData = await grab(`doc/uploads`, {
+        method: 'POST',
+        body: data,
+      });
 
-    setFiles([...files, ...resData.files]);
-    setFileIds([...fileIds, ...resData.files.map((file: any) => file.fileId)]);
-    setLoading(false);
+      if (!resData?.files) {
+        throw new Error(resData?.message ?? 'Upload failed.');
+      }
+
+      setFiles([...files, ...resData.files]);
+      setFileIds([
+        ...fileIds,
+        ...resData.files.map((file: any) => file.fileId),
+      ]);
+    } catch (error) {
+      toast.error(
+        error instanceof Error && error.message
+          ? error.message
+          : 'Failed to upload files. Please try again.',
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   return loading ? (
@@ -73,7 +90,7 @@ const AttachSmall = () => {
                   type="file"
                   onChange={handleChange}
                   ref={fileInputRef}
-                  accept=".pdf,.docx,.txt"
+                  accept=".pdf,.docx,.txt,.md,.html,.htm"
                   multiple
                   hidden
                 />
@@ -128,7 +145,7 @@ const AttachSmall = () => {
         type="file"
         onChange={handleChange}
         ref={fileInputRef}
-        accept=".pdf,.docx,.txt"
+        accept=".pdf,.docx,.txt,.md,.html,.htm"
         multiple
         hidden
       />

--- a/packages/research-agent-ui/src/components/FileUpload/FileAttachmentButton.tsx
+++ b/packages/research-agent-ui/src/components/FileUpload/FileAttachmentButton.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import { useChat } from '../../hooks/useChat';
 import grab from 'grab-url';
+import { toast } from 'sonner';
 
 const Attach = () => {
   const { files, setFiles, setFileIds, fileIds } = useChat();
@@ -35,14 +36,30 @@ const Attach = () => {
       data.append('files', e.target.files![i]);
     }
 
-    const resData = await grab(`doc/uploads`, {
-      method: 'POST',
-      body: data,
-    });
+    try {
+      const resData = await grab(`doc/uploads`, {
+        method: 'POST',
+        body: data,
+      });
 
-    setFiles([...files, ...resData.files]);
-    setFileIds([...fileIds, ...resData.files.map((file: any) => file.fileId)]);
-    setLoading(false);
+      if (!resData?.files) {
+        throw new Error(resData?.message ?? 'Upload failed.');
+      }
+
+      setFiles([...files, ...resData.files]);
+      setFileIds([
+        ...fileIds,
+        ...resData.files.map((file: any) => file.fileId),
+      ]);
+    } catch (error) {
+      toast.error(
+        error instanceof Error && error.message
+          ? error.message
+          : 'Failed to upload files. Please try again.',
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   return loading ? (
@@ -73,7 +90,7 @@ const Attach = () => {
                   type="file"
                   onChange={handleChange}
                   ref={fileInputRef}
-                  accept=".pdf,.docx,.txt"
+                  accept=".pdf,.docx,.txt,.md,.html,.htm"
                   multiple
                   hidden
                 />
@@ -130,7 +147,7 @@ const Attach = () => {
         type="file"
         onChange={handleChange}
         ref={fileInputRef}
-        accept=".pdf,.docx,.txt"
+        accept=".pdf,.docx,.txt,.md,.html,.htm"
         multiple
         hidden
       />

--- a/packages/research-agent-ui/src/components/FileUpload/FileUploadDropdown.tsx
+++ b/packages/research-agent-ui/src/components/FileUpload/FileUploadDropdown.tsx
@@ -43,9 +43,9 @@ const THINKING_OPTIONS = [
   { label: 'Unlimited', value: 0 },
 ];
 
-const SUPPORTED_EXTS = ['pdf', 'docx', 'txt', 'html', 'htm'];
+const SUPPORTED_EXTS = ['pdf', 'docx', 'txt', 'md', 'html', 'htm'];
 const TEXT_EXTS = [
-  'md', 'markdown', 'js', 'jsx', 'ts', 'tsx', 'py', 'rb', 'go', 'rs',
+  'markdown', 'js', 'jsx', 'ts', 'tsx', 'py', 'rb', 'go', 'rs',
   'java', 'c', 'cpp', 'h', 'hpp', 'cs', 'swift', 'kt', 'sh', 'bash',
   'zsh', 'json', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf', 'xml',
   'csv', 'tsv', 'log', 'env', 'sql', 'graphql', 'vue', 'svelte', 'astro',
@@ -113,6 +113,7 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
                 'application/pdf': ['.pdf'],
                 'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
                 'text/plain': ['.txt'],
+                'text/markdown': ['.md'],
                 'text/html': ['.html', '.htm'],
                 'image/*': ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg'],
               },

--- a/packages/research-agent-ui/src/components/FileUpload/useFileHandling.ts
+++ b/packages/research-agent-ui/src/components/FileUpload/useFileHandling.ts
@@ -1,14 +1,20 @@
 /**
- * Hook managing file attachment state: uploads supported document types (PDF, DOCX, TXT, HTML) to the server,
- * handles drag-and-drop events, and converts large clipboard pastes into PastedContent cards.
+ * Hook managing file attachment state: uploads supported document types (PDF, DOCX, TXT, MD, HTML) to the server,
+ * extracts typed-in URLs as attachable context, handles drag-and-drop events, validates file count/size limits,
+ * and converts large clipboard pastes into PastedContent cards.
  */
 import { useState, useCallback } from "react";
 import React from "react";
+import { toast } from "sonner";
 import { AttachedFile, PastedContent } from "../../types/research";
 import type { ChatFile } from "../../types/chat";
 import grab from "grab-url";
 
-const SUPPORTED_EXTS = ["pdf", "docx", "txt", "html", "htm"];
+const SUPPORTED_EXTS = ["pdf", "docx", "txt", "md", "html", "htm"];
+
+/** Server-enforced limits, mirrored client-side for immediate feedback. */
+const MAX_FILES_PER_REQUEST = 10;
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 
 interface UseFileHandlingOptions {
   setMessage: React.Dispatch<React.SetStateAction<string>>;
@@ -17,6 +23,17 @@ interface UseFileHandlingOptions {
   setContextFiles: (files: ChatFile[]) => void;
   setContextFileIds: (ids: string[]) => void;
 }
+
+/** Extracts a human-readable message from a failed upload response. */
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (error && typeof error === "object") {
+    const message =
+      (error as any).message ?? (error as any).error ?? (error as any).data?.message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  if (typeof error === "string" && error.length > 0) return error;
+  return fallback;
+};
 
 export function useFileHandling({
   setMessage,
@@ -28,10 +45,29 @@ export function useFileHandling({
   const [files, setFiles] = useState<AttachedFile[]>([]);
   const [pastedContent, setPastedContent] = useState<PastedContent[]>([]);
   const [isDragging, setIsDragging] = useState(false);
+  const [isExtractingUrl, setIsExtractingUrl] = useState(false);
 
   const handleFiles = useCallback(
     async (newFilesList: FileList | File[]) => {
-      const newFiles = Array.from(newFilesList).map((file) => {
+      let incoming = Array.from(newFilesList);
+
+      // Client-side validation mirroring the server's limits.
+      if (incoming.length > MAX_FILES_PER_REQUEST) {
+        toast.error(
+          `You can attach up to ${MAX_FILES_PER_REQUEST} files at a time.`,
+        );
+        incoming = incoming.slice(0, MAX_FILES_PER_REQUEST);
+      }
+      const oversized = incoming.filter((f) => f.size > MAX_FILE_SIZE_BYTES);
+      if (oversized.length > 0) {
+        toast.error(
+          `${oversized.map((f) => f.name).join(", ")} exceed${oversized.length === 1 ? "s" : ""} the 50 MB per-file limit.`,
+        );
+        incoming = incoming.filter((f) => f.size <= MAX_FILE_SIZE_BYTES);
+      }
+      if (incoming.length === 0) return;
+
+      const newFiles = incoming.map((file) => {
         const isImage =
           file.type.startsWith("image/") ||
           /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(file.name);
@@ -78,10 +114,17 @@ export function useFileHandling({
         const formData = new FormData();
         uploadable.forEach((f) => formData.append("files", f.file));
 
-        const data: { files: ChatFile[] } = await grab("/api/doc/uploads", {
-          method: "POST",
-          body: formData,
-        });
+        const data: { files?: ChatFile[]; message?: string } = await grab(
+          "/api/doc/uploads",
+          {
+            method: "POST",
+            body: formData,
+          },
+        );
+
+        if (!data?.files) {
+          throw new Error(getErrorMessage(data, "Upload failed."));
+        }
 
         setFiles((prev) =>
           prev.map((p) =>
@@ -96,7 +139,8 @@ export function useFileHandling({
           ...contextFileIds,
           ...data.files.map((f) => f.fileId),
         ]);
-      } catch {
+      } catch (error) {
+        toast.error(getErrorMessage(error, "Failed to upload files."));
         setFiles((prev) =>
           prev.map((p) =>
             uploadable.some((u) => u.id === p.id)
@@ -113,6 +157,52 @@ export function useFileHandling({
       setContextFiles,
       setContextFileIds,
     ],
+  );
+
+  /**
+   * Extracts a typed-in URL server-side (via extract-webpage) and attaches
+   * the resulting content as a context file.
+   */
+  const extractUrl = useCallback(
+    async (url: string): Promise<boolean> => {
+      const trimmed = url.trim();
+      if (!/^https?:\/\//i.test(trimmed)) {
+        toast.error("Enter a valid http(s) URL.");
+        return false;
+      }
+
+      setIsExtractingUrl(true);
+      try {
+        const data: { files?: ChatFile[]; message?: string } = await grab(
+          "/api/doc/uploads",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ url: trimmed }),
+          },
+        );
+
+        if (!data?.files || data.files.length === 0) {
+          throw new Error(
+            getErrorMessage(data, `Could not extract content from ${trimmed}`),
+          );
+        }
+
+        setContextFiles([...contextFiles, ...data.files]);
+        setContextFileIds([
+          ...contextFileIds,
+          ...data.files.map((f) => f.fileId),
+        ]);
+        toast.success(`Added "${data.files[0].fileName}" as context.`);
+        return true;
+      } catch (error) {
+        toast.error(getErrorMessage(error, "Failed to extract URL."));
+        return false;
+      } finally {
+        setIsExtractingUrl(false);
+      }
+    },
+    [contextFiles, contextFileIds, setContextFiles, setContextFileIds],
   );
 
   const onDragOver = (e: React.DragEvent) => {
@@ -170,7 +260,9 @@ export function useFileHandling({
     pastedContent,
     setPastedContent,
     isDragging,
+    isExtractingUrl,
     handleFiles,
+    extractUrl,
     onDragOver,
     onDragLeave,
     onDrop,


### PR DESCRIPTION
## Summary
Implements a complete file upload system allowing authenticated users to attach documents (PDF, DOCX, TXT, MD, HTML) and URLs as context for chat searches. Files are stored in Cloudflare R2 with per-user quota enforcement, and extracted content is integrated into the search pipeline.

## Key Changes

### Upload Management Infrastructure
- **New `lib/uploads/index.ts`**: Centralized upload helpers providing:
  - R2 storage access (native Workers binding with S3-compatible API fallback)
  - Text extraction for PDF, DOCX, TXT, MD, and HTML files
  - Per-user quota tracking and enforcement (1 GB limit)
  - Upload record management in D1 database

- **Database schema**: Added `uploads` table to track user uploads with fileId, fileName, extension, size, and timestamps

- **Drizzle migrations**: Created migration `0003_brown_tarantula.sql` with uploads table and indexes

### API Endpoint Enhancements (`/api/doc/uploads`)
- **Multipart file uploads**: Validates file count (max 10), size (max 50 MB), and type; enforces per-user quota
- **URL extraction**: New JSON endpoint accepting `{ url }` or `{ urls }` to extract webpage content as attachable context files
- **Listing**: `GET` returns user's uploads with quota usage
- **Deletion**: Supports single, batch (comma-separated), or bulk (`?all=true`) deletion with proper cleanup

### Search Pipeline Integration
- **Upload file loader**: Registered loader in `lib/chat/upload-file-loader.ts` allows the search pipeline to resolve fileIds to extracted content from R2
- **Doc utilities**: Added `registerUploadFileLoader` export to `agent-toolkit` for pipeline integration

### UI Components
- **Settings section**: New `Uploads.tsx` component displays storage usage with progress bar, lists uploads with sizes and dates, supports individual/batch/bulk deletion
- **File attachment buttons**: Enhanced with error handling, toast notifications, and support for URL extraction
- **File handling hook**: Updated to support MD files, enforce client-side limits, and handle URL extraction with improved error messages

### Client-Side Validation
- Mirrored server limits (10 files, 50 MB each) for immediate feedback
- Enhanced error messages extracted from server responses
- Toast notifications for upload/deletion operations

## Implementation Details
- Objects stored in R2 with dual keys: `<fileId>.<ext>` (original) and `<fileId>-extracted.json>` (extracted content)
- Quota enforcement only applies to authenticated users; anonymous uploads allowed
- Extraction failures gracefully degrade to empty content so uploads still succeed
- S3-compatible API fallback enables local development without Workers runtime

https://claude.ai/code/session_01NH21Ma8CrHYWfnqcRDSqik