### PR TITLE
Make Google One Tap conditional on backend provider configuration

### DIFF
--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import {
   ChatProvider,
   SessionProvider,
@@ -32,6 +33,18 @@ configureResearchAgentUI({
 });
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  // Google One Tap should only be prompted when the backend actually has the
+  // Google provider configured — otherwise the prompt can only fail (a
+  // sign-in with no provider to complete it against).
+  const [googleOneTapEnabled, setGoogleOneTapEnabled] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/auth/providers')
+      .then((res) => res.json())
+      .then((data) => setGoogleOneTapEnabled(!!data.providers?.includes('google')))
+      .catch(() => setGoogleOneTapEnabled(false));
+  }, []);
+
   return (
     <ThemeProvider
       attribute="class"
@@ -39,7 +52,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       enableSystem
       disableTransitionOnChange
     >
-      <SessionProvider authClient={authClient}>
+      <SessionProvider authClient={authClient} enableGoogleOneTap={googleOneTapEnabled}>
         <ExtractPanelProvider>
           <ChatProvider>
             <CategoryDockProvider>

--- a/packages/research-agent-ui/src/hooks/useSession.tsx
+++ b/packages/research-agent-ui/src/hooks/useSession.tsx
@@ -33,10 +33,18 @@ const SessionContext = createContext<SessionContextType>({
 export function SessionProvider({
   children,
   authClient,
+  enableGoogleOneTap = true,
 }: {
   children: React.ReactNode;
   /** Configured better-auth (or compatible) client used to manage the session. */
   authClient: ResearchAgentAuthClient;
+  /**
+   * Whether to prompt Google One Tap for unauthenticated users. Callers whose
+   * backend doesn't have the Google provider configured should pass `false`
+   * to avoid triggering a One Tap prompt that can only fail (the app has no
+   * way to resolve the resulting sign-in). Defaults to `true`.
+   */
+  enableGoogleOneTap?: boolean;
 }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -60,7 +68,7 @@ export function SessionProvider({
 
   // Prompt Google One Tap sign-in once we know the user is unauthenticated.
   useEffect(() => {
-    if (isLoading || user) return;
+    if (isLoading || user || !enableGoogleOneTap) return;
     authClient.oneTap({
       fetchOptions: {
         onSuccess: async () => {
@@ -69,7 +77,7 @@ export function SessionProvider({
         },
       },
     });
-  }, [isLoading, user]);
+  }, [isLoading, user, enableGoogleOneTap]);
 
   const signIn = () => {
     authClient.signIn.social({


### PR DESCRIPTION
## Summary
This PR makes the Google One Tap sign-in prompt conditional based on whether the backend has the Google provider actually configured. This prevents unnecessary failed authentication attempts when the Google provider isn't available.

## Key Changes
- Added `enableGoogleOneTap` prop to `SessionProvider` component (defaults to `true` for backward compatibility)
- Added backend provider detection in the web app's `Providers` component that fetches `/api/auth/providers` to check if Google is configured
- Updated the Google One Tap effect hook to respect the `enableGoogleOneTap` flag and skip prompting when disabled
- Added comprehensive JSDoc documentation explaining the purpose and usage of the new prop

## Implementation Details
- The provider check is performed once on component mount via `useEffect` in the web app layer
- If the API call fails or Google is not in the providers list, One Tap is disabled to fail safely
- The `enableGoogleOneTap` dependency is properly included in the effect dependency array to ensure the hook respects changes to this flag
- This maintains backward compatibility by defaulting to `true` for existing implementations that don't pass the prop

https://claude.ai/code/session_01WGcUjZ12xXd8h9wGs4HFHd