### PR TITLE
Refactor article action buttons and remove duplicate URL display

### DIFF
--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.tsx
@@ -1,8 +1,9 @@
 /**
- * Toolbar with Ask AI, Suggest, Copy, Highlight, and Favorite buttons shown at the top of the article extract panel.
+ * Toolbar with Ask AI, Suggest, Copy, Highlight, Favorite, Open-in-new-tab, and Close buttons
+ * shown at the top of the article extract panel.
  */
 import React from 'react';
-import { Bot, MessageCircleQuestion, Clipboard, Star, Highlighter } from 'lucide-react';
+import { Bot, MessageCircleQuestion, Clipboard, Star, Highlighter, ExternalLink, X } from 'lucide-react';
 import { Button } from '../../ui/button';
 import { cn } from '../../lib/utils';
 
@@ -12,12 +13,19 @@ interface ArticleActionButtonsProps {
   isLoadingFavorite: boolean;
   isFavorited: boolean;
   isHighlightMode: boolean;
+  articleUrl?: string;
   onAskClick: () => void;
   onSuggestClick: () => void;
   onCopyClick: () => void;
   onFavoriteClick: () => void;
   onHighlightToggle: () => void;
+  onClose: () => void;
 }
+
+const iconButtonClass = cn(
+  "h-9 w-9 rounded-xl transition-all duration-200",
+  "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
+);
 
 const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
   isLoadingAI,
@@ -25,14 +33,16 @@ const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
   isLoadingFavorite,
   isFavorited,
   isHighlightMode,
+  articleUrl,
   onAskClick,
   onSuggestClick,
   onCopyClick,
   onFavoriteClick,
   onHighlightToggle,
+  onClose,
 }) => {
   return (
-    <div className="flex flex-wrap items-center gap-1 rounded-2xl border border-muted bg-gradient-to-b from-background to-muted/30 p-1 shadow-sm">
+    <div className="flex flex-nowrap items-center gap-1 rounded-2xl border border-muted bg-gradient-to-b from-background to-muted/30 p-1 shadow-sm">
       <Button
         onClick={onAskClick}
         disabled={isLoadingAI}
@@ -65,10 +75,8 @@ const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
         onClick={onCopyClick}
         variant="ghost"
         size="icon"
-        className={cn(
-          "h-9 w-9 rounded-xl transition-all duration-200",
-          "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
-        )}
+        className={iconButtonClass}
+        title="Copy article"
       >
         <Clipboard className="size-4" />
       </Button>
@@ -107,6 +115,30 @@ const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
             isFavorited && "fill-yellow-400"
           )}
         />
+      </Button>
+
+      {articleUrl && (
+        <Button
+          asChild
+          variant="ghost"
+          size="icon"
+          className={iconButtonClass}
+          title="Open in new tab"
+        >
+          <a href={articleUrl} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="size-4" />
+          </a>
+        </Button>
+      )}
+
+      <Button
+        onClick={onClose}
+        variant="ghost"
+        size="icon"
+        className={cn(iconButtonClass, "ml-auto")}
+        title="Close"
+      >
+        <X className="size-4" />
       </Button>
     </div>
   );

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleContent.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleContent.tsx
@@ -5,7 +5,6 @@
 'use client';
 
 import React from 'react';
-import { ExternalLink } from 'lucide-react';
 import { Article } from '../../types/research';
 import LexicalArticleViewer from './LexicalArticleViewer';
 
@@ -20,19 +19,6 @@ const ArticleContent: React.FC<ArticleContentProps> = ({ article, isHighlightMod
       <div>
         {/* Title and Favorite Button */}
         <div className="flex items-start justify-between mb-2"></div>
-
-        {/* URL Display */}
-        {article.url && (
-          <a
-            href={article.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 mb-3 text-sm text-primary hover:underline truncate max-w-full"
-          >
-            <ExternalLink className="flex-shrink-0 size-3.5" />
-            <span className="truncate">{article.url}</span>
-          </a>
-        )}
 
         {/* Citation Information */}
         {article.cite && (

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
@@ -19,7 +19,6 @@ import { Dialog, DialogContent, DialogTitle } from '../../ui/dialog';
 import { VisuallyHidden } from '../../ui/visually-hidden';
 import { useExtractPanel } from './ExtractPanelContext';
 import {
-  ArticlePanelHeader,
   ArticleActionButtons,
   ArticlePromptInput,
   ArticleFollowupQuestions,
@@ -333,8 +332,6 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
 
   const renderPanelContent = () => (
     <div className="flex h-full flex-col bg-background shadow-xl">
-      <ArticlePanelHeader onClose={onClose} />
-
       <div className="flex-1 overflow-y-auto">
         <div className="p-4 space-y-6">
             <div className="space-y-4">
@@ -344,11 +341,13 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
                 isLoadingFavorite={isLoadingFavorite}
                 isFavorited={isFavorited}
                 isHighlightMode={isHighlightMode}
+                articleUrl={extractedArticle?.url || url}
                 onAskClick={() => callLanguageAPI('question')}
                 onSuggestClick={() => callLanguageAPI('suggest-followups')}
                 onCopyClick={handleCopyHTMLToClipboard}
                 onFavoriteClick={toggleFavorite}
                 onHighlightToggle={() => setIsHighlightMode(!isHighlightMode)}
+                onClose={onClose}
               />
 
               {showCopiedMessage && (


### PR DESCRIPTION
## Summary
This PR refactors the article reader UI by consolidating action buttons and removing redundant URL display. The "Open in new tab" and "Close" buttons are now integrated into the main action buttons toolbar, and the duplicate URL link has been removed from the article content area.

## Key Changes
- **ArticleActionButtons**: Added `ExternalLink` and `X` icons to the action buttons toolbar
  - New `articleUrl` prop to conditionally render the "Open in new tab" button
  - New `onClose` callback prop for the close button
  - Extracted common icon button styling into a reusable `iconButtonClass` constant
  - Changed flex layout from `flex-wrap` to `flex-nowrap` to maintain button alignment
  - Added `ml-auto` margin to the close button to push it to the right

- **ArticleContent**: Removed the URL display section that was previously shown below the article title
  - Removed the `ExternalLink` icon import
  - Deleted the URL link element and its container

- **ArticleExtractPanel**: Removed the `ArticlePanelHeader` component import and its usage
  - The close functionality is now handled by the close button in `ArticleActionButtons`

## Implementation Details
- The "Open in new tab" button is conditionally rendered only when `articleUrl` is provided
- The close button is now always visible and positioned at the right end of the toolbar using `ml-auto`
- Styling consistency is maintained across all icon buttons through the extracted `iconButtonClass` constant
- All buttons retain their existing hover states and disabled states

https://claude.ai/code/session_01KrvAbRJXTtxYUEeGSDzov9