### PR TITLE
Add LLM-generated chat titles and activity timestamps

### DIFF
--- a/apps/qwksearch-web/app/api/agent/chat-title/route.ts
+++ b/apps/qwksearch-web/app/api/agent/chat-title/route.ts
@@ -1,0 +1,13 @@
+import { createChatTitleHandler } from "research-agent-ui/api";
+import { getDB } from "@/lib/database";
+import { chats, messages } from "@/lib/database/schema";
+import { getUserId, requireUserId } from "@/lib/auth/session";
+
+const handler = createChatTitleHandler({
+  getDB,
+  requireUserId,
+  getUserId,
+  schema: { chats, messages },
+});
+
+export const { POST } = handler;

--- a/packages/chat-agent-toolkit/src/tools/search/titleGeneratorAgent.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/titleGeneratorAgent.ts
@@ -1,0 +1,61 @@
+/**
+ * @module research/chains/titleGeneratorAgent
+ * @description Generates a short, human-friendly title summarising a chat
+ * conversation using the Vercel AI SDK. Used to give conversations with
+ * multiple turns a meaningful title instead of the truncated first message.
+ */
+import { generateText, type LanguageModel } from "ai";
+import { formatChatHistoryAsString } from "../../utils";
+import type { ChatTurnMessage } from "./meta-search-types";
+
+const titleGeneratorPrompt = `
+You are a title generator for an AI powered search engine. You will be given a conversation between a user and an AI. Generate a concise, descriptive title that captures the overall topic of the whole conversation.
+
+Rules for the title:
+- Maximum 6 words, ideally 3-5.
+- No surrounding quotes, no trailing punctuation.
+- Use title case.
+- Describe the subject matter, not the fact that it is a conversation (e.g. "Quantum Computing Basics", not "A Chat About Quantum Computing").
+
+Return only the title between the XML tags <title> and </title>. For example:
+
+<title>SpaceX Starship Launch Timeline</title>
+
+Conversation:
+{chat_history}
+`;
+
+type TitleGeneratorInput = {
+  chat_history: ChatTurnMessage[];
+};
+
+/**
+ * Extracts the title from the model output, tolerating responses that omit
+ * the XML tags. Falls back to the trimmed raw text, stripped of surrounding
+ * quotes and truncated to a sane length.
+ */
+const parseTitle = (text: string): string => {
+  const match = text.match(/<title>([\s\S]*?)<\/title>/i);
+  const raw = (match ? match[1] : text).trim();
+  return raw.replace(/^["'\s]+|["'\s]+$/g, "").slice(0, 80);
+};
+
+const generateTitle = async (
+  input: TitleGeneratorInput,
+  llm: LanguageModel,
+): Promise<string> => {
+  const prompt = titleGeneratorPrompt.replace(
+    "{chat_history}",
+    formatChatHistoryAsString(input.chat_history),
+  );
+
+  const { text } = await generateText({
+    model: llm,
+    temperature: 0,
+    prompt,
+  });
+
+  return parseTitle(text);
+};
+
+export default generateTitle;

--- a/packages/research-agent-ui/src/api/handlers/chat-title.ts
+++ b/packages/research-agent-ui/src/api/handlers/chat-title.ts
@@ -1,0 +1,80 @@
+import generateTitle from "chat-agent-toolkit/tools/search/titleGeneratorAgent";
+import ModelRegistry from "chat-agent-toolkit/models/registry";
+import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
+import type { ChatTurnMessage } from "chat-agent-toolkit/tools/search/meta-search-types";
+import { eq } from "drizzle-orm";
+import type { ChatsDeps } from "../types";
+
+interface ChatTitleGenerationBody {
+  chatId?: string;
+  chatHistory: any[];
+  chatModel: ModelWithProvider;
+}
+
+/**
+ * Generates a concise LLM title for a conversation and, for authenticated
+ * users who own the chat, persists it to the `chats.title` column. The
+ * generated title is always returned so guest clients can store it locally.
+ */
+export function createChatTitleHandler(deps: ChatsDeps) {
+  const { chats } = deps.schema;
+
+  const POST = async (req: Request): Promise<Response> => {
+    try {
+      const body: ChatTitleGenerationBody = await req.json();
+
+      const chatHistory = body.chatHistory
+        .filter((msg: any) => msg.role === "user" || msg.role === "assistant")
+        .map(
+          (msg: any): ChatTurnMessage => ({
+            role: msg.role,
+            content: String(msg.content ?? ""),
+          }),
+        );
+
+      if (chatHistory.length === 0) {
+        return Response.json({ message: "No conversation content" }, { status: 400 });
+      }
+
+      const registry = new ModelRegistry();
+      const llm = await registry.loadChatModel(
+        body.chatModel.providerId,
+        body.chatModel.key,
+      );
+
+      const title = await generateTitle({ chat_history: chatHistory }, llm);
+
+      if (!title) {
+        return Response.json({ message: "Failed to generate title" }, { status: 500 });
+      }
+
+      // Persist for authenticated owners; guests update local storage client-side.
+      const userId = deps.getUserId ? await deps.getUserId() : null;
+      if (userId && body.chatId) {
+        try {
+          const db = deps.getDB();
+          const chat = await db.query.chats.findFirst({
+            where: eq(chats.id, body.chatId),
+          });
+          if (chat && chat.userId === userId) {
+            await db
+              .update(chats)
+              .set({ title })
+              .where(eq(chats.id, body.chatId))
+              .execute();
+          }
+        } catch (persistErr) {
+          // Non-fatal: still return the generated title to the client.
+          console.error("Failed to persist chat title:", persistErr);
+        }
+      }
+
+      return Response.json({ title }, { status: 200 });
+    } catch (err) {
+      console.error("Error generating chat title:", err);
+      return Response.json({ message: "Failed to generate title" }, { status: 500 });
+    }
+  };
+
+  return { POST };
+}

--- a/packages/research-agent-ui/src/api/handlers/chats.ts
+++ b/packages/research-agent-ui/src/api/handlers/chats.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray, sql, count, or, like } from "drizzle-orm";
+import { eq, and, inArray, sql, count, or, like, max } from "drizzle-orm";
 import type { ChatsDeps } from "../types";
 
 export function createChatsHandler(deps: ChatsDeps) {
@@ -18,6 +18,7 @@ export function createChatsHandler(deps: ChatsDeps) {
           userId: chats.userId,
           files: chats.files,
           messageCount: count(messages.id),
+          lastMessageAt: max(messages.createdAt),
         })
         .from(chats)
         .leftJoin(

--- a/packages/research-agent-ui/src/api/index.ts
+++ b/packages/research-agent-ui/src/api/index.ts
@@ -2,6 +2,7 @@ export * from "./types";
 export * from "./handlers/article-followups";
 export * from "./handlers/article-qa";
 export * from "./handlers/chats";
+export * from "./handlers/chat-title";
 export * from "./handlers/messages";
 export * from "./handlers/providers";
 export * from "./handlers/mcpservers";

--- a/packages/research-agent-ui/src/components/ChatConversation/RecentHistoryChips.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RecentHistoryChips.tsx
@@ -1,20 +1,29 @@
 /**
- * Horizontal row of pill chips linking to the three most recent chat sessions plus the history dropdown trigger.
+ * Horizontal row of pill chips linking to the five most recent chat sessions
+ * plus the history dropdown trigger, followed by a subtle label showing how
+ * long ago the most recent conversation was last active.
  */
 'use client';
 
 import Link from 'next/link';
 import { useHistoryState } from '../ChatHistoryDropdown/useHistoryState';
 import HistoryDropdown from '../ChatHistoryDropdown';
+import { formatRelativeTime } from '../../lib/relative-time';
+
+/** Most recent activity timestamp for a chat, falling back to creation time. */
+const activityTime = (chat: { lastMessageAt?: string | null; createdAt: string }) =>
+  new Date(chat.lastMessageAt || chat.createdAt).getTime();
 
 export default function RecentHistoryChips() {
   const { chats, loading } = useHistoryState();
 
   const recent = [...chats]
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    .slice(0, 3);
+    .sort((a, b) => activityTime(b) - activityTime(a))
+    .slice(0, 5);
 
-  if (loading) return null;
+  if (loading || recent.length === 0) return null;
+
+  const lastActive = formatRelativeTime(recent[0].lastMessageAt || recent[0].createdAt);
 
   return (
     <div className="flex flex-row items-center justify-center gap-2 flex-wrap">
@@ -29,6 +38,11 @@ export default function RecentHistoryChips() {
           {chat.title}
         </Link>
       ))}
+      {lastActive && (
+        <span className="text-xs text-muted-foreground/70 whitespace-nowrap">
+          {lastActive}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/research-agent-ui/src/components/ChatHistoryDropdown/useHistoryState.ts
+++ b/packages/research-agent-ui/src/components/ChatHistoryDropdown/useHistoryState.ts
@@ -11,12 +11,28 @@ import {
   getGuestChats,
   deleteGuestChat,
   clearAllGuestChats,
+  type GuestChat,
 } from "../../lib/guest";
 import { Chat } from "../../types/research";
 import { toast } from "sonner";
 import { listChats, deleteChatById, deleteAllChats, searchChats } from "qwksearch-api-client";
 
 const PINNED_CHATS_KEY = "qwksearch_pinned_chats";
+
+/**
+ * Derives the timestamp of a guest chat's most recent message so history can
+ * show how long ago the conversation was last active. Falls back to the
+ * chat's creation time when no messages carry a usable timestamp.
+ */
+function getLastMessageAt(chat: GuestChat): string {
+  const last = chat.messages?.[chat.messages.length - 1];
+  const raw = last && "createdAt" in last ? (last as { createdAt?: unknown }).createdAt : undefined;
+  if (raw) {
+    const time = new Date(raw as string | number | Date).getTime();
+    if (!Number.isNaN(time)) return new Date(time).toISOString();
+  }
+  return chat.createdAt;
+}
 
 function getPinnedChatIds(): string[] {
   if (typeof window === "undefined") return [];
@@ -97,6 +113,7 @@ export function useHistoryState() {
             ...chat,
             messageCount:
               chat.messages?.filter((m) => m.role === "user").length ?? 0,
+            lastMessageAt: getLastMessageAt(chat),
           }));
           setChats(guestChats);
           return;
@@ -232,6 +249,7 @@ export function useHistoryState() {
               ...chat,
               messageCount:
                 chat.messages?.filter((m) => m.role === "user").length ?? 0,
+              lastMessageAt: getLastMessageAt(chat),
             })),
           );
         }

