### PR TITLE
fix(settings): repair OpenConnectorApps crash on Settings page

### DIFF
--- a/apps/qwksearch-web/components/Settings/Sections/MCPServers/OpenConnectorApps.tsx
+++ b/apps/qwksearch-web/components/Settings/Sections/MCPServers/OpenConnectorApps.tsx
@@ -1,15 +1,48 @@
 import { useState } from 'react';
 import openConnectorData from 'agent-toolkit/connectors/openconnector-providers-index.json';
 
+type OpenConnectorProvider = {
+  service: string;
+  displayName: string;
+  categories: string[];
+  authTypes: string[];
+  homepageUrl: string | null;
+  actionCount: number;
+  actions: string[];
+};
+
 type Connector = {
   name: string;
-  connector_id: string | null;
+  connector_id: string;
   domain: string | null;
   description: string;
 };
 
-const connectors: Connector[] = (openConnectorData.connectors as Connector[]).filter(
-  (c) => c.connector_id !== null,
+const domainFromUrl = (url: string | null): string | null => {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+};
+
+const providers = openConnectorData as OpenConnectorProvider[];
+
+const connectors: Connector[] = (Array.isArray(providers) ? providers : []).map(
+  (p) => {
+    const categories = Array.isArray(p.categories) ? p.categories : [];
+    const description =
+      categories.length > 0
+        ? `${categories.join(', ')} · ${p.actionCount} action${p.actionCount === 1 ? '' : 's'}`
+        : `${p.actionCount} action${p.actionCount === 1 ? '' : 's'}`;
+    return {
+      name: p.displayName || p.service,
+      connector_id: p.service,
+      domain: domainFromUrl(p.homepageUrl),
+      description,
+    };
+  },
 );
 
 const ConnectorLogo = ({ connector }: { connector: Connector }) => {


### PR DESCRIPTION
The component read `openConnectorData.connectors` and mapped fields (name/connector_id/domain/description), but the connectors index JSON is a top-level array of providers with a different shape (service/displayName/categories/homepageUrl/actionCount). Accessing `.connectors` returned undefined, so `.filter()` threw "Cannot read properties of undefined (reading 'filter')" at module load, taking down the whole Settings React tree via the global error boundary.

Adapt the component to the real schema: iterate the array directly, map displayName->name, service->connector_id, derive domain from homepageUrl, and build a description from categories + action count. Add defensive guards (Array.isArray, safe URL parsing) so a schema drift degrades gracefully instead of crashing.


Claude-Session: https://claude.ai/code/session_01G592R9VqgVcKq1tpXZ4GzE