### PR TITLE
Fix EventEmitter listener cleanup in stream handler

### DIFF
--- a/apps/qwksearch-web/lib/chat/__tests__/stream-handler.test.ts
+++ b/apps/qwksearch-web/lib/chat/__tests__/stream-handler.test.ts
@@ -1,0 +1,76 @@
+import { EventEmitter } from 'stream'
+import { describe, expect, it, vi } from 'vitest'
+
+// stream-handler only needs the Document *type* from chat-agent-toolkit, which
+// is erased at runtime — stub the module so the runner needn't build it.
+vi.mock('chat-agent-toolkit', () => ({}))
+vi.mock('research-agent-ui/api', () => ({ describeError: (e: unknown) => String(e) }))
+vi.mock('@/lib/database', () => ({ getDB: () => undefined }))
+vi.mock('@/lib/database/schema', () => ({ messages: {} }))
+
+import { handleEmitterEvents } from '../stream-handler'
+
+/** A minimal WritableStreamDefaultWriter stub that records writes. */
+const makeWriter = () => {
+  const chunks: string[] = []
+  const decoder = new TextDecoder()
+  return {
+    chunks,
+    write: vi.fn(async (bytes: Uint8Array) => {
+      chunks.push(decoder.decode(bytes))
+    }),
+    close: vi.fn(async () => {}),
+  } as unknown as WritableStreamDefaultWriter & { chunks: string[] }
+}
+
+/** Waits for all currently-queued microtasks/timers to settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('handleEmitterEvents listener lifecycle', () => {
+  it('detaches all listeners after the "end" event', async () => {
+    const emitter = new EventEmitter()
+    const writer = makeWriter()
+
+    handleEmitterEvents(emitter, writer, new TextEncoder(), 'chat-1', null, undefined)
+
+    emitter.emit('data', JSON.stringify({ type: 'response', data: 'hello' }))
+    emitter.emit('end')
+    await flush()
+
+    expect(emitter.listenerCount('data')).toBe(0)
+    expect(emitter.listenerCount('end')).toBe(0)
+    expect(emitter.listenerCount('error')).toBe(0)
+    expect(writer.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('detaches all listeners after the "error" event', async () => {
+    const emitter = new EventEmitter()
+    const writer = makeWriter()
+
+    handleEmitterEvents(emitter, writer, new TextEncoder(), 'chat-1', null, undefined)
+
+    emitter.emit('error', JSON.stringify({ data: 'boom' }))
+    await flush()
+
+    expect(emitter.listenerCount('data')).toBe(0)
+    expect(emitter.listenerCount('end')).toBe(0)
+    expect(emitter.listenerCount('error')).toBe(0)
+  })
+
+  it('does not accumulate listeners when the bridge is re-attached on a reused emitter', async () => {
+    const emitter = new EventEmitter()
+
+    // Attach and tear down many times over the same emitter. Without cleanup
+    // this would exceed the default 10-listener threshold and warn.
+    for (let i = 0; i < 15; i++) {
+      const writer = makeWriter()
+      handleEmitterEvents(emitter, writer, new TextEncoder(), `chat-${i}`, null, undefined)
+      emitter.emit('end')
+      await flush()
+    }
+
+    expect(emitter.listenerCount('data')).toBe(0)
+    expect(emitter.listenerCount('end')).toBe(0)
+    expect(emitter.listenerCount('error')).toBe(0)
+  })
+})

--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -279,22 +279,16 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       body.thinkingTimeLimit,
     );
 
-    // Surface errors from the agent's EventEmitter that would otherwise crash
-    // the Node process as unhandled "error" events.
-    stream.on("error", (data: string) => {
-      try {
-        const parsed = JSON.parse(data);
-        console.error("[POST /api/agent/chat] agent emitter error:", parsed?.data ?? data);
-      } catch {
-        console.error("[POST /api/agent/chat] agent emitter error (raw):", data);
-      }
-    });
-
     // --- Set up the SSE response stream ---
     const responseStream = new TransformStream();
     const writer = responseStream.writable.getWriter();
     const encoder = new TextEncoder();
 
+    // handleEmitterEvents attaches the sole "error" listener synchronously
+    // here — before the agent's pipeline runs on its deferred macrotask — so
+    // emitted "error" events are always handled (never crashing the process as
+    // an unhandled EventEmitter "error") and its listeners detach on the first
+    // terminal event to avoid accumulating on the emitter.
     handleEmitterEvents(stream, writer, encoder, effectiveMessage.chatId, userId, db);
 
     // --- Persist chat session and human message (authenticated users only) ---

--- a/apps/qwksearch-web/lib/chat/stream-handler.ts
+++ b/apps/qwksearch-web/lib/chat/stream-handler.ts
@@ -102,7 +102,24 @@ export const handleEmitterEvents = async (
     return writer.write(encoder.encode("data: " + JSON.stringify(message) + "\n\n"));
   };
 
-  stream.on("data", (data: string) => {
+  /**
+   * Detaches every listener this bridge attached to the emitter.
+   *
+   * The search agent emits over a fresh {@link EventEmitter} per request, and
+   * the `"data"` listener closes over the accumulated `receivedMessage` buffer
+   * plus the writer, encoder, and DB handle. Detaching on the first terminal
+   * event ("end" or "error") releases those references immediately instead of
+   * keeping them reachable through the emitter, and prevents listeners from
+   * piling up on the emitter — the "Possible EventEmitter memory leak" class of
+   * bug that surfaces once an emitter outlives a single attach/detach cycle.
+   */
+  const cleanup = (): void => {
+    stream.removeListener("data", onData);
+    stream.removeListener("end", onEnd);
+    stream.removeListener("error", onError);
+  };
+
+  const onData = (data: string): void => {
     /** @type {StreamEvent} */
     const parsedData: StreamEvent = JSON.parse(data);
 
@@ -157,9 +174,10 @@ export const handleEmitterEvents = async (
           });
       }
     }
