### PR TITLE
Fix kokoro-js bundling for client and server builds

### DIFF
--- a/apps/qwksearch-web/vite.config.ts
+++ b/apps/qwksearch-web/vite.config.ts
@@ -56,7 +56,14 @@ export default defineConfig(({ command }) => ({
       // because workerd resolves bare specifiers relative to the chunk. The
       // AI SDK packages never reach the final client bundle anyway (they are
       // tree-shaken out), so they must simply be bundled server-side.
-      external: ["fsevents", "kokoro-js", /^@mastra\//],
+      //
+      // Do NOT add `kokoro-js` here: this list applies to the client build too,
+      // and externalizing it leaves a bare `import "kokoro-js"` the browser
+      // can't resolve ("Failed to resolve module specifier"), crashing the
+      // lazy-loaded voice component. It is a browser-only library and must be
+      // bundled client-side; the `externalize-kokoro-on-server` plugin below
+      // keeps it external in the server (rsc/ssr) worker build instead.
+      external: ["fsevents", /^@mastra\//],
     },
   },
   ssr: {
@@ -75,6 +82,31 @@ export default defineConfig(({ command }) => ({
     ],
   },
   plugins: [
+    {
+      // `kokoro-js` (transformers.js / onnxruntime-web) is a browser-only TTS
+      // library. It must be BUNDLED into the client so the lazy-loaded voice
+      // component can resolve it at runtime — leaving it external emits a bare
+      // `import "kokoro-js"` the browser can't resolve ("Failed to resolve
+      // module specifier"), which crashes the component during RSC preload.
+      //
+      // In the server (rsc/ssr) worker build, however, onnxruntime's native
+      // bindings have no place, and `kokoro-js` is never actually executed
+      // there (kokoro.ts is `use client` and only imports the model at runtime
+      // in the browser, via a dynamic `import()`). So keep it external for the
+      // server environments only, instead of globally via rolldownOptions.
+      name: "externalize-kokoro-on-server",
+      enforce: "pre",
+      resolveId(id) {
+        const envName = this.environment?.name;
+        if (
+          (id === "kokoro-js" || id.startsWith("kokoro-js/")) &&
+          (envName === "rsc" || envName === "ssr")
+        ) {
+          return { id, external: true };
+        }
+        return null;
+      },
+    },
     {
       // Resolve `cloudflare:workers` to a harmless stub in the client build,
       // and in local `vite serve` (where we intentionally skip the

--- a/packages/research-agent-ui/src/lib/kokoro.ts
+++ b/packages/research-agent-ui/src/lib/kokoro.ts
@@ -1,7 +1,11 @@
 'use client';
 
-import { KokoroTTS } from 'kokoro-js';
-
+// `kokoro-js` (transformers.js / onnxruntime-web) is a browser-only library
+// that is large and only needed once the user actually invokes TTS. Import it
+// lazily via a dynamic `import()` rather than a top-level static import so it:
+//   * code-splits into its own chunk that downloads on demand, and
+//   * is never evaluated at module load — in particular it stays out of the
+//     server (rsc/ssr) render path, where onnxruntime has no place.
 type DeviceMode = 'wasm' | 'webgpu';
 type DType = 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16';
 
@@ -40,6 +44,8 @@ async function loadModel(): Promise<any> {
   const backends: Backend[] = [];
   if (await hasWorkingWebGPU()) backends.push(WEBGPU_BACKEND);
   backends.push(WASM_BACKEND);
+
+  const { KokoroTTS } = await import('kokoro-js');
 
   let lastErr: unknown;
   for (const backend of backends) {


### PR DESCRIPTION
## Summary
Fixes kokoro-js (a browser-only TTS library) bundling to work correctly in both client and server environments. Previously, kokoro-js was globally externalized, which caused the client build to fail with unresolvable bare imports. This change bundles it for the client while keeping it external only in server/RSC builds.

## Key Changes
- **Vite config**: Removed `kokoro-js` from the global `external` list in rolldownOptions, as it was breaking the client build
- **New Vite plugin**: Added `externalize-kokoro-on-server` plugin that selectively externalizes `kokoro-js` only for `rsc` and `ssr` environments, preventing onnxruntime native bindings from being included in server builds
- **Lazy loading**: Changed kokoro.ts to use dynamic `import('kokoro-js')` instead of a top-level static import, enabling:
  - Code-splitting into a separate chunk that loads on-demand
  - Keeping the library out of the server render path where onnxruntime has no place

## Implementation Details
The solution uses Vite's environment-aware plugin system to conditionally externalize the module based on the build environment. The dynamic import in kokoro.ts ensures the library is only evaluated when actually needed (when the user invokes TTS), not during module initialization or server-side rendering.

https://claude.ai/code/session_01SuwnzzGxo57FWzwhF8oygw