--- a/packages/research-agent-ui/src/hooks/useChat/ChatProvider.tsx
+++ b/packages/research-agent-ui/src/hooks/useChat/ChatProvider.tsx
@@ -10,7 +10,8 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { useParams, useSearchParams, useRouter } from 'next/navigation';
 import { ChatTurn } from '../../components/ChatConversation/ChatWindow';
-import { saveGuestChat, GuestChat } from '../../lib/guest';
+import { saveGuestChat, GuestChat, updateGuestChatTitle } from '../../lib/guest';
+import { generateChatTitle } from '../../lib/chatTitle';
 import { useSession } from '../useSession';
 import { chatContext, ChatContextValue } from './ChatContext';
 import { useChatState } from './useChatState';
@@ -58,6 +59,12 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   );
   const abortControllerRef = useRef<AbortController | null>(null);
   const [incognito, setIncognito] = useState(false);
+
+  // LLM-generated conversation titles, keyed by chatId, so the guest-persist
+  // effect keeps them instead of falling back to the first message. A separate
+  // set guards against requesting a title more than once per chat per session.
+  const generatedTitlesRef = useRef<Record<string, string>>({});
+  const titleRequestedRef = useRef<Set<string>>(new Set());
 
   // ============ Effects ============
 
@@ -143,7 +150,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       );
 
       if (turns.length > 0) {
-        const title = turns[0].content.slice(0, 50);
+        const title =
+          generatedTitlesRef.current[state.chatId] ?? turns[0].content.slice(0, 50);
         const guestChat: GuestChat = {
           id: state.chatId,
           title,
@@ -161,6 +169,53 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     isAuthenticated,
     state.focusMode,
     state.files,
+  ]);
+
+  /**
+   * Generate an LLM title for conversations with multiple user turns.
+   *
+   * Once a chat started in this session reaches two or more user messages and
+   * the latest response has finished streaming, request a concise title
+   * summarising the whole conversation. The title is persisted server-side for
+   * authenticated users; for guests it is stored in localStorage and cached in
+   * `generatedTitlesRef` so the persist effect above keeps it. Runs at most
+   * once per chat per session.
+   */
+  useEffect(() => {
+    if (incognito || !state.chatId || !state.isMessagesLoaded) return;
+    // Only for chats originating in this session, not ones loaded from history.
+    if (!state.newChatCreated) return;
+    // Wait until the current response has finished streaming.
+    if (state.loading) return;
+
+    const userTurns = chatTurns.filter((turn) => turn.role === 'user').length;
+    if (userTurns < 2) return;
+
+    const chatId = state.chatId;
+    if (titleRequestedRef.current.has(chatId)) return;
+    titleRequestedRef.current.add(chatId);
+
+    void (async () => {
+      const title = await generateChatTitle(chatId, state.messages);
+      if (!title) {
+        // Allow a retry on the next completed turn if generation failed.
+        titleRequestedRef.current.delete(chatId);
+        return;
+      }
+      generatedTitlesRef.current[chatId] = title;
+      if (!isAuthenticated) {
+        updateGuestChatTitle(chatId, title);
+      }
+    })();
+  }, [
+    chatTurns,
+    state.messages,
+    state.chatId,
+    state.loading,
+    state.isMessagesLoaded,
+    state.newChatCreated,
+    incognito,
+    isAuthenticated,
   ]);
 
   /**

--- a/packages/research-agent-ui/src/lib/chatTitle.ts
+++ b/packages/research-agent-ui/src/lib/chatTitle.ts
@@ -1,0 +1,40 @@
+import grab from "grab-url";
+import { Message } from "../components/ChatConversation/ChatWindow";
+
+/**
+ * Requests an LLM-generated title summarising a conversation. For
+ * authenticated users the server persists the title on the chat; for guests
+ * the caller is responsible for storing the returned title locally. Returns
+ * an empty string on failure so callers can keep the existing title.
+ */
+export const generateChatTitle = async (
+  chatId: string,
+  chatHistory: Message[],
+): Promise<string> => {
+  const chatModel = localStorage.getItem("chatModelKey");
+  const chatModelProvider = localStorage.getItem("chatModelProviderId");
+
+  const filteredHistory = chatHistory
+    .filter((msg) => msg.role === "user" || msg.role === "assistant")
+    .map((msg) => ({ role: msg.role, content: (msg as any).content ?? "" }));
+
+  if (filteredHistory.length === 0) return "";
+
+  try {
+    const data = await grab<{ title?: string }>(`agent/chat-title`, {
+      method: "POST",
+      body: JSON.stringify({
+        chatId,
+        chatHistory: filteredHistory,
+        chatModel: {
+          providerId: chatModelProvider,
+          key: chatModel,
+        },
+      }),
+    });
+
+    return typeof data.title === "string" ? data.title : "";
+  } catch {
+    return "";
+  }
+};

