### PR TITLE
Refactor AI calls to use generateText and improve chat history UI

### DIFF
--- a/packages/research-agent-ui/package.json
+++ b/packages/research-agent-ui/package.json
@@ -65,6 +65,7 @@
     "@radix-ui/react-slot": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.2.9",
     "@ricky0123/vad-web": "^0.0.30",
+    "ai": "^5.0.0",
     "chat-agent-toolkit": "workspace:*",
     "domain-rank": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/packages/research-agent-ui/src/api/handlers/article-followups.ts
+++ b/packages/research-agent-ui/src/api/handlers/article-followups.ts
@@ -1,3 +1,4 @@
+import { generateText } from "ai";
 import ModelRegistry from "chat-agent-toolkit/models/registry";
 import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
 import type { ArticleDeps } from "../types";
@@ -55,15 +56,13 @@ ${historyContext}
 
 Generate ${maxQuestions} follow-up questions that would help readers dive deeper into this article.`;
 
-      const stream = await llm.stream([
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ]);
-
-      let fullResponse = "";
-      for await (const chunk of stream) {
-        fullResponse += chunk.content;
-      }
+      const { text: fullResponse } = await generateText({
+        model: llm,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      });
 
       const questions = fullResponse
         .split("\n")

--- a/packages/research-agent-ui/src/api/handlers/article-qa.ts
+++ b/packages/research-agent-ui/src/api/handlers/article-qa.ts
@@ -1,3 +1,4 @@
+import { generateText } from "ai";
 import ModelRegistry from "chat-agent-toolkit/models/registry";
 import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
 import type { ArticleDeps } from "../types";
@@ -62,15 +63,13 @@ User question: ${question}
 
 Please provide a helpful answer based on the article content above.`;
 
-      const stream = await llm.stream([
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ]);
-
-      let fullResponse = "";
-      for await (const chunk of stream) {
-        fullResponse += chunk.content;
-      }
+      const { text: fullResponse } = await generateText({
+        model: llm,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      });
 
       return Response.json({ content: fullResponse, success: true });
     } catch (error) {

--- a/packages/research-agent-ui/src/components/ChatConversation/RecentHistoryChips.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RecentHistoryChips.tsx
@@ -1,7 +1,8 @@
 /**
  * Horizontal row of pill chips linking to the five most recent chat sessions
- * plus the history dropdown trigger, followed by a subtle label showing how
- * long ago the most recent conversation was last active.
+ * plus the history dropdown trigger. Each pill shows the chat title followed
+ * by a subtle italic label showing how long ago that conversation was last
+ * active.
  */
 'use client';
 
@@ -23,26 +24,27 @@ export default function RecentHistoryChips() {
 
   if (loading || recent.length === 0) return null;
 
-  const lastActive = formatRelativeTime(recent[0].lastMessageAt || recent[0].createdAt);
-
   return (
     <div className="flex flex-row items-center justify-center gap-2 flex-wrap">
       <HistoryDropdown showLabel />
-      {recent.map((chat) => (
-        <Link
-          key={chat.id}
-          href={`/c/${chat.id}`}
-          className="px-3 py-1 rounded-full text-xs text-muted-foreground bg-secondary hover:bg-secondary/80 hover:text-foreground transition-colors duration-150 truncate max-w-[160px]"
-          title={chat.title}
-        >
-          {chat.title}
-        </Link>
-      ))}
-      {lastActive && (
-        <span className="text-xs text-muted-foreground/70 whitespace-nowrap">
-          {lastActive}
-        </span>
-      )}
+      {recent.map((chat) => {
+        const timeAgo = formatRelativeTime(chat.lastMessageAt || chat.createdAt);
+        return (
+          <Link
+            key={chat.id}
+            href={`/c/${chat.id}`}
+            className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs text-muted-foreground bg-secondary hover:bg-secondary/80 hover:text-foreground transition-colors duration-150 max-w-[220px]"
+            title={chat.title}
+          >
+            <span className="truncate">{chat.title}</span>
+            {timeAgo && (
+              <span className="italic text-muted-foreground/70 whitespace-nowrap">
+                {timeAgo}
+              </span>
+            )}
+          </Link>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR refactors AI model interactions to use the `generateText` utility from the `ai` package and improves the recent chat history UI to display timestamps inline with each chat pill.

## Key Changes

- **Refactored AI API handlers**: Updated `article-followups.ts` and `article-qa.ts` to use `generateText()` instead of manually streaming and concatenating chunks. This simplifies the code and provides a cleaner abstraction for non-streaming text generation.

- **Enhanced RecentHistoryChips component**: 
  - Modified the UI to display each chat's last active timestamp inline with the chat title, rather than showing only the most recent conversation's timestamp separately
  - Each chat pill now contains both the title and a subtle italic timestamp label
  - Increased max-width from 160px to 220px to accommodate the additional timestamp content
  - Updated component documentation to reflect the new behavior

- **Added `ai` package dependency**: Added `ai@^5.0.0` to support the new `generateText` utility function

## Implementation Details

The refactoring in the API handlers eliminates the need for manual stream iteration and string concatenation, making the code more maintainable and less error-prone. The UI improvements provide better context about when each conversation was last active without requiring users to hover or interact with individual chips.

https://claude.ai/code/session_01AsacRC2rDm3QzYAicSWy5B