### PR TITLE
Improve error logging with error cause chain flattening

### DIFF
--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -5,6 +5,7 @@
 
 import crypto from "crypto";
 import type { ChatTurnMessage } from "extract-webpage/search";
+import { describeError } from "research-agent-ui/api";
 import { getDB } from "@/lib/database";
 import { searchHandlers } from "extract-webpage/search";
 import ModelRegistry from "chat-agent-toolkit/models/registry";
@@ -297,16 +298,9 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       } catch (err) {
         // History persistence is best-effort: the answer stream is already
         // set up, so a failed save must not turn the request into a 500.
-        // Drizzle wraps the driver error; its message only echoes the query,
-        // so surface err.cause to see the actual D1/SQLite failure reason.
-        const cause =
-          err instanceof Error && err.cause instanceof Error
-            ? err.cause.message
-            : undefined;
         console.error(
           "[POST /api/agent/chat] handleHistorySave failed (continuing without history):",
-          err,
-          ...(cause ? [`cause: ${cause}`] : []),
+          describeError(err),
         );
       }
     }

--- a/apps/qwksearch-web/lib/chat/stream-handler.ts
+++ b/apps/qwksearch-web/lib/chat/stream-handler.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import type { Document } from "extract-webpage/search/document";
 import { EventEmitter } from "stream";
+import { describeError } from "research-agent-ui/api";
 import { getDB } from "@/lib/database";
 import { messages as messagesSchema } from "@/lib/database/schema";
 
@@ -144,7 +145,7 @@ export const handleEmitterEvents = async (
           .catch((err) => {
             console.error(
               "[handleEmitterEvents] failed to save source message:",
-              err,
+              describeError(err),
             );
           });
       }
@@ -170,7 +171,7 @@ export const handleEmitterEvents = async (
         .catch((err) => {
           console.error(
             "[handleEmitterEvents] failed to save assistant message:",
-            err,
+            describeError(err),
           );
         });
     }

--- a/packages/research-agent-ui/src/api/handlers/messages.ts
+++ b/packages/research-agent-ui/src/api/handlers/messages.ts
@@ -1,5 +1,23 @@
 import type { MessagesDeps } from "../types";
 
+const VALID_ROLES = ["assistant", "user", "source", "suggestion"] as const;
+
+/**
+ * Flattens an error's `cause` chain into one string. Drizzle wraps driver
+ * errors (e.g. D1's "no such column" / constraint failures) in a generic
+ * "Failed query" error and puts the real one in `cause`, which structured
+ * log sinks drop unless serialized explicitly.
+ */
+export function describeError(err: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = err;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    parts.push(current instanceof Error ? current.message : String(current));
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return parts.join(" <- caused by: ");
+}
+
 export function createMessagesHandler(deps: MessagesDeps) {
   const POST = async (req: Request): Promise<Response> => {
     try {
@@ -12,6 +30,13 @@ export function createMessagesHandler(deps: MessagesDeps) {
       if (!chatId || !messageId || !role) {
         return Response.json(
           { message: "Missing required fields" },
+          { status: 400 },
+        );
+      }
+
+      if (!VALID_ROLES.includes(role)) {
+        return Response.json(
+          { message: `Invalid role: ${role}` },
           { status: 400 },
         );
       }
@@ -29,7 +54,7 @@ export function createMessagesHandler(deps: MessagesDeps) {
 
       return Response.json({ message: "Message saved successfully" }, { status: 200 });
     } catch (err) {
-      console.error("Error saving message:", err);
+      console.error("Error saving message:", describeError(err));
       return Response.json({ message: "Failed to save message" }, { status: 500 });
     }
   };


### PR DESCRIPTION
## Summary
This PR improves error diagnostics by extracting error cause chains into a reusable utility function and applying it consistently across the codebase. This addresses issues where database driver errors (particularly from Drizzle ORM wrapping D1/SQLite failures) were not being properly surfaced in logs.

## Key Changes
- **New utility function**: Added `describeError()` in `packages/research-agent-ui/src/api/handlers/messages.ts` that flattens error cause chains up to 5 levels deep, joining them with " <- caused by: " for better readability in logs
- **Input validation**: Added validation for the `role` field in message creation to ensure only valid roles ("assistant", "user", "source", "suggestion") are accepted
- **Consistent error logging**: Replaced manual error cause extraction logic in two files with calls to the new `describeError()` utility:
  - `apps/qwksearch-web/lib/chat/handler.ts`: Simplified history persistence error logging
  - `apps/qwksearch-web/lib/chat/stream-handler.ts`: Updated two error logging calls for message persistence

## Implementation Details
- The `describeError()` function safely handles non-Error objects and limits recursion depth to prevent infinite loops
- The function is exported from the research-agent-ui API package and imported where needed, promoting code reuse
- Error messages now properly surface underlying database constraint failures and driver-level errors that were previously hidden by Drizzle's generic "Failed query" wrapper

https://claude.ai/code/session_01EXTqtVL6TyWKqgWpTFHyL9