--- a/packages/research-agent-ui/src/lib/relative-time.ts
+++ b/packages/research-agent-ui/src/lib/relative-time.ts
@@ -1,0 +1,31 @@
+/**
+ * Formats a timestamp as a compact "time ago" string (e.g. "5 min ago",
+ * "2 hr ago", "3 days ago"). Used by chat history to show how long ago a
+ * conversation was last active.
+ */
+export function formatRelativeTime(input: string | number | Date): string {
+  const then = new Date(input).getTime();
+  if (Number.isNaN(then)) return "";
+
+  const seconds = Math.round((Date.now() - then) / 1000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds} sec ago`;
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days} day${days === 1 ? "" : "s"} ago`;
+
+  const weeks = Math.round(days / 7);
+  if (weeks < 5) return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+
+  const years = Math.round(days / 365);
+  return `${years} year${years === 1 ? "" : "s"} ago`;
+}

--- a/packages/research-agent-ui/src/types/research.ts
+++ b/packages/research-agent-ui/src/types/research.ts
@@ -89,6 +89,8 @@ export interface Chat {
   id: string;
   title: string;
   createdAt: string;
+  /** Timestamp of the most recent message, used for "last active" display. */
+  lastMessageAt?: string | null;
   focusMode: string;
   userId?: string | null;
   files?: ChatFile[];


### PR DESCRIPTION
## Summary
This PR enhances the chat history UI by automatically generating concise LLM-based titles for conversations and displaying when each chat was last active. Previously, chats defaulted to truncated first messages with no activity indicators.

## Key Changes

- **LLM Title Generation**: Added a new `/api/agent/chat-title` endpoint that uses an LLM to generate descriptive titles (3-5 words) for conversations. Titles are persisted server-side for authenticated users and stored locally for guests.

- **Title Generator Agent**: Implemented `titleGeneratorAgent.ts` in chat-agent-toolkit that uses the Vercel AI SDK to summarize multi-turn conversations with configurable rules (title case, no punctuation, max 6 words).

- **Activity Timestamps**: Extended the `Chat` type with an optional `lastMessageAt` field to track the most recent message timestamp, falling back to creation time when unavailable.

- **Relative Time Formatting**: Added `formatRelativeTime()` utility to display compact "time ago" strings (e.g., "5 min ago", "2 days ago") in the chat history UI.

- **Enhanced Recent History Display**: Updated `RecentHistoryChips` component to:
  - Show up to 5 recent chats (increased from 3)
  - Sort by last activity time instead of creation time
  - Display a subtle timestamp showing when the most recent chat was last active
  - Handle empty chat lists gracefully

- **Automatic Title Generation in Chat Provider**: Added logic to automatically request LLM titles once a chat reaches 2+ user turns and the response finishes streaming. Caches generated titles to prevent duplicate requests and ensures guest chats retain them across sessions.

- **Guest Chat Title Persistence**: Extended guest chat storage to support title updates via `updateGuestChatTitle()`.

## Implementation Details

- Title generation is request-gated per chat per session to avoid redundant API calls
- Server-side title persistence is non-fatal; failures don't block the client from using the generated title
- The title generator uses temperature=0 for deterministic output and includes XML tag parsing with fallback handling
- Chat history sorting now uses `lastMessageAt` (or `createdAt` as fallback) to properly reflect activity order

https://claude.ai/code/session_019WZenS6M9FWu1m38xjKggH