-  });
+  };
 
-  stream.on("end", async () => {
+  const onEnd = async (): Promise<void> => {
+    cleanup();
     await writeSSE({ type: "messageEnd" });
     await writer.close();
 
@@ -182,9 +200,10 @@ export const handleEmitterEvents = async (
           );
         });
     }
-  });
+  };
 
-  stream.on("error", async (data: string) => {
+  const onError = async (data: string): Promise<void> => {
+    cleanup();
     let errorText: string;
     try {
       errorText = JSON.parse(data)?.data ?? data;
@@ -202,5 +221,11 @@ export const handleEmitterEvents = async (
     } catch {
       // Writer may already be closed if a prior frame errored.
     }
-  });
+  };
+
+  stream.on("data", onData);
+  // "end" and "error" are terminal: register with `once` so they auto-detach
+  // after firing, and cleanup() removes the remaining "data" listener.
+  stream.once("end", onEnd);
+  stream.once("error", onError);
 };


### PR DESCRIPTION
## Summary
Refactored the stream event handler to properly detach listeners after terminal events, preventing listener accumulation and memory leaks when emitters are reused across multiple requests.

## Key Changes
- Extracted `onData`, `onEnd`, and `onError` handlers into named functions to enable proper listener management
- Added a `cleanup()` function that removes all three listeners from the emitter
- Changed `stream.on("end")` and `stream.on("error")` to `stream.once()` to auto-detach after firing
- Explicitly call `cleanup()` in both terminal event handlers to remove the remaining "data" listener
- Removed redundant error logging from `handler.ts` since `handleEmitterEvents` now handles all error cases
- Added comprehensive documentation explaining why cleanup is necessary

## Implementation Details
The search agent emits over a fresh `EventEmitter` per request. Previously, listeners were never removed, causing them to accumulate if an emitter was reused. This could trigger Node's "Possible EventEmitter memory leak" warning after 10+ listeners.

The fix uses `stream.once()` for terminal events ("end" and "error") which auto-detach after firing, while `cleanup()` explicitly removes the "data" listener. This ensures all references (accumulated message buffer, writer, encoder, DB handle) are released immediately rather than remaining reachable through the emitter.

The test suite validates that listeners are properly detached after both "end" and "error" events, and that the handler can be safely re-attached to the same emitter multiple times without accumulating listeners.

https://claude.ai/code/session_016SzUgFiLxrmED3w8B9ogP2