### PR TITLE
Fix chat history save race condition and improve error logging

### DIFF
--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -297,9 +297,16 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       } catch (err) {
         // History persistence is best-effort: the answer stream is already
         // set up, so a failed save must not turn the request into a 500.
+        // Drizzle wraps the driver error; its message only echoes the query,
+        // so surface err.cause to see the actual D1/SQLite failure reason.
+        const cause =
+          err instanceof Error && err.cause instanceof Error
+            ? err.cause.message
+            : undefined;
         console.error(
           "[POST /api/agent/chat] handleHistorySave failed (continuing without history):",
           err,
+          ...(cause ? [`cause: ${cause}`] : []),
         );
       }
     }

--- a/apps/qwksearch-web/lib/chat/history.ts
+++ b/apps/qwksearch-web/lib/chat/history.ts
@@ -64,15 +64,30 @@ export const handleHistorySave = async (
   );
 
   /**
-   * Check whether the parent chat session already exists for this user.
-   * If not, create it using the first message's content as the title.
+   * Check whether the parent chat session already exists. The lookup is by
+   * id alone (not id + userId): chat ids are client-generated and travel in
+   * URLs, so the same id can be replayed by a different account. Filtering
+   * by userId here made that case invisible and the insert below then died
+   * on a `chats.id` primary-key conflict.
    */
   const chat = await db.query.chats.findFirst({
-    where: and(eq(chats.id, message.chatId), eq(chats.userId, userId)),
+    where: eq(chats.id, message.chatId),
   });
+
+  if (chat && chat.userId !== userId) {
+    // The chat id belongs to another account. Don't insert (PK conflict)
+    // and don't attach this user's messages to someone else's chat.
+    console.warn(
+      "[handleHistorySave] chatId belongs to another user; skipping history save:",
+      message.chatId,
+    );
+    return;
+  }
 
   if (!chat) {
     console.log("[handleHistorySave] Creating new chat:", message.chatId);
+    // onConflictDoNothing: concurrent requests for the same new chat can
+    // both pass the existence check; the second insert must not throw.
     await db
       .insert(chats)
       .values({
@@ -83,6 +98,7 @@ export const handleHistorySave = async (
         userId,
         thinkingTimeLimit,
       })
+      .onConflictDoNothing()
       .execute();
     console.log(
       "[handleHistorySave] Chat created successfully:",

--- a/packages/agent-toolkit/src/config/language-models-database.ts
+++ b/packages/agent-toolkit/src/config/language-models-database.ts
@@ -1347,13 +1347,6 @@ export const LANGUAGE_MODELS = [
       "type": "text"
     },
     {
-      "name": "Dolphin Mistral 24B Venice Edition",
-      "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-      "contextLength": 33_000,
-      "free": true,
-      "type": "text"
-    },
-    {
       "name": "LFM 2.5 1.2B Thinking",
       "id": "liquid/lfm-2.5-1.2b-thinking:free",
       "contextLength": 33_000,


### PR DESCRIPTION
## Summary
This PR fixes a critical race condition in chat history persistence where concurrent requests could cause primary key conflicts, and improves error visibility when history saves fail.

## Key Changes

- **Fixed chat ID lookup logic in `handleHistorySave`**: Changed from filtering by both `chatId` and `userId` to filtering by `chatId` alone, then explicitly checking if the chat belongs to a different user. This prevents the invisible case where a replayed chat ID from a different account would cause a silent PK conflict.

- **Added security check**: When a chat ID is found to belong to another user, the function now returns early with a warning log instead of attempting to insert, preventing cross-user message attachment.

- **Added `onConflictDoNothing()` to chat insert**: Handles the case where concurrent requests both pass the existence check and attempt to insert the same new chat simultaneously. The second insert will now silently succeed instead of throwing.

- **Improved error logging in `handleChatRequest`**: Enhanced error messages when history persistence fails by extracting and surfacing `err.cause` (the actual D1/SQLite error) in addition to the Drizzle wrapper error, making debugging easier.

- **Removed deprecated model**: Removed "Dolphin Mistral 24B Venice Edition" from the language models database.

## Implementation Details

The core issue was that client-generated chat IDs can be replayed across different user accounts (since they travel in URLs). The original code's `userId` filter made this case invisible—the lookup would return null, but then the insert would fail on a PK conflict. The fix makes this scenario explicit and safe by checking ownership after lookup and gracefully handling concurrent inserts.

https://claude.ai/code/session_011UaL2UuyJ8pzoFZqUzJf41