### PR TITLE
Add file upload support to chat with default analysis prompt

### DIFF
--- a/apps/qwksearch-web/lib/chat/__tests__/schemas.test.ts
+++ b/apps/qwksearch-web/lib/chat/__tests__/schemas.test.ts
@@ -4,7 +4,13 @@ import { describe, expect, it, vi } from 'vitest'
 // module so the test runner does not need the workspace package built.
 vi.mock('chat-agent-toolkit/models/types', () => ({}))
 
-import { safeValidateBody, messageSchema, chatModelSchema } from '../schemas'
+import {
+  safeValidateBody,
+  messageSchema,
+  chatModelSchema,
+  resolveMessageContent,
+  DEFAULT_UPLOAD_ANALYSIS_PROMPT,
+} from '../schemas'
 
 const validBody = {
   message: { messageId: 'msg-1', chatId: 'chat-1', content: 'Hello' },
@@ -32,18 +38,20 @@ describe('messageSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects missing content', () => {
+  it('defaults missing content to an empty string (files may carry the request)', () => {
     const result = messageSchema.safeParse({ messageId: 'm1', chatId: 'c1' })
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.content).toBe('')
   })
 
-  it('rejects empty content', () => {
+  it('accepts empty content (validated against files at the body level)', () => {
     const result = messageSchema.safeParse({
       messageId: 'm1',
       chatId: 'c1',
       content: '',
     })
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
   })
 })
 
@@ -149,5 +157,61 @@ describe('safeValidateBody', () => {
 
   it('accepts thinkingTimeLimit of 0', () => {
     expect(safeValidateBody({ ...validBody, thinkingTimeLimit: 0 }).success).toBe(true)
+  })
+
+  it('accepts a blank message when files are attached', () => {
+    const result = safeValidateBody({
+      ...validBody,
+      message: { messageId: 'm1', chatId: 'c1', content: '' },
+      files: ['file-abc'],
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.files).toEqual(['file-abc'])
+  })
+
+  it('accepts a message with omitted content when files are attached', () => {
+    const result = safeValidateBody({
+      ...validBody,
+      message: { messageId: 'm1', chatId: 'c1' },
+      files: ['file-abc'],
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.message.content).toBe('')
+  })
+
+  it('rejects a blank message with no attached files', () => {
+    const result = safeValidateBody({
+      ...validBody,
+      message: { messageId: 'm1', chatId: 'c1', content: '   ' },
+      files: [],
+    })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.some((e) => e.path === 'message.content')).toBe(true)
+  })
+})
+
+describe('resolveMessageContent', () => {
+  it('returns the typed message verbatim when present', () => {
+    expect(resolveMessageContent('summarize this', [])).toBe('summarize this')
+    expect(resolveMessageContent('  keep spaces inside  ', [])).toBe(
+      '  keep spaces inside  ',
+    )
+  })
+
+  it('falls back to the default analysis prompt for a blank message with files', () => {
+    expect(resolveMessageContent('', ['file-1'])).toBe(
+      DEFAULT_UPLOAD_ANALYSIS_PROMPT,
+    )
+    expect(resolveMessageContent('   ', ['file-1', 'file-2'])).toBe(
+      DEFAULT_UPLOAD_ANALYSIS_PROMPT,
+    )
+  })
+
+  it('returns null when there is neither text nor a file', () => {
+    expect(resolveMessageContent('', [])).toBeNull()
+    expect(resolveMessageContent('   ', undefined)).toBeNull()
   })
 })

--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -19,7 +19,7 @@ const searchHandlers = createSearchHandlers({
 import ModelRegistry from "chat-agent-toolkit/models/registry";
 import { getUserId } from "@/lib/auth/session";
 import { checkGuestRateLimit } from "@/lib/rate-limit/guestRateLimiter";
-import { safeValidateBody } from "./schemas";
+import { safeValidateBody, resolveMessageContent } from "./schemas";
 import type { Body } from "./schemas";
 import { handleEmitterEvents } from "./stream-handler";
 import { handleHistorySave } from "./history";
@@ -169,11 +169,21 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
     const body = parseBody.data;
     const { message } = body;
 
-    if (message.content === "") {
-      console.warn("[POST /api/agent/chat] empty message content");
+    // Resolve the effective query. A blank message with attached files is
+    // valid and becomes an "analyse the uploaded file(s)" instruction so the
+    // uploaded content (added to the answer context) still reaches the LLM.
+    const resolvedContent = resolveMessageContent(message.content, body.files);
+    if (resolvedContent === null) {
+      console.warn("[POST /api/agent/chat] empty message with no attached files");
       return Response.json(
-        { message: "Please provide a message to process" },
+        { message: "Please provide a message or attach a file to process" },
         { status: 400 },
+      );
+    }
+    const effectiveMessage = { ...message, content: resolvedContent };
+    if (resolvedContent !== message.content) {
+      console.log(
+        `[POST /api/agent/chat] blank message with ${body.files.length} file(s); using default analysis prompt`,
       );
     }
 
@@ -234,7 +244,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
 
     // --- Resolve message ID (use client-provided or generate one) ---
     const humanMessageId =
-      message.messageId ?? crypto.randomBytes(7).toString("hex");
+      effectiveMessage.messageId ?? crypto.randomBytes(7).toString("hex");
 
     // --- Convert history tuples to AI SDK chat messages ---
     const history = buildChatHistory(body.history);
@@ -258,7 +268,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       `[POST /api/agent/chat] starting searchAndAnswer focusMode=${body.focusMode} optimizationMode=${body.optimizationMode}`,
     );
     const stream = await handler.searchAndAnswer(
-      message.content,
+      effectiveMessage.content,
       history,
       llm,
       body.optimizationMode,
@@ -285,7 +295,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
     const writer = responseStream.writable.getWriter();
     const encoder = new TextEncoder();
 
-    handleEmitterEvents(stream, writer, encoder, message.chatId, userId, db);
+    handleEmitterEvents(stream, writer, encoder, effectiveMessage.chatId, userId, db);
 
     // --- Persist chat session and human message (authenticated users only) ---
     console.log(
@@ -295,7 +305,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
     if (userId && db) {
       try {
         await handleHistorySave(
-          message,
+          effectiveMessage,
           humanMessageId,
           body.focusMode,
           body.files,

--- a/apps/qwksearch-web/lib/chat/index.ts
+++ b/apps/qwksearch-web/lib/chat/index.ts
@@ -25,6 +25,8 @@ export {
   chatModelSchema,
   bodySchema,
   safeValidateBody,
+  resolveMessageContent,
+  DEFAULT_UPLOAD_ANALYSIS_PROMPT,
   type Message,
   type Body,
   type ValidationError,

--- a/apps/qwksearch-web/lib/chat/schemas.ts
+++ b/apps/qwksearch-web/lib/chat/schemas.ts
@@ -2,6 +2,14 @@ import { z } from "zod";
 import { ModelWithProvider } from "chat-agent-toolkit/models/types";
 
 /**
+ * Default query used when a user attaches a file (or files) but sends no
+ * message text. The uploaded content is placed in the answer context, so the
+ * model is instructed to analyse it directly.
+ */
+export const DEFAULT_UPLOAD_ANALYSIS_PROMPT =
+  "Analyze the uploaded file(s) and summarize the key points.";
+
+/**
  * Schema for a single chat message sent by the client.
  *
  * @property {string} messageId  - Client-generated unique identifier for the message.
@@ -13,9 +21,36 @@ export const messageSchema = z.object({
   messageId: z.string().min(1, "Message ID is required"),
   /** Identifier of the chat session this message belongs to. */
   chatId: z.string().min(1, "Chat ID is required"),
-  /** The user's message text. Must be non-empty. */
-  content: z.string().min(1, "Message content is required"),
+  /**
+   * The user's message text. May be empty when files are attached — in that
+   * case the request is treated as "analyse the uploaded file(s)". The
+   * body-level refinement enforces that a request has either text or files.
+   */
+  content: z.string().default(""),
 });
+
+/**
+ * Resolves the effective query to send to the search pipeline and the LLM.
+ *
+ * When the user typed a message, that message is used verbatim. When the
+ * message is blank but files are attached, a default analysis prompt is
+ * substituted so the model has an explicit instruction to work with the
+ * uploaded content. Returns `null` when there is neither text nor a file,
+ * signalling the caller to reject the request.
+ *
+ * @param content - The raw message text from the client (may be empty).
+ * @param files   - Attached file identifiers.
+ * @returns The query to use, or `null` when the request has nothing to act on.
+ */
+export const resolveMessageContent = (
+  content: string,
+  files: readonly string[] | undefined,
+): string | null => {
+  const trimmed = (content ?? "").trim();
+  if (trimmed.length > 0) return content;
+  if (files && files.length > 0) return DEFAULT_UPLOAD_ANALYSIS_PROMPT;
+  return null;
+};
 
 /**
  * Schema for the chat model selection sent by the client.
@@ -80,6 +115,19 @@ export const bodySchema = z.object({
    * 0 = unlimited (uses server default); >0 = budget spread across top 3 sources.
    */
   thinkingTimeLimit: z.number().int().min(0).optional().default(5),
+}).superRefine((data, ctx) => {
+  // A request must carry something to act on: either message text or at least
+  // one attached file. A blank message with files is valid — it means
+  // "analyse the uploaded file(s)".
+  const hasText = data.message.content.trim().length > 0;
+  const hasFiles = Array.isArray(data.files) && data.files.length > 0;
+  if (!hasText && !hasFiles) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["message", "content"],
+      message: "Provide a message or attach a file",
+    });
+  }
 });
 
 /**

--- a/apps/qwksearch-web/lib/uploads/__tests__/index.test.ts
+++ b/apps/qwksearch-web/lib/uploads/__tests__/index.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for the centralized upload management helpers.
+ *
+ * The Cloudflare runtime and D1 database are mocked so these run under plain
+ * Node: `@/lib/cloudflare-context` exposes an in-memory R2 stub (exercising the
+ * native Workers binding path), and `@/lib/database` exposes a hand-rolled
+ * Drizzle-shaped query builder backed by controllable in-memory state.
+ */
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+// Shared mock state, hoisted so the vi.mock factories below can reference it.
+const mocks = vi.hoisted(() => {
+  const makeR2 = () => {
+    const store = new Map<string, string>()
+    return {
+      store,
+      put: vi.fn(async (key: string, body: Buffer | string) => {
+        store.set(key, typeof body === 'string' ? body : body.toString('utf-8'))
+      }),
+      get: vi.fn(async (key: string) => {
+        if (!store.has(key)) return null
+        return { text: async () => store.get(key)! }
+      }),
+      delete: vi.fn(async (key: string) => {
+        store.delete(key)
+      }),
+    }
+  }
+
+  return {
+    r2: makeR2(),
+    db: {
+      selectRows: [] as any[],
+      inserted: [] as any[],
+      deleted: [] as any[],
+    },
+  }
+})
+
+vi.mock('@/lib/cloudflare-context', () => ({
+  getCloudflareContext: () => ({ env: { R2: mocks.r2 }, cf: undefined, ctx: null }),
+}))
+
+vi.mock('@/lib/database', () => {
+  // A thenable that also exposes `.orderBy()` so both
+  // `select().from().where()` and `select().from().where().orderBy()` work.
+  const thenable = (rows: any[]) => ({
+    orderBy: () => Promise.resolve(rows),
+    then: (onF: any, onR: any) => Promise.resolve(rows).then(onF, onR),
+  })
+  return {
+    getDB: () => ({
+      select: () => ({ from: () => ({ where: () => thenable(mocks.db.selectRows) }) }),
+      insert: () => ({
+        values: (v: any) => {
+          mocks.db.inserted.push(v)
+          return Promise.resolve()
+        },
+      }),
+      delete: () => ({
+        where: () => {
+          mocks.db.deleted.push(true)
+          return Promise.resolve()
+        },
+      }),
+    }),
+  }
+})
+
+vi.mock('extract-pdf', () => ({
+  convertPDFToHTML: vi.fn(async () => ({ error: null, html: '<p>pdf text</p>' })),
+}))
+
+vi.mock('extract-webpage', () => ({
+  convertDOCXToHTML: vi.fn(async () => '<p>docx text</p>'),
+  extractContent: vi.fn(async (html: string) => ({
+    error: null,
+    html: '<article>cleaned html</article>',
+  })),
+}))
+
+import {
+  originalObjectKey,
+  extractedObjectKey,
+  extractUploadText,
+  storeUpload,
+  getExtractedUpload,
+  getUserUploadQuota,
+  deleteUploadObjects,
+  MAX_FILE_SIZE_BYTES,
+  USER_STORAGE_QUOTA_BYTES,
+  SUPPORTED_UPLOAD_EXTENSIONS,
+} from '../index'
+
+beforeEach(() => {
+  mocks.r2.store.clear()
+  mocks.r2.put.mockClear()
+  mocks.r2.get.mockClear()
+  mocks.r2.delete.mockClear()
+  mocks.db.selectRows = []
+  mocks.db.inserted = []
+  mocks.db.deleted = []
+})
+
+describe('object key builders', () => {
+  it('builds the original object key from id + extension', () => {
+    expect(originalObjectKey('abc123', 'pdf')).toBe('abc123.pdf')
+  })
+
+  it('builds the extracted object key from id', () => {
+    expect(extractedObjectKey('abc123')).toBe('abc123-extracted.json')
+  })
+})
+
+describe('constants', () => {
+  it('exposes the expected limits', () => {
+    expect(MAX_FILE_SIZE_BYTES).toBe(50 * 1024 * 1024)
+    expect(USER_STORAGE_QUOTA_BYTES).toBe(1024 * 1024 * 1024)
+    expect(SUPPORTED_UPLOAD_EXTENSIONS).toContain('pdf')
+    expect(SUPPORTED_UPLOAD_EXTENSIONS).toContain('docx')
+  })
+})
+
+describe('extractUploadText', () => {
+  it('returns plain text unchanged for txt/md', async () => {
+    const buf = Buffer.from('hello world', 'utf-8')
+    expect(await extractUploadText(buf, 'a.txt', 'txt')).toBe('hello world')
+    expect(await extractUploadText(buf, 'a.md', 'md')).toBe('hello world')
+  })
+
+  it('extracts HTML content via extract-webpage', async () => {
+    const buf = Buffer.from('<html><body>x</body></html>', 'utf-8')
+    expect(await extractUploadText(buf, 'a.html', 'html')).toBe(
+      '<article>cleaned html</article>',
+    )
+  })
+
+  it('converts PDF to HTML via extract-pdf', async () => {
+    const out = await extractUploadText(Buffer.from('%PDF'), 'a.pdf', 'pdf')
+    expect(out).toBe('<p>pdf text</p>')
+  })
+
+  it('converts DOCX to HTML via extract-webpage', async () => {
+    const out = await extractUploadText(Buffer.from('PK'), 'a.docx', 'docx')
+    expect(out).toBe('<p>docx text</p>')
+  })
+
+  it('returns an empty string when extraction throws', async () => {
+    const { convertPDFToHTML } = await import('extract-pdf')
+    ;(convertPDFToHTML as any).mockRejectedValueOnce(new Error('boom'))
+    expect(await extractUploadText(Buffer.from('%PDF'), 'a.pdf', 'pdf')).toBe('')
+  })
+})
+
+describe('storeUpload', () => {
+  it('stores the original file and extracted JSON in R2 and records the upload', async () => {
+    await storeUpload({
+      fileId: 'file-1',
+      fileName: 'notes.txt',
+      fileExtension: 'txt',
+      size: 11,
+      userId: 'user-1',
+      originalBuffer: Buffer.from('hello world', 'utf-8'),
+      extracted: { title: 'notes.txt', content: 'hello world' },
+    })
+
+    // Original + extracted objects both written to the uploads bucket.
+    expect(mocks.r2.store.get('file-1.txt')).toBe('hello world')
+    const extractedRaw = mocks.r2.store.get('file-1-extracted.json')
+    expect(extractedRaw).toBeDefined()
+    expect(JSON.parse(extractedRaw!)).toEqual({
+      title: 'notes.txt',
+      content: 'hello world',
+    })
+
+    // Quota accounting record inserted for the authenticated user.
+    expect(mocks.db.inserted).toHaveLength(1)
+    expect(mocks.db.inserted[0]).toMatchObject({
+      fileId: 'file-1',
+      userId: 'user-1',
+      fileName: 'notes.txt',
+      fileExtension: 'txt',
+      size: 11,
+    })
+  })
+
+  it('skips the original object and the DB record for guest uploads', async () => {
+    await storeUpload({
+      fileId: 'file-2',
+      fileName: 'page',
+      fileExtension: 'url',
+      size: 5,
+      userId: null,
+      extracted: { title: 'page', content: 'body', url: 'https://x.test' },
+    })
+
+    // Only the extracted JSON is written (no original buffer supplied).
+    expect(mocks.r2.store.has('file-2-extracted.json')).toBe(true)
+    expect(mocks.db.inserted).toHaveLength(0)
+  })
+})
+
+describe('getExtractedUpload', () => {
+  it('reads and parses the extracted JSON back from R2', async () => {
+    await storeUpload({
+      fileId: 'file-3',
+      fileName: 'doc.md',
+      fileExtension: 'md',
+      size: 3,
+      userId: null,
+      extracted: { title: 'Doc', content: 'abc' },
+    })
+
+    const extracted = await getExtractedUpload('file-3')
+    expect(extracted).toEqual({ title: 'Doc', content: 'abc' })
+  })
+
+  it('returns null for a missing file', async () => {
+    expect(await getExtractedUpload('does-not-exist')).toBeNull()
+  })
+
+  it('applies defaults for a payload missing fields', async () => {
+    mocks.r2.store.set('file-4-extracted.json', JSON.stringify({}))
+    const extracted = await getExtractedUpload('file-4')
+    expect(extracted).toEqual({ title: 'Uploaded Document', content: '' })
+  })
+})
+
+describe('getUserUploadQuota', () => {
+  it('sums recorded sizes and reports remaining space', async () => {
+    mocks.db.selectRows = [{ size: 100 }, { size: 200 }]
+    const quota = await getUserUploadQuota('user-1', 50)
+    expect(quota.used).toBe(300)
+    expect(quota.quota).toBe(USER_STORAGE_QUOTA_BYTES)
+    expect(quota.remaining).toBe(USER_STORAGE_QUOTA_BYTES - 300)
+    expect(quota.allowed).toBe(true)
+  })
+
+  it('disallows an upload that would exceed the quota', async () => {
+    mocks.db.selectRows = [{ size: USER_STORAGE_QUOTA_BYTES }]
+    const quota = await getUserUploadQuota('user-1', 1)
+    expect(quota.remaining).toBe(0)
+    expect(quota.allowed).toBe(false)
+  })
+})
+
+describe('deleteUploadObjects', () => {
+  it('deletes both the extracted JSON and the original object', async () => {
+    await storeUpload({
+      fileId: 'file-5',
+      fileName: 'notes.txt',
+      fileExtension: 'txt',
+      size: 4,
+      userId: null,
+      originalBuffer: Buffer.from('data', 'utf-8'),
+      extracted: { title: 'notes.txt', content: 'data' },
+    })
+    expect(mocks.r2.store.size).toBe(2)
+
+    await deleteUploadObjects('file-5', 'txt')
+    expect(mocks.r2.store.has('file-5-extracted.json')).toBe(false)
+    expect(mocks.r2.store.has('file-5.txt')).toBe(false)
+  })
+})

--- a/packages/chat-agent-toolkit/test/upload-file-loader.test.ts
+++ b/packages/chat-agent-toolkit/test/upload-file-loader.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Tests for uploaded-file resolution in the search pipeline.
+ *
+ * Verifies that when a chat request carries uploaded `fileIds`, the registered
+ * upload loader is used to resolve them and the extracted file content is
+ * folded into the answer context (i.e. it is transferred over to the LLM).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  registerUploadFileLoader,
+  rerankDocs,
+  processDocs,
+} from '../src/tools/search/doc-utils';
+import type { Document } from '../src/tools/search/document';
+
+describe('rerankDocs with an uploaded file loader', () => {
+  it('resolves fileIds via the registered loader and includes their content', async () => {
+    const loader = vi.fn(async (fileId: string) => ({
+      title: `Title ${fileId}`,
+      content: `Extracted content for ${fileId}`,
+    }));
+    registerUploadFileLoader(loader);
+
+    const result = await rerankDocs('analyze', [], ['file-abc'], 'balanced');
+
+    expect(loader).toHaveBeenCalledWith('file-abc');
+    expect(result).toHaveLength(1);
+    expect(result[0].pageContent).toBe('Extracted content for file-abc');
+    expect(result[0].metadata.title).toBe('Title file-abc');
+    expect(result[0].metadata.url).toBe('File');
+  });
+
+  it('places uploaded file docs ahead of web results in the context', async () => {
+    registerUploadFileLoader(async (fileId) => ({
+      title: 'Uploaded',
+      content: 'FILE_BODY',
+    }));
+
+    const webDocs: Document[] = [
+      { pageContent: 'WEB_BODY', metadata: { title: 'Web', url: 'https://x.test' } },
+    ];
+
+    const result = await rerankDocs('analyze', webDocs, ['file-1'], 'speed');
+
+    expect(result[0].pageContent).toBe('FILE_BODY');
+    expect(result[1].pageContent).toBe('WEB_BODY');
+
+    // The formatted context handed to the LLM contains the file content.
+    const context = processDocs(result);
+    expect(context).toContain('FILE_BODY');
+  });
+
+  it('skips files whose loader returns null', async () => {
+    registerUploadFileLoader(async () => null);
+    const result = await rerankDocs('analyze', [], ['missing'], 'balanced');
+    expect(result).toHaveLength(0);
+  });
+
+  it('tolerates a loader that throws and yields no file docs', async () => {
+    registerUploadFileLoader(async () => {
+      throw new Error('loader boom');
+    });
+    const result = await rerankDocs('analyze', [], ['bad'], 'balanced');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns docs unchanged when there are no docs and no fileIds', async () => {
+    const result = await rerankDocs('analyze', [], [], 'balanced');
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/research-agent-ui/src/components/FileUpload/FilePreviewCard.tsx
+++ b/packages/research-agent-ui/src/components/FileUpload/FilePreviewCard.tsx
@@ -30,6 +30,13 @@ export const FilePreviewCard: React.FC<FilePreviewCardProps> = ({ file, onRemove
                 <div className="w-full h-full relative">
                     <img src={file.preview!} alt={file.file.name} className="w-full h-full object-cover" />
                     <div className="absolute inset-0 bg-black/20 group-hover:bg-black/0 transition-colors" />
+                    {/* File size badge overlaid on the generated preview square */}
+                    <span
+                        className="absolute bottom-1 left-1 px-1.5 py-0.5 rounded-md bg-black/60 text-white text-[10px] font-medium leading-none backdrop-blur-sm pointer-events-none"
+                        title={file.file.name}
+                    >
+                        {formatFileSize(file.file.size)}
+                    </span>
                 </div>
             ) : (
                 <div className="w-full h-full p-3 flex flex-col justify-between">

--- a/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
+++ b/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
@@ -19,6 +19,14 @@ import { agentChat, saveMessage } from "qwksearch-api-client";
 const ARTICLE_PREFETCH_COUNT = 3;
 
 /**
+ * Query used when the user attaches files but types no message. Mirrors the
+ * server's `DEFAULT_UPLOAD_ANALYSIS_PROMPT` so a file-only send is treated as
+ * "analyse the uploaded file(s)".
+ */
+const DEFAULT_UPLOAD_ANALYSIS_PROMPT =
+  "Analyze the uploaded file(s) and summarize the key points.";
+
+/**
  * Generates a 14-char hex message ID using the Web Crypto API, matching the
  * format of server-generated IDs (`crypto.randomBytes(7).toString("hex")`).
  * Node's `crypto` module is unavailable in the browser bundle.
@@ -148,8 +156,17 @@ export async function sendMessage(
       ? Number(localStorage.getItem(THINKING_TIME_KEY) ?? "0") || 0
       : 0;
 
-  // Prevent duplicate sends or empty messages
-  if (loading || !message) return;
+  // Prevent duplicate sends. An empty message is allowed when files are
+  // attached — it is treated as "analyse the uploaded file(s)". A truly empty
+  // send (no text, no files) is ignored.
+  if (loading) return;
+  const trimmedMessage = message?.trim() ?? "";
+  const hasFiles = Array.isArray(fileIds) && fileIds.length > 0;
+  if (!trimmedMessage && !hasFiles) return;
+
+  // The text shown as the user's turn and sent to the API. When blank with
+  // files attached, fall back to the default analysis prompt.
+  const effectiveMessage = trimmedMessage ? message : DEFAULT_UPLOAD_ANALYSIS_PROMPT;
 
   // Create a new AbortController for this request
   const abortController = new AbortController();
@@ -182,7 +199,7 @@ export async function sendMessage(
   setMessages((prevMessages) => [
     ...prevMessages,
     {
-      content: message,
+      content: effectiveMessage,
       messageId: messageId,
       chatId: chatId,
       role: "user",
@@ -334,7 +351,7 @@ export async function sendMessage(
         // Update chat history with the complete exchange
         setChatHistory((prevHistory) => [
           ...prevHistory,
-          ["human", message],
+          ["human", effectiveMessage],
           ["assistant", receivedMessage],
         ]);
 
@@ -407,7 +424,7 @@ export async function sendMessage(
         message: {
           messageId: messageId,
           chatId: chatId,
-          content: message,
+          content: effectiveMessage,
         },
         optimizationMode: optimizationMode as "speed" | "balanced" | "quality",
         focusMode: focusMode,
@@ -464,7 +481,7 @@ export async function sendMessage(
       if (receivedMessage) {
         setChatHistory((prevHistory) => [
           ...prevHistory,
-          ["human", message],
+          ["human", effectiveMessage],
           ["assistant", receivedMessage],
         ]);
       }


### PR DESCRIPTION
## Summary
This PR adds comprehensive file upload support to the chat system, allowing users to attach files (PDF, DOCX, TXT, MD, HTML) and have their extracted content included in the LLM context. When files are attached without message text, a default analysis prompt is automatically used.

## Key Changes

### Upload Management
- **New upload helpers module** (`apps/qwksearch-web/lib/uploads/index.ts`): Centralized management for file uploads with R2 storage integration, including:
  - Text extraction from multiple file formats (PDF, DOCX, HTML, TXT, MD)
  - Original file and extracted JSON storage in R2
  - User storage quota tracking and enforcement (1GB per user, 50MB per file)
  - Upload deletion and cleanup utilities
- **Comprehensive test suite** for upload operations with mocked R2 and database

### Chat Schema & Validation
- **Updated message schema** to allow empty content when files are attached
- **New `resolveMessageContent()` function** that:
  - Returns user-typed text verbatim when present
  - Falls back to `DEFAULT_UPLOAD_ANALYSIS_PROMPT` ("Analyze the uploaded file(s) and summarize the key points.") when message is blank but files are attached
  - Returns `null` when neither text nor files are provided
- **Body-level validation** enforcing that requests contain either message text or attached files
- **Updated tests** to verify blank messages with files are accepted

### Server-Side Handler
- **Chat request handler** (`handler.ts`) now:
  - Uses `resolveMessageContent()` to determine effective query
  - Logs when default analysis prompt is substituted
  - Passes file IDs to the search pipeline for context inclusion
  - Rejects requests with neither text nor files

### Client-Side Integration
- **File upload UI** (`FilePreviewCard.tsx`): Added file size badge overlay on preview thumbnails
- **Message sending logic** (`sendMessage.ts`):
  - Allows blank message submission when files are attached
  - Uses matching `DEFAULT_UPLOAD_ANALYSIS_PROMPT` for consistency with server
  - Displays effective message (original or default prompt) in chat history
  - Prevents truly empty sends (no text, no files)

### Search Pipeline
- **Upload file loader** (`upload-file-loader.test.ts`): New test suite verifying:
  - Registered loader resolves file IDs to extracted content
  - Uploaded file docs are prioritized ahead of web results
  - Graceful handling of missing or failed file loads
  - Extracted content is properly folded into answer context for the LLM

## Implementation Details
- File extraction uses `extract-pdf` for PDFs and `extract-webpage` for DOCX/HTML
- Extracted content is stored as JSON with title and content fields
- User quota is tracked per-file with remaining space calculations
- Both client and server use identical default analysis prompt for consistency
- Upload operations are fully tested with in-memory mocks for R2 and database

https://claude.ai/code/session_0139rqkZGDbnj9eDbgTXhgz3