### PR TITLE
Refactor API handlers to use chatModel instead of provider

### DIFF
--- a/packages/research-agent-ui/src/api/handlers/article-followups.ts
+++ b/packages/research-agent-ui/src/api/handlers/article-followups.ts
@@ -1,13 +1,11 @@
 import ModelRegistry from "chat-agent-toolkit/models/registry";
 import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
-import { eq } from "drizzle-orm";
 import type { ArticleDeps } from "../types";
 
 interface ArticleFollowupsBody {
   article: string;
   chatHistory?: Array<{ role: string; content: string }>;
   maxQuestions?: number;
-  provider?: string;
   chatModel?: ModelWithProvider;
 }
 
@@ -15,55 +13,25 @@ export function createArticleFollowupsHandler(deps: ArticleDeps) {
   return async (req: Request): Promise<Response> => {
     try {
       const body: ArticleFollowupsBody = await req.json();
-      const {
-        article,
-        chatHistory = [],
-        maxQuestions = 5,
-        provider = "groq",
-        chatModel,
-      } = body;
+      const { article, chatHistory = [], maxQuestions = 5, chatModel } = body;
 
       if (!article) {
         return Response.json({ error: "Article is required" }, { status: 400 });
       }
 
-      const db = deps.getDB();
-      const userId = await deps.getUserId();
-      let user = null;
-      let apiKey = null;
-
-      if (userId) {
-        user = await db.query.user.findFirst({
-          where: eq(deps.userSchema.id, userId),
-        });
-      }
-
-      if (user) {
-        apiKey = user.settings?.providerApiKeys?.find(
-          (key: any) => key.provider == provider,
-        )?.key;
-      }
-
-      if (!apiKey) {
-        apiKey = provider == "groq" ? deps.getEnv("GROQ_API_KEY") : null;
-      }
-
-      if (!apiKey) {
-        return Response.json({ error: "API key is required" }, { status: 500 });
-      }
-
       const registry = new ModelRegistry();
       let llm;
 
-      if (chatModel) {
-        llm = await registry.loadChatModel(chatModel.providerId, chatModel.key);
-      } else {
-        llm = await registry.loadChatModel("groq", "llama-3.3-70b-versatile");
-      }
-
-      if (!llm) {
+      try {
+        llm = await registry.loadChatModel(chatModel?.providerId, chatModel?.key);
+      } catch (error) {
         return Response.json(
-          { error: "Failed to load language model" },
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to load language model",
+          },
           { status: 500 },
         );
       }

--- a/packages/research-agent-ui/src/api/handlers/article-qa.ts
+++ b/packages/research-agent-ui/src/api/handlers/article-qa.ts
@@ -1,13 +1,11 @@
 import ModelRegistry from "chat-agent-toolkit/models/registry";
 import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
-import { eq } from "drizzle-orm";
 import type { ArticleDeps } from "../types";
 
 interface ArticleQABody {
   article: string;
   question: string;
   chatHistory?: Array<{ role: string; content: string }>;
-  provider?: string;
   chatModel?: ModelWithProvider;
 }
 
@@ -15,13 +13,7 @@ export function createArticleQAHandler(deps: ArticleDeps) {
   return async (req: Request): Promise<Response> => {
     try {
       const body: ArticleQABody = await req.json();
-      const {
-        article,
-        question,
-        chatHistory = [],
-        provider = "groq",
-        chatModel,
-      } = body;
+      const { article, question, chatHistory = [], chatModel } = body;
 
       if (!article || !question) {
         return Response.json(
@@ -30,43 +22,19 @@ export function createArticleQAHandler(deps: ArticleDeps) {
         );
       }
 
-      const db = deps.getDB();
-      const userId = await deps.getUserId();
-      let user = null;
-      let apiKey = null;
-
-      if (userId) {
-        user = await db.query.user.findFirst({
-          where: eq(deps.userSchema.id, userId),
-        });
-      }
-
-      if (user) {
-        apiKey = user.settings?.providerApiKeys?.find(
-          (key: any) => key.provider == provider,
-        )?.key;
-      }
-
-      if (!apiKey) {
-        apiKey = provider == "groq" ? deps.getEnv("GROQ_API_KEY") : null;
-      }
-
-      if (!apiKey) {
-        return Response.json({ error: "API key is required" }, { status: 500 });
-      }
-
       const registry = new ModelRegistry();
       let llm;
 
-      if (chatModel) {
-        llm = await registry.loadChatModel(chatModel.providerId, chatModel.key);
-      } else {
-        llm = await registry.loadChatModel("groq", "llama-3.3-70b-versatile");
-      }
-
-      if (!llm) {
+      try {
+        llm = await registry.loadChatModel(chatModel?.providerId, chatModel?.key);
+      } catch (error) {
         return Response.json(
-          { error: "Failed to load language model" },
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to load language model",
+          },
           { status: 500 },
         );
       }

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
@@ -30,6 +30,7 @@ import {
 } from '.';
 import { researchAgentUIConfig } from '../../config';
 import { useSession } from '../../hooks/useSession';
+import { useChat } from '../../hooks/useChat';
 
 const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
   const {
@@ -42,6 +43,7 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
   } = useExtractPanel();
 
   const { isAuthenticated } = useSession();
+  const { chatModelProvider } = useChat();
 
   const isOpen = props.isOpen !== undefined ? props.isOpen : contextIsOpen;
   const onClose = props.onClose || closePanel;
@@ -265,7 +267,7 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
             article,
             question: queryText,
             chatHistory: chatHistory.slice(-5),
-            provider: 'groq',
+            chatModel: chatModelProvider,
           },
         });
 
@@ -300,7 +302,7 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
             article,
             chatHistory: chatHistory.slice(-5),
             maxQuestions,
-            provider: 'groq',
+            chatModel: chatModelProvider,
           },
         });
 


### PR DESCRIPTION
## Summary
This PR refactors the article API handlers to remove hardcoded provider logic and instead accept a `chatModel` parameter that encapsulates both the provider and model information. This simplifies the API contract and removes database/user-specific API key lookup logic from the handlers.

## Key Changes
- **Removed provider parameter**: Eliminated the `provider` field from request bodies in `article-qa.ts` and `article-followups.ts`
- **Removed API key lookup logic**: Deleted database queries and user settings lookups that attempted to retrieve provider API keys from user profiles
- **Simplified model loading**: Changed from conditional logic with fallback to "groq" provider to directly using the provided `chatModel` parameter with optional chaining
- **Improved error handling**: Wrapped model loading in try-catch to provide more descriptive error messages from the registry
- **Updated UI integration**: Modified `ArticleExtractPanel.tsx` to use `chatModelProvider` from the `useChat` hook instead of hardcoding `provider: 'groq'`

## Implementation Details
- The handlers now delegate provider/API key management to the caller, making them more flexible and testable
- Error messages from the model registry are now properly propagated to the client
- The `chatModel` parameter is optional in the request body, allowing the registry to handle defaults if needed
- Removed unused `drizzle-orm` imports from both handler files

https://claude.ai/code/session_01Ko2cRULSqWvmHvT2XXduxu