### PR TITLE
Optimize footer and chat layout for mobile devices

### DIFF
--- a/apps/qwksearch-web/components/layout/CategoryDock.tsx
+++ b/apps/qwksearch-web/components/layout/CategoryDock.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "shadcn-app-dock"
-import { useSession } from "research-agent-ui"
+import { useSession, useChat } from "research-agent-ui"
 import iconRead from "../icons/icon-read.svg"
 import iconConfigure from "../icons/icon-configure.svg"
 
@@ -27,6 +27,9 @@ export function CategoryDock() {
   const pathname = usePathname()
   const router = useRouter()
   const { isAuthenticated, signIn, signOut } = useSession()
+  const { newChat } = useChat()
+
+  const isOnResearch = pathname === "/" || pathname.startsWith("/c")
 
   const items: DockNavItem[] = [
     ...NAV_ITEMS.map(({ href, label, icon }) => ({
@@ -35,9 +38,14 @@ export function CategoryDock() {
       icon,
       active:
         href === "/"
-          ? pathname === "/" || pathname.startsWith("/c")
+          ? isOnResearch
           : pathname.startsWith(href),
-      onClick: () => router.push(href),
+      // Tapping the Research icon while already on a research page closes the
+      // current chat and opens a fresh one instead of navigating in place.
+      onClick:
+        href === "/" && isOnResearch
+          ? () => newChat()
+          : () => router.push(href),
     })),
     {
       key: "settings",

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -88,8 +88,9 @@ export default function ChatHomepage() {
       </div>
 
       <div className="relative z-10">
-        {/* Centered content with input in the middle of the page */}
-        <div className="flex flex-col items-center justify-center min-h-screen max-w-screen-sm mx-auto p-2 pb-20 md:pb-2">
+        {/* Content: centered on desktop, bottom-aligned on mobile so the input sits
+            just above the app dock with almost no gap */}
+        <div className="flex flex-col items-center justify-end md:justify-center min-h-[calc(100dvh-64px)] md:min-h-screen max-w-screen-sm mx-auto p-2 pb-1 md:pb-2">
           <div style={{ height: '200px', width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <QuantumWaveOrbital
               autoRandomize={true}

--- a/packages/research-agent-ui/src/components/Footer.tsx
+++ b/packages/research-agent-ui/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import * as LucideIcons from "lucide-react";
 
@@ -16,7 +17,13 @@ interface FooterProps {
 }
 
 /**
- * Footer component that displays a list of links with optional icons
+ * Footer component that displays a list of links with optional icons.
+ *
+ * On desktop the links render as a bar pinned to the bottom-center of the screen.
+ * On mobile the bar is collapsed into a small info icon in the bottom corner that,
+ * when tapped, reveals the same links in a popover — keeping the chat input clear
+ * of the footer and the OS app dock.
+ *
  * @param listFooterLinks - Array of footer links with their properties
  * @param optionShowIcons - Whether to show icons next to links (default: true)
  * @param optionBackgroundColor - Background color class for the footer (default: "bg-black/40")
@@ -26,54 +33,98 @@ export default function Footer({
     optionShowIcons = true,
     optionBackgroundColor = "bg-black/40",
 }: FooterProps) {
+    const [open, setOpen] = useState(false);
+    const mobileRef = useRef<HTMLDivElement>(null);
+
+    // Close the mobile popover when tapping/clicking outside of it.
+    useEffect(() => {
+        if (!open) return;
+        const handleClickOutside = (event: MouseEvent) => {
+            if (mobileRef.current && !mobileRef.current.contains(event.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, [open]);
+
+    const renderLinks = () =>
+        listFooterLinks.map(({ url, text, icon }) => {
+            const IconComponent = icon ? (LucideIcons as any)[icon] : null;
+
+            const isExternal = url.startsWith("http");
+            const linkProps = isExternal
+                ? { target: "_blank", rel: "noopener noreferrer" }
+                : {};
+
+            const content = (
+                <>
+                    {optionShowIcons && IconComponent && <IconComponent size={14} />}
+                    <span
+                        className="font-semibold tracking-wide text-md"
+                        style={{ fontVariant: "small-caps" }}
+                    >
+                        {text}
+                    </span>
+                    <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-current transition-all duration-300 group-hover:w-full group-hover:shadow-[0_0_8px_rgba(255,255,255,0.6)]" />
+                </>
+            );
+
+            return isExternal ? (
+                <a
+                    key={url}
+                    href={url}
+                    {...linkProps}
+                    className="relative group inline-flex items-center gap-1 hover:text-white hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300 whitespace-nowrap"
+                >
+                    {content}
+                </a>
+            ) : (
+                <Link
+                    key={url}
+                    href={url}
+                    className="relative group inline-flex items-center gap-1 hover:text-white hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300 whitespace-nowrap"
+                >
+                    {content}
+                </Link>
+            );
+        });
+
+    const InfoIcon = (LucideIcons as any).Info;
+
     return (
-        <div
-            className={`absolute bottom-2 left-1/2 -translate-x-1/2 text-slate-200 text-xs z-20 ${optionBackgroundColor} rounded-lg px-2 py-1 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-wrap items-center justify-center gap-x-6 max-w-[90vw]`}
-        >
-            <div className={`max-w-4xl mx-auto grid grid-cols-3 gap-2`}>
-                {listFooterLinks.map(({ url, text, icon }) => {
-                    const IconComponent = icon ? (LucideIcons as any)[icon] : null;
-
-                    const isExternal = url.startsWith("http");
-                    const linkProps = isExternal
-                        ? { target: "_blank", rel: "noopener noreferrer" }
-                        : {};
-
-                    const content = (
-                        <>
-                            {optionShowIcons && IconComponent && (
-                                <IconComponent size={14} />
-                            )}
-                            <span
-                                className="font-semibold tracking-wide text-md"
-                                style={{ fontVariant: "small-caps" }}
-                            >
-                                {text}
-                            </span>
-                            <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-current transition-all duration-300 group-hover:w-full group-hover:shadow-[0_0_8px_rgba(255,255,255,0.6)]" />
-                        </>
-                    );
-
-                    return isExternal ? (
-                        <a
-                            key={url}
-                            href={url}
-                            {...linkProps}
-                            className="relative group inline-flex items-center gap-1 hover:text-white hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300 whitespace-nowrap"
-                        >
-                            {content}
-                        </a>
-                    ) : (
-                        <Link
-                            key={url}
-                            href={url}
-                            className="relative group inline-flex items-center gap-1 hover:text-white hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300 whitespace-nowrap"
-                        >
-                            {content}
-                        </Link>
-                    );
-                })}
+        <>
+            {/* Desktop: full footer bar pinned bottom-center */}
+            <div
+                className={`hidden md:flex absolute bottom-2 left-1/2 -translate-x-1/2 text-slate-200 text-xs z-20 ${optionBackgroundColor} rounded-lg px-2 py-1 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex-wrap items-center justify-center gap-x-6 max-w-[90vw]`}
+            >
+                <div className="max-w-4xl mx-auto grid grid-cols-3 gap-2">
+                    {renderLinks()}
+                </div>
             </div>
-        </div>
+
+            {/* Mobile: collapsed to an info icon in the top corner that reveals the links */}
+            <div
+                ref={mobileRef}
+                className="md:hidden fixed top-[calc(8px+env(safe-area-inset-top,0px))] right-2 z-30"
+            >
+                {open && (
+                    <div
+                        className={`absolute top-full right-0 mt-2 text-slate-200 text-xs ${optionBackgroundColor} rounded-lg px-3 py-2 shadow-lg flex flex-col items-start gap-2 backdrop-blur-sm`}
+                    >
+                        {renderLinks()}
+                    </div>
+                )}
+                <button
+                    type="button"
+                    onClick={() => setOpen((prev) => !prev)}
+                    aria-label={open ? "Hide links" : "Show links"}
+                    aria-expanded={open}
+                    className={`flex items-center justify-center h-8 w-8 rounded-full text-slate-200 ${optionBackgroundColor} shadow-lg backdrop-blur-sm hover:text-white transition-all duration-300`}
+                >
+                    {InfoIcon ? <InfoIcon size={16} /> : "i"}
+                </button>
+            </div>
+        </>
     );
 }


### PR DESCRIPTION
## Summary
This PR improves the mobile experience by collapsing the footer into a compact info icon and adjusting the chat homepage layout to better accommodate mobile app docks and safe areas.

## Key Changes

### Footer Component (`packages/research-agent-ui/src/components/Footer.tsx`)
- **Responsive design**: Footer now displays as a full bar on desktop (hidden on mobile with `hidden md:flex`) and collapses to a small info icon button on mobile
- **Mobile popover**: Added state management (`useState`, `useRef`) to toggle a popover menu that reveals footer links when the info icon is tapped
- **Click-outside handling**: Implemented `useEffect` hook to close the mobile popover when clicking outside of it
- **Safe area support**: Mobile footer icon respects safe area insets (notches, home indicators) using `env(safe-area-inset-top)`
- **Refactored link rendering**: Extracted link rendering logic into a `renderLinks()` function to avoid duplication between desktop and mobile layouts

### Chat Homepage (`packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx`)
- **Mobile layout adjustment**: Changed from `justify-center` to `justify-end md:justify-center` so content aligns to the bottom on mobile, positioning the chat input just above the app dock
- **Dynamic height**: Updated `min-h-screen` to `min-h-[calc(100dvh-64px)] md:min-h-screen` to account for mobile app dock height (64px) while maintaining full-screen centering on desktop
- **Reduced bottom padding**: Changed `pb-20 md:pb-2` to `pb-1 md:pb-2` to minimize gap between input and dock on mobile

### Category Dock (`apps/qwksearch-web/components/layout/CategoryDock.tsx`)
- **New hook import**: Added `useChat` hook alongside existing `useSession`
- **Smart navigation**: Research icon now triggers `newChat()` when already on a research page (instead of navigating in place), providing a better UX for starting fresh conversations
- **Extracted condition**: Created `isOnResearch` variable to improve code readability

## Implementation Details
- The mobile footer uses `fixed` positioning in the top-right corner to avoid interfering with the chat input area
- Both desktop and mobile footers share the same link rendering logic via the extracted `renderLinks()` function
- The mobile popover includes `backdrop-blur-sm` for visual polish and uses `flex-col items-start` for vertical stacking
- Safe area insets are applied using CSS `env()` function for proper notch/home indicator spacing

https://claude.ai/code/session_017xXcPcsw1wqBn3AmuokbXH