### PR TITLE
fix(kokoro): recover from failed in-browser model load

### DIFF
--- a/packages/research-agent-ui/src/lib/kokoro.ts
+++ b/packages/research-agent-ui/src/lib/kokoro.ts
@@ -8,6 +8,14 @@ const MODEL_ID = 'onnx-community/Kokoro-82M-v1.0-ONNX';
 type DeviceMode = 'wasm' | 'webgpu';
 type DType = 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16';
 
+interface Backend {
+  device: DeviceMode;
+  dtype: DType;
+}
+
+const WEBGPU_BACKEND: Backend = { device: 'webgpu', dtype: 'fp32' };
+const WASM_BACKEND: Backend = { device: 'wasm', dtype: 'q8' };
+
 let ttsPromise: Promise<any> | null = null;
 let chosenDevice: DeviceMode | null = null;
 
@@ -15,31 +23,73 @@ function supportsWebGPU() {
   return typeof navigator !== 'undefined' && 'gpu' in navigator;
 }
 
-export function getRecommendedBackend(): { device: DeviceMode; dtype: DType } {
-  if (supportsWebGPU()) {
-    return { device: 'webgpu', dtype: 'fp32' };
+// Actually confirm a usable GPU adapter exists. `'gpu' in navigator` is true in
+// many environments (headless/Linux Chrome, browsers behind flags, locked-down
+// corporate profiles) where `requestAdapter()` still resolves to null. Relying
+// on the property alone makes the WebGPU model load throw with no way to
+// recover, which is the most common "model won't load" symptom.
+async function hasWorkingWebGPU(): Promise<boolean> {
+  if (!supportsWebGPU()) return false;
+  try {
+    const adapter = await (navigator as any).gpu.requestAdapter();
+    return adapter != null;
+  } catch {
+    return false;
   }
-  return { device: 'wasm', dtype: 'q8' };
+}
+
+export function getRecommendedBackend(): Backend {
+  return supportsWebGPU() ? WEBGPU_BACKEND : WASM_BACKEND;
+}
+
+async function loadModel(): Promise<any> {
+  if (!KokoroTTS) {
+    try {
+      const mod = await import('kokoro-js');
+      KokoroTTS = mod.KokoroTTS;
+    } catch (err) {
+      console.error('Failed to import kokoro-js:', err);
+      throw new Error('Kokoro.js library not available');
+    }
+  }
+
+  // Try the best available backend first, but always keep WASM as a fallback so
+  // a WebGPU failure (unsupported op, OOM, driver issue) still produces audio.
+  const backends: Backend[] = [];
+  if (await hasWorkingWebGPU()) backends.push(WEBGPU_BACKEND);
+  backends.push(WASM_BACKEND);
+
+  let lastErr: unknown;
+  for (const backend of backends) {
+    try {
+      const tts = await KokoroTTS.from_pretrained(MODEL_ID, {
+        device: backend.device,
+        dtype: backend.dtype,
+      });
+      chosenDevice = backend.device;
+      return tts;
+    } catch (err) {
+      lastErr = err;
+      console.warn(
+        `Kokoro model failed to load on "${backend.device}" backend:`,
+        err,
+      );
+    }
+  }
+
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error('Failed to load Kokoro model');
 }
 
 export async function preloadKokoro() {
   if (!ttsPromise) {
-    if (!KokoroTTS) {
-      try {
-        const mod = await import('kokoro-js');
-        KokoroTTS = mod.KokoroTTS;
-      } catch (err) {
-        console.error('Failed to import kokoro-js:', err);
-        throw new Error('Kokoro.js library not available');
-      }
-    }
-
-    const { device, dtype } = getRecommendedBackend();
-    chosenDevice = device;
-
-    ttsPromise = KokoroTTS.from_pretrained(MODEL_ID, {
-      device,
-      dtype,
+    ttsPromise = loadModel().catch((err) => {
+      // Never cache a rejected promise: reset it so a later call can retry
+      // (e.g. after a transient network failure) instead of permanently
+      // returning the same rejection until the page is reloaded.
+      ttsPromise = null;
+      throw err;
     });
   }
 


### PR DESCRIPTION
The client-side Kokoro TTS model would fail to load and never recover:

- WebGPU was selected whenever `'gpu' in navigator` was true, but that is true in many environments (headless/Linux Chrome, flagged/locked-down browsers) where `requestAdapter()` returns null, so `from_pretrained` with `device: "webgpu"` threw.
- There was no fallback to WASM when the WebGPU load failed.
- The rejected `from_pretrained` promise was cached in `ttsPromise`, so every subsequent warmup/retry returned the same rejection until reload.

Now WebGPU is only used after `requestAdapter()` confirms a usable adapter, WASM (q8) is always kept as a fallback backend, and a failed load resets the cached promise so retries can succeed.


Claude-Session: https://claude.ai/code/session_01Y8gciJC1ZT4omUafABwVQS