### PR TITLE
Replace docs placeholder with embedded editor iframe

### DIFF
--- a/apps/qwksearch-web/app/docs/page.tsx
+++ b/apps/qwksearch-web/app/docs/page.tsx
@@ -2,8 +2,12 @@
 
 export default function Page() {
   return (
-    <div className="flex h-screen w-screen items-center justify-center text-muted-foreground">
-      <p>The docs editor is currently unavailable.</p>
-    </div>
+    <iframe
+      src="https://edit.qwksearch.com/"
+      title="Reason - Research Manager"
+      className="h-full w-full border-0"
+      allow="clipboard-read; clipboard-write; microphone; camera; fullscreen"
+      allowFullScreen
+    />
   )
 }


### PR DESCRIPTION
## Summary
Replaced the unavailable docs editor placeholder with an embedded iframe that loads the external Reason Research Manager editor from `https://edit.qwksearch.com/`.

## Key Changes
- Removed the centered placeholder message indicating the docs editor was unavailable
- Added an iframe component that embeds the external editor application
- Configured the iframe to use full viewport dimensions (`h-full w-full`)
- Enabled necessary permissions for the embedded editor: clipboard access, microphone, camera, and fullscreen capabilities
- Set appropriate accessibility attributes (`title` and `allowFullScreen`)

## Implementation Details
- The iframe is configured with `border-0` to provide a seamless integration with the page layout
- Permissions are explicitly granted via the `allow` attribute to support the editor's full functionality
- The embedded editor now provides a complete user experience without leaving the docs page

https://claude.ai/code/session_01MW1QxoZu98EyDCVuw6979d