### PR TITLE
Refactor ModelRegistry mocking in config API tests

### DIFF
--- a/apps/qwksearch-web/app/api/config/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/config/__tests__/route.test.ts
@@ -9,7 +9,6 @@ vi.mock('next/server', () => ({
         headers: { 'Content-Type': 'application/json' },
         ...opts,
       })
-      response.status = status
       return response
     },
   },
@@ -36,12 +35,14 @@ vi.mock('@/lib/env', () => ({
 
 import configManager from '@/lib/config'
 import { getEnv } from '@/lib/env'
+import ModelRegistry from 'chat-agent-toolkit/models/registry'
 import { GET, POST } from '../route'
 
 const mockGetCurrentConfig = configManager.getCurrentConfig as ReturnType<typeof vi.fn>
 const mockGetUIConfigSections = configManager.getUIConfigSections as ReturnType<typeof vi.fn>
 const mockUpdateConfig = configManager.updateConfig as ReturnType<typeof vi.fn>
 const mockGetEnv = getEnv as ReturnType<typeof vi.fn>
+const mockModelRegistry = ModelRegistry as unknown as ReturnType<typeof vi.fn>
 
 const baseConfig = () => ({
   modelProviders: [],
@@ -53,6 +54,11 @@ beforeEach(() => {
   mockGetCurrentConfig.mockReturnValue(baseConfig())
   mockGetUIConfigSections.mockReturnValue([])
   mockGetEnv.mockReturnValue(undefined)
+  // restoreMocks (vitest config) wipes the factory implementation before each
+  // test, so re-establish the default ModelRegistry behavior here.
+  mockModelRegistry.mockImplementation(() => ({
+    getActiveProviders: vi.fn().mockResolvedValue([]),
+  }))
 })
 
 function makeRequest(method = 'GET', body?: unknown) {
@@ -77,8 +83,7 @@ describe('GET /api/config', () => {
       modelProviders: [{ id: 'openai', chatModels: [] }],
       search: { tavilyApiKey: '' },
     })
-    const { default: ModelRegistry } = await import('chat-agent-toolkit/models/registry')
-    ;(ModelRegistry as any).mockImplementation(() => ({
+    mockModelRegistry.mockImplementation(() => ({
       getActiveProviders: vi.fn().mockResolvedValue([
         { id: 'openai', chatModels: [{ key: 'gpt-4o' }] },
       ]),

--- a/apps/qwksearch-web/vitest.config.ts
+++ b/apps/qwksearch-web/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'grab-url': resolve(__dirname, './lib/api/grab.ts'),
       'domain-rank': resolve(__dirname, '../../packages/domain-rank'),
       'search-web-api': resolve(__dirname, '../../packages/search-web-api/src'),
+      'write-language': resolve(__dirname, '../../packages/write-language/src'),
       'chat-agent-toolkit/models/registry': resolve(__dirname, '../../packages/agent-toolkit/src/models/registry.ts'),
     },
   },


### PR DESCRIPTION
## Summary
Refactored the test setup for the config API route to improve mock management and reduce test-specific imports. The changes centralize ModelRegistry mocking in the beforeEach hook and add a new path alias for the write-language package.

## Key Changes
- Moved ModelRegistry mock initialization from individual tests to the `beforeEach` hook for consistent setup across all tests
- Removed dynamic import of ModelRegistry within test cases, using the centralized mock instead
- Removed unnecessary `response.status = status` assignment in the NextResponse mock (status is already set via constructor)
- Added `write-language` package path alias to vitest config
- Added explanatory comment documenting why mock restoration requires re-establishing default behavior in beforeEach

## Implementation Details
- The ModelRegistry mock is now established once in beforeEach with default behavior (`getActiveProviders` returning empty array)
- Individual tests can override the mock implementation as needed without re-importing
- This approach is more maintainable and follows the pattern of other mocked dependencies (configManager, getEnv)

https://claude.ai/code/session_01VAyT7XSNEtV4WHyGR4wy1A