### PR TITLE
Fix import paths for search-extract-web-api package

### DIFF
--- a/apps/qwksearch-web/app/api/search/engines/route.ts
+++ b/apps/qwksearch-web/app/api/search/engines/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ALL_ENGINES } from "search-extract-web-api/src/search/search-engines-registry-list.js";
-import { CATEGORIES } from "search-extract-web-api/src/registry/search-engine-category-registry.js";
+import { ALL_ENGINES } from "search-extract-web-api/search/search-engines-registry-list.js";
+import { CATEGORIES } from "search-extract-web-api/registry/search-engine-category-registry.js";
 
 export const GET = async () => {
   try {

--- a/apps/qwksearch-web/app/api/search/engines/test/route.ts
+++ b/apps/qwksearch-web/app/api/search/engines/test/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Search } from "search-extract-web-api/src/search/search-query-executor.js";
+import { Search } from "search-extract-web-api/search/search-query-executor.js";
 
 export const POST = async (req: NextRequest) => {
   try {


### PR DESCRIPTION
## Summary
Updated import paths to remove `/src` directory references from the `search-extract-web-api` package imports, aligning with the package's export structure.

## Key Changes
- Updated import paths in `apps/qwksearch-web/app/api/search/engines/route.ts`:
  - `search-extract-web-api/src/search/search-engines-registry-list.js` → `search-extract-web-api/search/search-engines-registry-list.js`
  - `search-extract-web-api/src/registry/search-engine-category-registry.js` → `search-extract-web-api/registry/search-engine-category-registry.js`

- Updated import path in `apps/qwksearch-web/app/api/search/engines/test/route.ts`:
  - `search-extract-web-api/src/search/search-query-executor.js` → `search-extract-web-api/search/search-query-executor.js`

## Details
These changes correct the import paths to match the actual export structure of the `search-extract-web-api` package, removing the unnecessary `/src` directory prefix from all three import statements across two files.

https://claude.ai/code/session_019fHm8LhdiBC9hfAWmMupg1