### PR TITLE
fix(auth): resolve Google sign-in CORS failures on beta subdomain

### DIFF
--- a/apps/qwksearch-web/.env.example
+++ b/apps/qwksearch-web/.env.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 #   openssl rand -base64 32
 BETTER_AUTH_SECRET=replace_with_a_long_random_secret
 
+# Additional origins allowed to make authenticated requests, comma-separated.
+# The apex domain, its subdomains (e.g. beta.), and http://localhost:3000 are
+# trusted by default; add any other hosts (preview URLs, custom domains) here.
+# Example: https://staging.example.com,https://app.example.com
+# BETTER_AUTH_TRUSTED_ORIGINS=
+
 # ============================================================================
 # Discord OAuth
 # ============================================================================

--- a/apps/qwksearch-web/lib/auth/client.ts
+++ b/apps/qwksearch-web/lib/auth/client.ts
@@ -9,8 +9,17 @@ import {
   NEXT_PUBLIC_GOOGLE_CLIENT_ID,
 } from "../config/site";
 
+// Use the current browser origin so auth requests are always same-origin.
+// The app ships its own /api/auth routes on every deployment (qwksearch.com,
+// beta.qwksearch.com, preview builds, localhost), so hardcoding a single
+// baseURL made requests from any other host go cross-origin and fail the CORS
+// preflight (no Access-Control-Allow-Origin header). Fall back to the
+// configured base URL during SSR, where `window` is undefined.
+const baseURL =
+  typeof window !== "undefined" ? window.location.origin : NEXT_PUBLIC_BASE_URL;
+
 export const authClient = createAuthClient({
-  baseURL: NEXT_PUBLIC_BASE_URL,
+  baseURL,
   plugins: [
     oneTapClient({
       clientId: NEXT_PUBLIC_GOOGLE_CLIENT_ID!,

--- a/apps/qwksearch-web/lib/auth/index.ts
+++ b/apps/qwksearch-web/lib/auth/index.ts
@@ -44,8 +44,30 @@ async function authBuilder() {
     };
   }
 
+  // Origins allowed to make authenticated requests. The app is served from
+  // several hosts that all share the same auth backend (production apex, the
+  // `beta.` subdomain, preview builds, and localhost during development).
+  // Without listing them here, better-auth rejects cross-subdomain requests
+  // and omits the CORS headers, which surfaced as a blocked preflight when
+  // signing in from beta.qwksearch.com. Extra origins can be supplied via the
+  // BETTER_AUTH_TRUSTED_ORIGINS env var (comma-separated).
+  const trustedOrigins = Array.from(
+    new Set(
+      [
+        NEXT_PUBLIC_BASE_URL,
+        "https://qwksearch.com",
+        "https://*.qwksearch.com",
+        "http://localhost:3000",
+        ...(process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",") ?? []),
+      ]
+        .map((origin) => origin?.trim())
+        .filter((origin): origin is string => Boolean(origin)),
+    ),
+  );
+
   return betterAuth({
     baseURL: NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
+    trustedOrigins,
     database: drizzleAdapter(db, {
       provider: "sqlite",
       schema,


### PR DESCRIPTION
The browser auth client was hardcoded to baseURL = NEXT_PUBLIC_BASE_URL (https://qwksearch.com), so pages served from beta.qwksearch.com fired sign-in requests cross-origin to qwksearch.com. That triggered a CORS preflight the server rejected (no Access-Control-Allow-Origin), which also aborted the Google FedCM/One Tap prompt.

- client: derive baseURL from window.location.origin in the browser so auth requests are always same-origin (SSR falls back to the env value)
- server: add trustedOrigins covering the apex, its subdomains (*.qwksearch.com), and localhost, extendable via BETTER_AUTH_TRUSTED_ORIGINS, so better-auth accepts and emits CORS headers for cross-subdomain requests
- document BETTER_AUTH_TRUSTED_ORIGINS in .env.example


Claude-Session: https://claude.ai/code/session_01VNtCf4aU8aGaqLAzNVWy8G