### PR TITLE
Add keyboard shortcuts and Storybook stories for UI components

### DIFF
--- a/packages/extract-webpage/src/html-to-content/html-utils.ts
+++ b/packages/extract-webpage/src/html-to-content/html-utils.ts
@@ -206,96 +206,229 @@ export function convertMarkdownToHTML(content, toHtml = true) {
   if (!toHtml) return convertHTMLToMarkdown(content);
 
   return content?.length ? marked.parse(content) : "";
+}
 
-  var html = contentconvertMarkdownToHTML
-    // Convert headers
-    .replace(/^(#{1,6})\s(.+)$/gm, (match, hashes, content) => {
-      const level = hashes.length;
-      return `<h${level}>${content.trim()}</h${level}>`;
-    })
+/**
+ * Escape the HTML-significant characters in a raw string so it can be
+ * safely embedded inside generated HTML (used for code spans/blocks).
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHTMLChars(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
 
-    // Convert bold text
-    .replace(/\*\*(.+?)\*\*/g, "<b>$1</b>")
-
-    // Convert italic text
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-
-    // Convert unordered lists
-    .replace(/^\s*\*\s(.+)$/gm, "<li>$1</li>")
-    .replace(/(<li>.*<\/li>)/s, "<ul>$1</ul>")
-
-    // Convert ordered lists
-    .replace(/^\s*\d+\.\s(.+)$/gm, "<li>$1</li>")
-    .replace(/(<li>.*<\/li>)/s, "<ol>$1</ol>")
-
-    // Convert horizontal rules (---, ___, ***)
-    .replace(/^[-_*]{3,}\s*$/gm, "<hr>")
-
-    // Convert code blocks (```)
-    .replace(/```([^`]+)```/g, "<code>$1</code>")
-
-    .replace(/```(\w*)\n([\s\S]*?)```/g, function (match, lang, code) {
-      code = code
-        .trim()
-        // Remove leading whitespace from each line while preserving relative indentation
-        .replace(/^[ \t]*/gm, "")
-        // Encode HTML special characters
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
-
-      return lang
-        ? `<code class="language-${lang}">${code}</code>`
-        : `<code>${code}</code>`;
-    })
-
-    // Handle inline code blocks
+/**
+ * Apply inline-level Markdown regexp replacements (images, links, bold,
+ * italic, strikethrough) to a single already-block-parsed line of text.
+ * Inline code spans are expected to already be swapped out for placeholders
+ * so their contents are never touched here.
+ * @param {string} text
+ * @returns {string}
+ */
+function applyInlineMarkdown(text) {
+  return text
+    // Images: ![alt](src "title") -- must run before links
     .replace(
-      /(^|[^\\])(`+)([^\r]*?[^`])\2(?!`)/gm,
-      function (match, pre, backticks, code) {
-        code = code
-          .trim()
-          // Remove leading and trailing whitespace
-          .replace(/^[ \t]*/g, "")
-          .replace(/[ \t]*$/g, "")
-          // Encode HTML special characters
-
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;")
-          .replace(/"/g, "&quot;")
-          .replace(/'/g, "&#39;");
-
-        return pre + "<code>" + code + "</code>";
-      }
+      /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
+      (_m, alt, src, title) =>
+        `<img src="${src}" alt="${alt}"${title ? ` title="${title}"` : ""} />`
     )
+    // Links: [text](href "title")
+    .replace(
+      /\[([^\]]+)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
+      (_m, label, href, title) =>
+        `<a href="${href}"${title ? ` title="${title}"` : ""}>${label}</a>`
+    )
+    // Bold: **text** or __text__
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/__([^_]+)__/g, "<strong>$1</strong>")
+    // Italic: *text* or _text_ (avoid matching inside words for `_`)
+    .replace(/\*([^*\n]+)\*/g, "<em>$1</em>")
+    .replace(/(^|[^A-Za-z0-9_])_([^_\n]+)_(?=[^A-Za-z0-9_]|$)/g, "$1<em>$2</em>")
+    // Strikethrough: ~~text~~
+    .replace(/~~([^~]+)~~/g, "<del>$1</del>");
+}
 
-    // Convert inline code (`)
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
+/**
+ * Convert a Markdown document to formatted HTML using regular expressions to
+ * detect Markdown syntax. Unlike {@link convertMarkdownToHTML} (which relies on
+ * the `marked` library), this is a dependency-free, self-contained converter
+ * intended for post-processing content returned as Markdown (e.g. from the
+ * JINA reader fallback in the scraper).
+ *
+ * Supported block elements: ATX headers (`#`..`######`), fenced code blocks
+ * (```lang), blockquotes (`>`), unordered lists (`-`, `*`, `+`), ordered lists
+ * (`1.`, `1)`), horizontal rules (`---`, `***`, `___`) and paragraphs.
+ * Supported inline elements: bold, italic, strikethrough, inline code, images
+ * and links.
+ *
+ * @param {string} markdown - The Markdown content to convert.
+ * @returns {string} The resulting formatted HTML string.
+ * @category HTML Utilities
+ * @example
+ * convertMarkdownToFormattedHTML("# Title\n\nSome **bold** text.");
+ * // => "<h1>Title</h1>\n<p>Some <strong>bold</strong> text.</p>"
+ */
+export function convertMarkdownToFormattedHTML(markdown) {
+  if (!markdown || typeof markdown !== "string") return "";
 
-    // Convert paragraphs
-    .split("\n\n")
-    .map((para) => {
-      if (!para.startsWith("<")) {
-        return `<p>${para.trim()}</p>`;
+  let text = markdown.replace(/\r\n?/g, "\n");
+
+  // 1. Pull fenced code blocks out first so their contents are never parsed
+  // as Markdown. Each is replaced by a placeholder restored at the end.
+  const codeBlocks = [];
+  text = text.replace(
+    /```([^\n`]*)\n([\s\S]*?)```/g,
+    (_m, lang, code) => {
+      const language = (lang || "").trim();
+      const cls = language ? ` class="language-${language}"` : "";
+      const body = escapeHTMLChars(code.replace(/\n$/, ""));
+      codeBlocks.push(`<pre><code${cls}>${body}</code></pre>`);
+      return `\u0000CB${codeBlocks.length - 1}\u0000`;
+    }
+  );
+
+  // 2. Pull inline code spans out next for the same reason.
+  const inlineCodes = [];
+  text = text.replace(/`([^`\n]+)`/g, (_m, code) => {
+    inlineCodes.push(`<code>${escapeHTMLChars(code)}</code>`);
+    return `\u0000IC${inlineCodes.length - 1}\u0000`;
+  });
+
+  const lines = text.split("\n");
+  const out = [];
+  let inUl = false;
+  let inOl = false;
+  let inBlockquote = false;
+  let paragraph = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length) {
+      out.push(`<p>${applyInlineMarkdown(paragraph.join(" "))}</p>`);
+      paragraph = [];
+    }
+  };
+  const closeLists = () => {
+    if (inUl) {
+      out.push("</ul>");
+      inUl = false;
+    }
+    if (inOl) {
+      out.push("</ol>");
+      inOl = false;
+    }
+  };
+  const closeBlockquote = () => {
+    if (inBlockquote) {
+      out.push("</blockquote>");
+      inBlockquote = false;
+    }
+  };
+
+  for (const line of lines) {
+    // Standalone fenced-code-block placeholder line
+    const cb = line.match(/^\u0000CB(\d+)\u0000$/);
+    if (cb) {
+      flushParagraph();
+      closeLists();
+      closeBlockquote();
+      out.push(codeBlocks[Number(cb[1])]);
+      continue;
+    }
+
+    // Blank line closes open blocks
+    if (/^\s*$/.test(line)) {
+      flushParagraph();
+      closeLists();
+      closeBlockquote();
+      continue;
+    }
+
+    // Horizontal rule: ---, ***, ___ (3+)
+    if (/^\s*([-*_])(?:\s*\1){2,}\s*$/.test(line)) {
+      flushParagraph();
+      closeLists();
+      closeBlockquote();
+      out.push("<hr>");
+      continue;
+    }
+
+    // ATX header: # .. ######
+    const header = line.match(/^\s*(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (header) {
+      flushParagraph();
+      closeLists();
+      closeBlockquote();
+      const level = header[1].length;
+      out.push(`<h${level}>${applyInlineMarkdown(header[2])}</h${level}>`);
+      continue;
+    }
+
+    // Blockquote: > text
+    const bq = line.match(/^\s*>\s?(.*)$/);
+    if (bq) {
+      flushParagraph();
+      closeLists();
+      if (!inBlockquote) {
+        out.push("<blockquote>");
+        inBlockquote = true;
       }
-      return para;
-    })
-    .join("\n")
+      out.push(`<p>${applyInlineMarkdown(bq[1])}</p>`);
+      continue;
+    }
+    closeBlockquote();
 
-    // Convert images
-    .replace(/\!\[(.*?)\]\((.*?)\)/g, '<img src="$2" alt="$1" />')
+    // Unordered list item: -, *, +
+    const ul = line.match(/^\s*[-*+]\s+(.+)$/);
+    if (ul) {
+      flushParagraph();
+      if (inOl) {
+        out.push("</ol>");
+        inOl = false;
+      }
+      if (!inUl) {
+        out.push("<ul>");
+        inUl = true;
+      }
+      out.push(`<li>${applyInlineMarkdown(ul[1])}</li>`);
+      continue;
+    }
 
-    // Convert links
-    .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>')
+    // Ordered list item: 1. or 1)
+    const ol = line.match(/^\s*\d+[.)]\s+(.+)$/);
+    if (ol) {
+      flushParagraph();
+      if (inUl) {
+        out.push("</ul>");
+        inUl = false;
+      }
+      if (!inOl) {
+        out.push("<ol>");
+        inOl = true;
+      }
+      out.push(`<li>${applyInlineMarkdown(ol[1])}</li>`);
+      continue;
+    }
 
-    // Clean up extra newlines
-    .replace(/\n\s*\n/g, "\n")
-    .trim();
+    // Otherwise accumulate into the current paragraph
+    closeLists();
+    paragraph.push(line.trim());
+  }
 
-  return html;
+  flushParagraph();
+  closeLists();
+  closeBlockquote();
+
+  let html = out.join("\n");
+
+  // Restore inline code placeholders
+  html = html.replace(/\u0000IC(\d+)\u0000/g, (_m, i) => inlineCodes[Number(i)]);
+
+  return html.trim();
 }
 
 export function convertHTMLToMarkdown(html) {

--- a/packages/extract-webpage/src/url-to-content/url-to-html.ts
+++ b/packages/extract-webpage/src/url-to-content/url-to-html.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { convertHTMLToBasicHTML } from "../html-to-content/html-to-basic-html";
-import { convertMarkdownToHTML } from "../html-to-content/html-utils";
+import { convertMarkdownToFormattedHTML } from "../html-to-content/html-utils";
 import grab from "../utils/grab";
 
 /**
@@ -299,7 +299,10 @@ export async function scrapeJINA(url) {
   var match = articleExtract.match(/Markdown Content:([\s\S]*)/);
   articleExtract = match ? match[1] : articleExtract;
 
-  articleExtract = convertMarkdownToHTML(articleExtract);
+  // JINA returns the article body as Markdown. Convert it to formatted HTML
+  // using regexp-based Markdown detection so headers, lists, links, emphasis,
+  // and code render correctly downstream.
+  articleExtract = convertMarkdownToFormattedHTML(articleExtract);
 
   if (title) articleExtract = "<title>" + title + "</title>" + articleExtract;
 

--- a/packages/research-agent-ui/.storybook/main.ts
+++ b/packages/research-agent-ui/.storybook/main.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
 
 /**
@@ -24,6 +25,16 @@ const config: StorybookConfig = {
     const { default: tailwindcss } = await import('@tailwindcss/vite');
     viteConfig.plugins = viteConfig.plugins ?? [];
     viteConfig.plugins.push(tailwindcss());
+
+    // Stories render outside a Next.js app, so alias `next/link` to a plain
+    // anchor stub. This lets presentational components that use it (e.g.
+    // Footer, HistoryChatItem) render in isolation without an App Router.
+    viteConfig.resolve = viteConfig.resolve ?? {};
+    viteConfig.resolve.alias = {
+      ...(viteConfig.resolve.alias ?? {}),
+      'next/link': fileURLToPath(new URL('./next-link-stub.tsx', import.meta.url)),
+    };
+
     return viteConfig;
   },
 };

--- a/packages/research-agent-ui/.storybook/next-link-stub.tsx
+++ b/packages/research-agent-ui/.storybook/next-link-stub.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+/**
+ * Storybook stub for `next/link`.
+ *
+ * Stories render outside a Next.js app, so the real `next/link` (which reaches
+ * for the App Router context) can error. This drop-in renders a plain anchor
+ * with the same common props, which is all the presentational components need.
+ */
+type NextLinkProps = {
+  href?: string | { pathname?: string };
+  children?: React.ReactNode;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
+
+const Link = React.forwardRef<HTMLAnchorElement, NextLinkProps>(
+  ({ href, children, ...props }, ref) => {
+    const resolved =
+      typeof href === 'string' ? href : href?.pathname ?? '#';
+    return (
+      <a ref={ref} href={resolved} {...props}>
+        {children}
+      </a>
+    );
+  },
+);
+
+Link.displayName = 'NextLinkStub';
+
+export default Link;

--- a/packages/research-agent-ui/STORYBOOK.md
+++ b/packages/research-agent-ui/STORYBOOK.md
@@ -1,0 +1,268 @@
+# Storybook — `research-agent-ui`
+
+This package ships a [Storybook](https://storybook.js.org/) so every UI
+element can be developed, reviewed, and tested in isolation — no live API,
+auth session, or chat backend required. All stories render against **mock data
+only**.
+
+- Storybook version: **9.x** (`@storybook/react-vite`)
+- Config: [`.storybook/main.ts`](.storybook/main.ts),
+  [`.storybook/preview.tsx`](.storybook/preview.tsx)
+- Shared fixtures: [`src/stories/mocks.ts`](src/stories/mocks.ts)
+- Stories live next to their components as `src/**/*.stories.tsx`
+
+---
+
+## Running it locally
+
+From this package (`packages/research-agent-ui`):
+
+```bash
+# install workspace deps once, from the repo root
+pnpm install        # or: bun install / npm install
+
+# start Storybook with hot reload on http://localhost:6006
+pnpm storybook      # → runs `storybook dev -p 6006`
+```
+
+The preview toolbar has a **Theme** switch (light / dark) that toggles the
+`.dark` class so you can verify both palettes. Every story is wrapped in a
+Radix `TooltipProvider`, so tooltip-bearing components work standalone.
+
+### What has stories
+
+| Area | Examples |
+| --- | --- |
+| **UI primitives** (`src/ui`) | `Button`, `Badge`, `Loader`, `Tooltip`, `Dialog`, `DropdownMenu`, `Popover`, `LiveWaveform`, `GlowingEffect`, `VisuallyHidden` |
+| **Article reader** | `ArticleActionButtons`, `ArticleAIResponse`, `ArticleFollowupQuestions`, `ArticlePromptInput`, `ArticlePanelHeader` |
+| **Chat** | `MessageReasoningPanel`, `ThinkTagProcessor`, `SearchProgressIndicator`, `FollowUpSuggestions`, `UserMessageHeader` |
+| **Actions & results** | `CopyMessageButton`, `WebCitationBadge`, `HistoryChatItem` |
+| **File upload / composer** | `FilePreviewCard`, `PastedContentCard` |
+| **Misc** | `ConfigError`, `Footer` |
+
+Container components that require a live `ChatProvider` / `SessionProvider` or
+network access (e.g. `ChatWindow`, `ModelSelector`, `VoiceSettingsPanel`) are
+intentionally **not** storied — they are composed from the individual elements
+above, which are.
+
+---
+
+## Writing a new story
+
+Colocate a `*.stories.tsx` file next to the component and follow the existing
+convention:
+
+```tsx
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';           // spy for callback args
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<typeof MyComponent> = {
+  title: 'Area/MyComponent',                    // groups it in the sidebar
+  component: MyComponent,
+  args: { onClick: fn() },                       // default args for all stories
+};
+export default meta;
+
+type Story = StoryObj<typeof MyComponent>;
+
+export const Default: Story = {};
+export const Variant: Story = { args: { variant: 'secondary' } };
+```
+
+Guidelines:
+
+- **Mock, don't call.** Reuse fixtures from `src/stories/mocks.ts`; add new
+  ones there so they're shared. Never hit a real API from a story.
+- **Callbacks** use `fn()` from `storybook/test` so clicks are logged in the
+  **Actions** panel.
+- **Components that need a context provider** (e.g. `useExtractPanel`) should
+  wrap the story in that provider via a `decorators` array — see
+  `WebCitationBadge.stories.tsx`.
+- Prefer several small, named stories (one per state) over one story with many
+  controls.
+
+---
+
+## Testing the stories
+
+### 1. Type-check
+
+Stories are type-checked with the rest of the package:
+
+```bash
+pnpm type-check      # tsc --noEmit
+```
+
+A story that passes props the component doesn't accept fails here.
+
+### 2. Interaction tests (play functions)
+
+Storybook 9 bundles a test API (`storybook/test`) built on Testing Library.
+Add a `play` function to script and assert on interactions; it runs in the
+**Interactions** panel as you view the story:
+
+```tsx
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+export const CopiesOnClick: Story = {
+  args: { onCopyClick: fn() },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /copy/i }));
+    await expect(args.onCopyClick).toHaveBeenCalled();
+  },
+};
+```
+
+### 3. Run every story headlessly (test runner)
+
+The [test runner](https://storybook.js.org/docs/writing-tests/test-runner)
+renders each story in a headless browser, fails on any render error or console
+error, and executes every `play` function. It is not installed by default — add
+it when you want CI coverage:
+
+```bash
+pnpm add -D @storybook/test-runner
+```
+
+```jsonc
+// package.json → scripts
+"test-storybook": "test-storybook"
+```
+
+```bash
+# Terminal A: serve Storybook
+pnpm storybook
+
+# Terminal B: run the tests against it
+pnpm test-storybook
+```
+
+> This environment ships Chromium at `/opt/pw-browsers`. Set
+> `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` and do **not** run
+> `playwright install` — the browser is already present.
+
+In CI, run it against a built Storybook so nothing has to stay running:
+
+```bash
+pnpm build-storybook --quiet
+npx concurrently -k -s first -n SB,TEST \
+  "npx http-server storybook-static --port 6006 --silent" \
+  "npx wait-on tcp:6006 && pnpm test-storybook --url http://127.0.0.1:6006"
+```
+
+### 4. Accessibility checks (optional)
+
+Add the a11y addon to surface WCAG violations per story in the **Accessibility**
+panel (and fail the test runner on violations):
+
+```bash
+pnpm add -D @storybook/addon-a11y
+```
+
+```ts
+// .storybook/main.ts
+addons: ['@storybook/addon-a11y'],
+```
+
+---
+
+## Hosting it live
+
+`build-storybook` produces a fully static site in `storybook-static/` that any
+static host can serve:
+
+```bash
+pnpm build-storybook          # → storybook-static/
+```
+
+Pick one of the following to publish it.
+
+### GitHub Pages (free, in-repo)
+
+Add a workflow that builds this package's Storybook and deploys the static
+output to Pages:
+
+```yaml
+# .github/workflows/storybook.yml
+name: Publish Storybook
+on:
+  push:
+    branches: [master]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter research-agent-ui build-storybook
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/research-agent-ui/storybook-static
+      - id: deploy
+        uses: actions/deploy-pages@v4
+```
+
+Enable **Settings → Pages → Source: GitHub Actions** once; every push to
+`master` then republishes to `https://<org>.github.io/<repo>/`.
+
+### Chromatic (free tier, adds visual regression)
+
+[Chromatic](https://www.chromatic.com/) is built by the Storybook team and
+also snapshots every story for visual-diff review on each PR:
+
+```bash
+pnpm add -D chromatic
+npx chromatic --project-token=<token>        # prints the published URL
+```
+
+### Cloudflare Pages
+
+This repo already uses Cloudflare (`wrangler`). Deploy the static build
+directly:
+
+```bash
+pnpm build-storybook
+npx wrangler pages deploy storybook-static --project-name qwksearch-storybook
+```
+
+Or, in the Cloudflare Pages dashboard, set **Build command** to
+`pnpm --filter research-agent-ui build-storybook` and **Output directory** to
+`packages/research-agent-ui/storybook-static`.
+
+### Vercel / Netlify
+
+Any static host works. For Vercel:
+
+```bash
+pnpm build-storybook
+npx vercel deploy storybook-static --prod
+```
+
+For Netlify, set the build command to
+`pnpm --filter research-agent-ui build-storybook` and the publish directory to
+`packages/research-agent-ui/storybook-static`.
+
+---
+
+## Quick reference
+
+| Task | Command |
+| --- | --- |
+| Dev server | `pnpm storybook` |
+| Static build | `pnpm build-storybook` |
+| Type-check stories | `pnpm type-check` |
+| Headless test all stories | `pnpm test-storybook` *(after adding the runner)* |
+| Deploy static output | serve / upload `storybook-static/` |

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleAIResponse.stories.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleAIResponse.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ArticleAIResponse from './ArticleAIResponse';
+
+/**
+ * `ArticleAIResponse` renders the AI answer to a question about the current
+ * article. It shows a spinner while loading, the (HTML) response when ready,
+ * and an error banner on failure.
+ */
+const meta: Meta<typeof ArticleAIResponse> = {
+  title: 'ArticleReader/ArticleAIResponse',
+  component: ArticleAIResponse,
+  parameters: { layout: 'padded' },
+  args: {
+    response: '',
+    isLoading: false,
+    error: '',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleAIResponse>;
+
+export const Loading: Story = {
+  args: { isLoading: true },
+};
+
+export const WithResponse: Story = {
+  args: {
+    response:
+      '<p><strong>Summary:</strong></p><ul>' +
+      '<li>Solid-state cells replace liquid electrolyte with a solid one.</li>' +
+      '<li>Higher energy density and improved safety.</li>' +
+      '<li>Pilot production targeted for 2027.</li></ul>',
+  },
+};
+
+export const Error: Story = {
+  args: { error: 'The model is temporarily unavailable. Please try again.' },
+};

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.stories.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import ArticleActionButtons from './ArticleActionButtons';
+
+/**
+ * `ArticleActionButtons` is the toolbar at the top of the article extract
+ * panel: Ask AI, Suggest, Copy, Highlight, Favorite, Open-in-new-tab, zoom
+ * controls, and Close. Every button has a hover tooltip showing its keyboard
+ * shortcut (e.g. `Alt+A`).
+ */
+const meta: Meta<typeof ArticleActionButtons> = {
+  title: 'ArticleReader/ArticleActionButtons',
+  component: ArticleActionButtons,
+  parameters: { layout: 'padded' },
+  args: {
+    isLoadingAI: false,
+    isLoadingFollowups: false,
+    isLoadingFavorite: false,
+    isFavorited: false,
+    isHighlightMode: false,
+    articleUrl: 'https://en.wikipedia.org/wiki/Solid-state_battery',
+    fontScale: 1,
+    onAskClick: fn(),
+    onSuggestClick: fn(),
+    onCopyClick: fn(),
+    onFavoriteClick: fn(),
+    onHighlightToggle: fn(),
+    onZoomIn: fn(),
+    onZoomOut: fn(),
+    onZoomReset: fn(),
+    onClose: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleActionButtons>;
+
+/** Default toolbar. Hover any button to see its tooltip + shortcut. */
+export const Default: Story = {};
+
+/** Highlight mode active and the article favorited. */
+export const ActiveStates: Story = {
+  args: { isHighlightMode: true, isFavorited: true },
+};
+
+/** AI request in flight (the Ask button shows a loading state). */
+export const Loading: Story = {
+  args: { isLoadingAI: true, isLoadingFollowups: true },
+};
+
+/** Zoomed in to 130%. */
+export const ZoomedIn: Story = {
+  args: { fontScale: 1.3 },
+};
+
+/** Without an article URL the open-in-new-tab button is hidden. */
+export const NoUrl: Story = {
+  args: { articleUrl: undefined },
+};

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.tsx
@@ -1,11 +1,57 @@
 /**
  * Toolbar with Ask AI, Suggest, Copy, Highlight, Favorite, Open-in-new-tab, and Close buttons
  * shown at the top of the article extract panel.
+ *
+ * Each button has a shadcn/Radix tooltip that appears on hover (zero delay) showing the
+ * action label and its keyboard shortcut. The shortcut key definitions are exported as
+ * {@link ARTICLE_TOOLBAR_SHORTCUTS} so the panel can wire up the matching key handlers.
  */
 import React from 'react';
 import { Bot, MessageCircleQuestion, Clipboard, Star, Highlighter, ExternalLink, ZoomIn, ZoomOut, X } from 'lucide-react';
 import { Button } from '../../ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../ui/tooltip';
 import { cn } from '../../lib/utils';
+
+/**
+ * Keyboard shortcut definitions for the article toolbar actions. `alt` means the
+ * shortcut requires the Alt/Option modifier; `close` uses a bare Escape key.
+ * Shared between the tooltip hints here and the key handler in the panel so the
+ * displayed shortcut and the actual binding never drift apart.
+ */
+export const ARTICLE_TOOLBAR_SHORTCUTS = {
+  ask: { alt: true, key: 'a' },
+  suggest: { alt: true, key: 's' },
+  copy: { alt: true, key: 'c' },
+  highlight: { alt: true, key: 'h' },
+  favorite: { alt: true, key: 'f' },
+  open: { alt: true, key: 'o' },
+  zoomOut: { alt: true, key: '-' },
+  zoomReset: { alt: true, key: '0' },
+  zoomIn: { alt: true, key: '=' },
+  close: { alt: false, key: 'Escape' },
+} as const;
+
+export type ArticleToolbarAction = keyof typeof ARTICLE_TOOLBAR_SHORTCUTS;
+
+const isMac =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '');
+
+/**
+ * Render a shortcut definition as a short, platform-aware label
+ * (e.g. "⌥A" on macOS, "Alt+A" elsewhere, "Esc" for the close action).
+ */
+export function formatToolbarShortcut(action: ArticleToolbarAction): string {
+  const { alt, key } = ARTICLE_TOOLBAR_SHORTCUTS[action];
+  const keyLabel =
+    key === 'Escape'
+      ? 'Esc'
+      : key.length === 1
+        ? key.toUpperCase()
+        : key;
+  if (!alt) return keyLabel;
+  return isMac ? `⌥${keyLabel}` : `Alt+${keyLabel}`;
+}
 
 interface ArticleActionButtonsProps {
   isLoadingAI: boolean;
@@ -31,6 +77,29 @@ const iconButtonClass = cn(
   "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
 );
 
+/**
+ * Wrap a toolbar control in a hover tooltip showing its label and keyboard shortcut.
+ */
+const ToolbarTip: React.FC<{
+  label: string;
+  action?: ArticleToolbarAction;
+  children: React.ReactNode;
+}> = ({ label, action, children }) => (
+  <Tooltip>
+    <TooltipTrigger asChild>{children}</TooltipTrigger>
+    <TooltipContent side="bottom">
+      <span className="flex items-center gap-1.5">
+        <span>{label}</span>
+        {action && (
+          <kbd className="rounded bg-primary-foreground/20 px-1 py-0.5 text-[10px] font-semibold leading-none tracking-wide">
+            {formatToolbarShortcut(action)}
+          </kbd>
+        )}
+      </span>
+    </TooltipContent>
+  </Tooltip>
+);
+
 const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
   isLoadingAI,
   isLoadingFollowups,
@@ -53,134 +122,152 @@ const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
   const zoomPercent = Math.round((fontScale ?? 1) * 100);
   return (
     <div className="flex flex-nowrap items-center gap-1 rounded-2xl border border-muted bg-gradient-to-b from-background to-muted/30 p-1 shadow-sm">
-      <Button
-        onClick={onAskClick}
-        disabled={isLoadingAI}
-        variant="ghost"
-        size="sm"
-        className={cn(
-          "flex items-center gap-2 px-3 h-9 rounded-xl transition-all duration-200",
-          "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
-        )}
-      >
-        <Bot className="size-4" />
-        <span className="font-medium">{isLoadingAI ? '...' : 'Ask'}</span>
-      </Button>
-
-      <Button
-        onClick={onSuggestClick}
-        disabled={isLoadingFollowups}
-        variant="ghost"
-        size="sm"
-        className={cn(
-          "flex items-center gap-2 px-3 h-9 rounded-xl transition-all duration-200",
-          "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
-        )}
-      >
-        <MessageCircleQuestion className="size-4" />
-        <span className="font-medium">Suggest</span>
-      </Button>
-
-      <Button
-        onClick={onCopyClick}
-        variant="ghost"
-        size="icon"
-        className={iconButtonClass}
-        title="Copy article"
-      >
-        <Clipboard className="size-4" />
-      </Button>
-
-      <Button
-        onClick={onHighlightToggle}
-        variant="ghost"
-        size="icon"
-        className={cn(
-          "h-9 w-9 rounded-xl transition-all duration-200",
-          isHighlightMode
-            ? "text-yellow-500 bg-yellow-50 dark:bg-yellow-950/30 hover:bg-yellow-100 dark:hover:bg-yellow-950/50"
-            : "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
-        )}
-        title={isHighlightMode ? 'Disable highlighting' : 'Enable highlighting'}
-      >
-        <Highlighter className="size-4" />
-      </Button>
-
-      <Button
-        onClick={onFavoriteClick}
-        disabled={isLoadingFavorite}
-        variant="ghost"
-        size="icon"
-        className={cn(
-          "h-9 w-9 rounded-xl transition-all duration-200",
-          isFavorited
-            ? "text-yellow-500 hover:text-yellow-600 hover:bg-yellow-50 dark:hover:bg-yellow-950/30"
-            : "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
-        )}
-        title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
-      >
-        <Star
-          className={cn(
-            "size-4",
-            isFavorited && "fill-yellow-400"
-          )}
-        />
-      </Button>
-
-      {articleUrl && (
+      <ToolbarTip label="Ask AI about this article" action="ask">
         <Button
-          asChild
+          onClick={onAskClick}
+          disabled={isLoadingAI}
+          variant="ghost"
+          size="sm"
+          className={cn(
+            "flex items-center gap-2 px-3 h-9 rounded-xl transition-all duration-200",
+            "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
+          )}
+        >
+          <Bot className="size-4" />
+          <span className="font-medium">{isLoadingAI ? '...' : 'Ask'}</span>
+        </Button>
+      </ToolbarTip>
+
+      <ToolbarTip label="Suggest follow-up questions" action="suggest">
+        <Button
+          onClick={onSuggestClick}
+          disabled={isLoadingFollowups}
+          variant="ghost"
+          size="sm"
+          className={cn(
+            "flex items-center gap-2 px-3 h-9 rounded-xl transition-all duration-200",
+            "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
+          )}
+        >
+          <MessageCircleQuestion className="size-4" />
+          <span className="font-medium">Suggest</span>
+        </Button>
+      </ToolbarTip>
+
+      <ToolbarTip label="Copy article" action="copy">
+        <Button
+          onClick={onCopyClick}
           variant="ghost"
           size="icon"
           className={iconButtonClass}
-          title="Open in new tab"
         >
-          <a href={articleUrl} target="_blank" rel="noopener noreferrer">
-            <ExternalLink className="size-4" />
-          </a>
+          <Clipboard className="size-4" />
         </Button>
+      </ToolbarTip>
+
+      <ToolbarTip
+        label={isHighlightMode ? 'Disable highlighting' : 'Enable highlighting'}
+        action="highlight"
+      >
+        <Button
+          onClick={onHighlightToggle}
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "h-9 w-9 rounded-xl transition-all duration-200",
+            isHighlightMode
+              ? "text-yellow-500 bg-yellow-50 dark:bg-yellow-950/30 hover:bg-yellow-100 dark:hover:bg-yellow-950/50"
+              : "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
+          )}
+        >
+          <Highlighter className="size-4" />
+        </Button>
+      </ToolbarTip>
+
+      <ToolbarTip
+        label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+        action="favorite"
+      >
+        <Button
+          onClick={onFavoriteClick}
+          disabled={isLoadingFavorite}
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "h-9 w-9 rounded-xl transition-all duration-200",
+            isFavorited
+              ? "text-yellow-500 hover:text-yellow-600 hover:bg-yellow-50 dark:hover:bg-yellow-950/30"
+              : "hover:bg-muted/80 hover:text-foreground text-muted-foreground"
+          )}
+        >
+          <Star
+            className={cn(
+              "size-4",
+              isFavorited && "fill-yellow-400"
+            )}
+          />
+        </Button>
+      </ToolbarTip>
+
+      {articleUrl && (
+        <ToolbarTip label="Open in new tab" action="open">
+          <Button
+            asChild
+            variant="ghost"
+            size="icon"
+            className={iconButtonClass}
+          >
+            <a href={articleUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="size-4" />
+            </a>
+          </Button>
+        </ToolbarTip>
       )}
 
       {showZoomControls && (
         <div className="ml-auto flex items-center gap-0.5 rounded-xl border border-muted/60 bg-muted/20 px-1">
-          <Button
-            onClick={onZoomOut}
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 rounded-lg text-muted-foreground transition-all duration-200 hover:bg-muted/80 hover:text-foreground"
-            title="Zoom out"
-          >
-            <ZoomOut className="size-4" />
-          </Button>
-          <button
-            type="button"
-            onClick={onZoomReset}
-            className="min-w-[3rem] rounded-md px-1 text-center text-xs font-medium tabular-nums text-muted-foreground transition-colors hover:text-foreground"
-            title="Reset zoom"
-          >
-            {zoomPercent}%
-          </button>
-          <Button
-            onClick={onZoomIn}
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 rounded-lg text-muted-foreground transition-all duration-200 hover:bg-muted/80 hover:text-foreground"
-            title="Zoom in"
-          >
-            <ZoomIn className="size-4" />
-          </Button>
+          <ToolbarTip label="Zoom out" action="zoomOut">
+            <Button
+              onClick={onZoomOut}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 rounded-lg text-muted-foreground transition-all duration-200 hover:bg-muted/80 hover:text-foreground"
+            >
+              <ZoomOut className="size-4" />
+            </Button>
+          </ToolbarTip>
+          <ToolbarTip label="Reset zoom" action="zoomReset">
+            <button
+              type="button"
+              onClick={onZoomReset}
+              className="min-w-[3rem] rounded-md px-1 text-center text-xs font-medium tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {zoomPercent}%
+            </button>
+          </ToolbarTip>
+          <ToolbarTip label="Zoom in" action="zoomIn">
+            <Button
+              onClick={onZoomIn}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 rounded-lg text-muted-foreground transition-all duration-200 hover:bg-muted/80 hover:text-foreground"
+            >
+              <ZoomIn className="size-4" />
+            </Button>
+          </ToolbarTip>
         </div>
       )}
 
-      <Button
-        onClick={onClose}
-        variant="ghost"
-        size="icon"
-        className={cn(iconButtonClass, !showZoomControls && "ml-auto")}
-        title="Close"
-      >
-        <X className="size-4" />
-      </Button>
+      <ToolbarTip label="Close" action="close">
+        <Button
+          onClick={onClose}
+          variant="ghost"
+          size="icon"
+          className={cn(iconButtonClass, !showZoomControls && "ml-auto")}
+        >
+          <X className="size-4" />
+        </Button>
+      </ToolbarTip>
     </div>
   );
 };

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
@@ -28,6 +28,7 @@ import {
   ChatMessage,
   ArticleExtractPanelProps
 } from '.';
+import { ARTICLE_TOOLBAR_SHORTCUTS } from './ArticleActionButtons';
 import { researchAgentUIConfig } from '../../config';
 import { useSession } from '../../hooks/useSession';
 import { useChat } from '../../hooks/useChat';
@@ -70,8 +71,11 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
   const [isPanelReady, setIsPanelReady] = useState(false);
   const [fontScale, setFontScale] = useState(1);
   const resizeRef = useRef<HTMLDivElement>(null);
+  // Holds the latest toolbar action handlers so the global keydown listener
+  // (registered once per open) always calls current closures, never stale ones.
+  const shortcutActionsRef = useRef<Partial<Record<string, () => void>>>({});
 
-  const MIN_FONT_SCALE = 0.8;
+  const MIN_FONT_SCALE = 0.5;
   const MAX_FONT_SCALE = 1.8;
   const FONT_SCALE_STEP = 0.1;
 
@@ -409,6 +413,78 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
       console.error('Failed to copy to clipboard:', error);
     }
   };
+
+  // Keep the shortcut handler map pointing at the freshest closures every render.
+  shortcutActionsRef.current = {
+    ask: () => callLanguageAPI('question'),
+    suggest: () => callLanguageAPI('suggest-followups'),
+    copy: handleCopyHTMLToClipboard,
+    highlight: () => setIsHighlightMode((prev) => !prev),
+    favorite: toggleFavorite,
+    open: () => {
+      const target = extractedArticle?.url || url;
+      if (target) window.open(target, '_blank', 'noopener,noreferrer');
+    },
+    zoomIn: handleZoomIn,
+    zoomOut: handleZoomOut,
+    zoomReset: handleZoomReset,
+    close: onClose,
+  };
+
+  // Global keyboard shortcuts for the toolbar actions while the panel is open.
+  // Alt/Option + key triggers an action; Escape always closes. Typing in an
+  // input, textarea, or contenteditable is never intercepted.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Map a shortcut key to its physical KeyboardEvent.code. Matching on `code`
+    // (not `key`) is required because holding Alt/Option on macOS rewrites
+    // `event.key` to an alternate character (e.g. Option+A -> "å").
+    const codeForKey = (key: string): string => {
+      if (/^[a-z]$/.test(key)) return `Key${key.toUpperCase()}`;
+      if (/^[0-9]$/.test(key)) return `Digit${key}`;
+      if (key === '-') return 'Minus';
+      if (key === '=') return 'Equal';
+      return key;
+    };
+
+    const actionByCode: Record<string, string> = {};
+    (Object.keys(ARTICLE_TOOLBAR_SHORTCUTS) as Array<keyof typeof ARTICLE_TOOLBAR_SHORTCUTS>)
+      .forEach((action) => {
+        const { alt, key } = ARTICLE_TOOLBAR_SHORTCUTS[action];
+        if (alt) actionByCode[codeForKey(key.toLowerCase())] = action;
+      });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        shortcutActionsRef.current.close?.();
+        return;
+      }
+      if (!event.altKey || event.ctrlKey || event.metaKey) return;
+
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      const action = actionByCode[event.code];
+      if (!action) return;
+
+      const run = shortcutActionsRef.current[action];
+      if (run) {
+        event.preventDefault();
+        run();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
 
   const renderPanelContent = () => (
     <div className="flex h-full flex-col bg-background shadow-xl">

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleFollowupQuestions.stories.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleFollowupQuestions.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import ArticleFollowupQuestions from './ArticleFollowupQuestions';
+
+/**
+ * `ArticleFollowupQuestions` renders clickable, AI-suggested follow-up
+ * questions for the open article. A leading "summarize" prompt is always
+ * offered, and multi-question strings are split into individual chips.
+ */
+const meta: Meta<typeof ArticleFollowupQuestions> = {
+  title: 'ArticleReader/ArticleFollowupQuestions',
+  component: ArticleFollowupQuestions,
+  parameters: { layout: 'padded' },
+  args: {
+    isLoading: false,
+    error: '',
+    onQuestionClick: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleFollowupQuestions>;
+
+export const Default: Story = {
+  args: {
+    questions: [
+      'Which companies are closest to mass production?',
+      'How do solid-state cells compare on energy density?',
+      'What are the main manufacturing challenges?',
+    ],
+  },
+};
+
+/** A single string containing several questions is split automatically. */
+export const AutoSplit: Story = {
+  args: {
+    questions: [
+      'What is the cycle life? How hot can they run? Are they cheaper to make?',
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { questions: [] },
+};

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticlePanelHeader.stories.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticlePanelHeader.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import ArticlePanelHeader from './ArticlePanelHeader';
+
+/**
+ * `ArticlePanelHeader` is the minimal top bar of the article extract panel,
+ * containing just a close button.
+ */
+const meta: Meta<typeof ArticlePanelHeader> = {
+  title: 'ArticleReader/ArticlePanelHeader',
+  component: ArticlePanelHeader,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    onClose: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticlePanelHeader>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="w-96">
+      <ArticlePanelHeader {...args} />
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticlePromptInput.stories.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticlePromptInput.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import ArticlePromptInput from './ArticlePromptInput';
+
+/**
+ * `ArticlePromptInput` is the single-line box for asking the AI a question
+ * about the current article. It submits on Enter.
+ */
+const meta: Meta<typeof ArticlePromptInput> = {
+  title: 'ArticleReader/ArticlePromptInput',
+  component: ArticlePromptInput,
+  parameters: { layout: 'padded' },
+  args: {
+    value: '',
+    onChange: fn(),
+    onSubmit: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticlePromptInput>;
+
+export const Empty: Story = {};
+
+export const WithText: Story = {
+  args: { value: 'What are the main manufacturing challenges?' },
+};
+
+/** Fully interactive: the input is controlled by local state. */
+export const Interactive: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState('');
+    return (
+      <div className="w-96">
+        <ArticlePromptInput {...args} value={value} onChange={setValue} />
+      </div>
+    );
+  },
+};

--- a/packages/research-agent-ui/src/components/ArticleReader/index.ts
+++ b/packages/research-agent-ui/src/components/ArticleReader/index.ts
@@ -3,6 +3,11 @@
  */
 export { default as ArticlePanelHeader } from "./ArticlePanelHeader";
 export { default as ArticleActionButtons } from "./ArticleActionButtons";
+export {
+  ARTICLE_TOOLBAR_SHORTCUTS,
+  formatToolbarShortcut,
+  type ArticleToolbarAction,
+} from "./ArticleActionButtons";
 export { default as ArticlePromptInput } from "./ArticlePromptInput";
 export { default as ArticleFollowupQuestions } from "./ArticleFollowupQuestions";
 export { default as ArticleAIResponse } from "./ArticleAIResponse";

--- a/packages/research-agent-ui/src/components/ChatConversation/MessageBubble/ThinkTagProcessor.stories.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/MessageBubble/ThinkTagProcessor.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ThinkTagProcessor from './ThinkTagProcessor';
+
+/**
+ * `ThinkTagProcessor` maps the custom `<think>` markdown tag in AI responses to
+ * the collapsible reasoning panel. It simply forwards its children as the
+ * reasoning content.
+ */
+const meta: Meta<typeof ThinkTagProcessor> = {
+  title: 'Chat/ThinkTagProcessor',
+  component: ThinkTagProcessor,
+  parameters: { layout: 'padded' },
+  args: {
+    children:
+      'Let me break this down: first the electrolyte chemistry, then the ' +
+      'manufacturing bottlenecks, then who is shipping first.',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThinkTagProcessor>;
+
+export const Thinking: Story = {
+  args: { thinkingEnded: false },
+};
+
+export const Ended: Story = {
+  args: { thinkingEnded: true },
+};

--- a/packages/research-agent-ui/src/components/ChatConversation/MessageReasoningPanel.stories.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/MessageReasoningPanel.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ThinkBox from './MessageReasoningPanel';
+
+/**
+ * `MessageReasoningPanel` (ThinkBox) is the collapsible panel that shows the
+ * model's internal reasoning extracted from `<think>` tags. It stays expanded
+ * while thinking and auto-collapses once `thinkingEnded` becomes true.
+ */
+const meta: Meta<typeof ThinkBox> = {
+  title: 'Chat/MessageReasoningPanel',
+  component: ThinkBox,
+  parameters: { layout: 'padded' },
+  args: {
+    content:
+      'The question is about solid-state batteries. I should cover the ' +
+      'electrolyte type, energy density, and the production timeline before ' +
+      'summarizing the key players.',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThinkBox>;
+
+/** Actively thinking — panel is expanded. */
+export const Thinking: Story = {
+  args: { thinkingEnded: false },
+};
+
+/** Finished — panel auto-collapses. */
+export const Ended: Story = {
+  args: { thinkingEnded: true },
+};

--- a/packages/research-agent-ui/src/components/ChatHistoryDropdown/HistoryChatItem.stories.tsx
+++ b/packages/research-agent-ui/src/components/ChatHistoryDropdown/HistoryChatItem.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { HistoryChatItem } from './HistoryChatItem';
+import type { Chat } from '../../types/research';
+
+/**
+ * `HistoryChatItem` is a single row in the chat-history dropdown: title,
+ * relative timestamp, question-count badge, and hover-revealed pin/delete
+ * actions.
+ */
+const baseChat: Chat = {
+  id: 'chat-1',
+  title: 'Solid-state battery breakthroughs',
+  createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
+  lastMessageAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+  focusMode: 'webSearch',
+  messageCount: 4,
+};
+
+const meta: Meta<typeof HistoryChatItem> = {
+  title: 'ChatHistory/HistoryChatItem',
+  component: HistoryChatItem,
+  parameters: { layout: 'padded' },
+  args: {
+    chat: baseChat,
+    isPinned: false,
+    onTogglePin: fn(),
+    onDelete: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72 rounded-lg border border-border p-1">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof HistoryChatItem>;
+
+export const Default: Story = {};
+
+export const Pinned: Story = {
+  args: { isPinned: true },
+};
+
+export const NoMessages: Story = {
+  args: { chat: { ...baseChat, messageCount: 0, title: 'Empty draft chat' } },
+};
+
+export const LongTitle: Story = {
+  args: {
+    chat: {
+      ...baseChat,
+      title:
+        'A very long conversation title that should be truncated with an ellipsis when it overflows the row',
+    },
+  },
+};

--- a/packages/research-agent-ui/src/components/ConfigError.stories.tsx
+++ b/packages/research-agent-ui/src/components/ConfigError.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ConfigError from './ConfigError';
+
+/**
+ * `ConfigError` is the full-screen setup guide shown when no AI providers are
+ * configured. It lists the environment variables the host app needs.
+ */
+const meta: Meta<typeof ConfigError> = {
+  title: 'Misc/ConfigError',
+  component: ConfigError,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfigError>;
+
+export const Default: Story = {};

--- a/packages/research-agent-ui/src/components/Footer.stories.tsx
+++ b/packages/research-agent-ui/src/components/Footer.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Footer from './Footer';
+
+/**
+ * `Footer` renders a compact bar of links (with optional Lucide icons) pinned
+ * to the bottom of the screen. On small screens it collapses into an info icon
+ * that reveals the links in a popover. `icon` values are Lucide icon names.
+ */
+const meta: Meta<typeof Footer> = {
+  title: 'Misc/Footer',
+  component: Footer,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    optionShowIcons: true,
+    listFooterLinks: [
+      { url: 'https://github.com', text: 'GitHub', icon: 'Github' },
+      { url: 'https://example.com/blog', text: 'Blog', icon: 'Newspaper' },
+      { url: 'https://example.com/docs', text: 'Docs', icon: 'BookOpen' },
+      { url: 'mailto:hi@example.com', text: 'Contact', icon: 'Mail' },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Footer>;
+
+export const Default: Story = {};
+
+export const WithoutIcons: Story = {
+  args: { optionShowIcons: false },
+};
+
+export const Empty: Story = {
+  args: { listFooterLinks: [] },
+};

--- a/packages/research-agent-ui/src/components/MessageActions/CopyMessageButton.stories.tsx
+++ b/packages/research-agent-ui/src/components/MessageActions/CopyMessageButton.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Copy from './CopyMessageButton';
+import { mockSection } from '../../stories/mocks';
+
+/**
+ * `CopyMessageButton` copies an assistant message plus its citation URLs to the
+ * clipboard and briefly swaps its icon to a checkmark to confirm. Hover to see
+ * the tooltip; click to copy.
+ */
+const meta: Meta<typeof Copy> = {
+  title: 'MessageActions/CopyMessageButton',
+  component: Copy,
+  parameters: { layout: 'centered' },
+  args: {
+    section: mockSection as any,
+    initialMessage: mockSection.assistantMessage?.content ?? '',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Copy>;
+
+export const Default: Story = {};

--- a/packages/research-agent-ui/src/components/SearchResults/WebCitationBadge.stories.tsx
+++ b/packages/research-agent-ui/src/components/SearchResults/WebCitationBadge.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Citation from './WebCitationBadge';
+import { ExtractPanelProvider } from '../ArticleReader/ExtractPanelContext';
+import { mockSources } from '../../stories/mocks';
+
+/**
+ * `WebCitationBadge` (Citation) is the inline, numbered citation chip rendered
+ * from `<citation>` tags in AI responses. Hovering shows the source title and
+ * favicon; clicking opens the source in the article extract panel (mocked here
+ * via `ExtractPanelProvider`).
+ */
+const meta: Meta<typeof Citation> = {
+  title: 'SearchResults/WebCitationBadge',
+  component: Citation,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <ExtractPanelProvider>
+        <p className="max-w-md text-sm leading-relaxed">
+          Solid-state cells improve safety and energy density
+          <Story />, with pilot lines targeted for 2027.
+        </p>
+      </ExtractPanelProvider>
+    ),
+  ],
+  args: {
+    href: mockSources[0].metadata.url as string,
+    children: '1',
+    sources: mockSources as any,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Citation>;
+
+/** Resolves to a known source: hover shows its title + domain. */
+export const KnownSource: Story = {};
+
+/** No matching source: the tooltip falls back to the domain only. */
+export const UnknownSource: Story = {
+  args: {
+    href: 'https://unlisted.example.com/article',
+    children: '9',
+  },
+};

--- a/packages/research-agent-ui/src/ui/Loader.stories.tsx
+++ b/packages/research-agent-ui/src/ui/Loader.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Loader from './Loader';
+
+/**
+ * `Loader` is the spinning SVG used as an inline loading indicator. It inherits
+ * its color from the surrounding text (`text-*`) and its size from `w-*`/`h-*`
+ * utility classes on a wrapper.
+ */
+const meta: Meta<typeof Loader> = {
+  title: 'UI/Loader',
+  component: Loader,
+};
+
+export default meta;
+type Story = StoryObj<typeof Loader>;
+
+export const Default: Story = {};
+
+/** Recolored via a wrapper's text color. */
+export const Colored: Story = {
+  render: () => (
+    <div className="flex items-center gap-6 text-primary">
+      <Loader />
+      <span className="text-blue-500">
+        <Loader />
+      </span>
+      <span className="text-emerald-500">
+        <Loader />
+      </span>
+    </div>
+  ),
+};
+
+/** In context next to a label. */
+export const WithLabel: Story = {
+  render: () => (
+    <div className="flex items-center gap-3 text-muted-foreground">
+      <Loader />
+      <span className="text-sm">Researching…</span>
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/badge.stories.tsx
+++ b/packages/research-agent-ui/src/ui/badge.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Check, Sparkles } from 'lucide-react';
+import { Badge } from './badge';
+
+/**
+ * `Badge` is a small inline label used for statuses, tags, and callouts
+ * ("New", "Beta", counts). It supports several color variants and can render
+ * `asChild` (e.g. as a link).
+ */
+const meta: Meta<typeof Badge> = {
+  title: 'UI/Badge',
+  component: Badge,
+  args: {
+    children: 'Badge',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'secondary', 'destructive', 'outline', 'new', 'beta', 'highlight'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {};
+export const Secondary: Story = { args: { variant: 'secondary' } };
+export const Destructive: Story = { args: { variant: 'destructive' } };
+export const Outline: Story = { args: { variant: 'outline' } };
+export const New: Story = { args: { variant: 'new', children: 'New' } };
+export const Beta: Story = { args: { variant: 'beta', children: 'Beta' } };
+export const Highlight: Story = { args: { variant: 'highlight', children: 'Highlight' } };
+
+/** Badge with a leading icon. */
+export const WithIcon: Story = {
+  args: {
+    variant: 'new',
+    children: (
+      <>
+        <Sparkles />
+        AI
+      </>
+    ),
+  },
+};
+
+/** All variants together. */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge>Default</Badge>
+      <Badge variant="secondary">Secondary</Badge>
+      <Badge variant="destructive">Destructive</Badge>
+      <Badge variant="outline">Outline</Badge>
+      <Badge variant="new">New</Badge>
+      <Badge variant="beta">Beta</Badge>
+      <Badge variant="highlight">
+        <Check />
+        Done
+      </Badge>
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/button.stories.tsx
+++ b/packages/research-agent-ui/src/ui/button.stories.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { ArrowRight, Trash2 } from 'lucide-react';
+import { Button } from './button';
+
+/**
+ * `Button` is the shadcn/Radix button primitive used across the UI. It supports
+ * six visual `variant`s and four `size`s, and can render `asChild` to project
+ * its styles onto a custom element (e.g. an anchor).
+ */
+const meta: Meta<typeof Button> = {
+  title: 'UI/Button',
+  component: Button,
+  args: {
+    children: 'Button',
+    onClick: fn(),
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg', 'icon'],
+    },
+    disabled: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {};
+
+export const Secondary: Story = { args: { variant: 'secondary' } };
+
+export const Destructive: Story = { args: { variant: 'destructive' } };
+
+export const Outline: Story = { args: { variant: 'outline' } };
+
+export const Ghost: Story = { args: { variant: 'ghost' } };
+
+export const Link: Story = { args: { variant: 'link' } };
+
+export const Disabled: Story = { args: { disabled: true } };
+
+/** Icon-only button (square). */
+export const Icon: Story = {
+  args: { size: 'icon', children: <Trash2 className="size-4" />, 'aria-label': 'Delete' },
+};
+
+/** Icon + label. */
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        Continue
+        <ArrowRight className="size-4" />
+      </>
+    ),
+  },
+};
+
+/** Every variant side by side. */
+export const AllVariants: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button {...args} variant="default">Default</Button>
+      <Button {...args} variant="secondary">Secondary</Button>
+      <Button {...args} variant="destructive">Destructive</Button>
+      <Button {...args} variant="outline">Outline</Button>
+      <Button {...args} variant="ghost">Ghost</Button>
+      <Button {...args} variant="link">Link</Button>
+    </div>
+  ),
+};
+
+/** Every size side by side. */
+export const AllSizes: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button {...args} size="sm">Small</Button>
+      <Button {...args} size="default">Default</Button>
+      <Button {...args} size="lg">Large</Button>
+      <Button {...args} size="icon" aria-label="Icon"><ArrowRight className="size-4" /></Button>
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/dialog.stories.tsx
+++ b/packages/research-agent-ui/src/ui/dialog.stories.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+import { Button } from './button';
+
+/**
+ * `Dialog` (Radix) is the modal used for confirmations and settings. Compose it
+ * from `DialogTrigger`, `DialogContent`, and the header/footer helpers.
+ */
+const meta: Meta<typeof Dialog> = {
+  title: 'UI/Dialog',
+  component: Dialog,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+export const Default: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename chat</DialogTitle>
+          <DialogDescription>
+            Give this research session a memorable title.
+          </DialogDescription>
+        </DialogHeader>
+        <input
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+          defaultValue="Solid-state batteries"
+        />
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button>Save</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+/** Destructive confirmation flow. */
+export const Destructive: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="destructive">Delete chat</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete this chat?</DialogTitle>
+          <DialogDescription>
+            This permanently removes the conversation and its history.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button variant="destructive">Delete</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/dropdown-menu.stories.tsx
+++ b/packages/research-agent-ui/src/ui/dropdown-menu.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { Copy, Pencil, Trash2, Star } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from './dropdown-menu';
+import { Button } from './button';
+
+/**
+ * `DropdownMenu` (Radix) is the popover action menu used for message actions,
+ * chat history items, and model selection.
+ */
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'UI/DropdownMenu',
+  component: DropdownMenu,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Actions</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        <DropdownMenuLabel>Message</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={fn()}>
+          <Copy className="size-4" />
+          Copy
+          <DropdownMenuShortcut>⌘C</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={fn()}>
+          <Pencil className="size-4" />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={fn()}>
+          <Star className="size-4" />
+          Favorite
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onSelect={fn()}>
+          <Trash2 className="size-4" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/glowing-effect.stories.tsx
+++ b/packages/research-agent-ui/src/ui/glowing-effect.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { GlowingEffect } from './glowing-effect';
+
+/**
+ * `GlowingEffect` paints an animated conic-gradient border that tracks the
+ * pointer. It positions itself absolutely, so it must live inside a
+ * `relative`, rounded container. Set `disabled={false}` and `glow` to see the
+ * pointer-reactive glow.
+ */
+const meta: Meta<typeof GlowingEffect> = {
+  title: 'UI/GlowingEffect',
+  component: GlowingEffect,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    spread: { control: { type: 'range', min: 5, max: 60, step: 1 } },
+    borderWidth: { control: { type: 'range', min: 1, max: 6, step: 1 } },
+    proximity: { control: { type: 'range', min: 0, max: 120, step: 5 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GlowingEffect>;
+
+/** Move the pointer near the card to activate the glow. */
+export const OnCard: Story = {
+  args: {
+    disabled: false,
+    glow: true,
+    spread: 40,
+    borderWidth: 2,
+    proximity: 64,
+  },
+  render: (args) => (
+    <div className="relative h-40 w-72 rounded-2xl border border-border bg-card p-6">
+      <GlowingEffect {...args} />
+      <div className="relative">
+        <p className="text-sm font-semibold">Research card</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Hover near this card to trace the glowing border.
+        </p>
+      </div>
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/live-waveform.stories.tsx
+++ b/packages/research-agent-ui/src/ui/live-waveform.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LiveWaveform } from './live-waveform';
+
+/**
+ * `LiveWaveform` renders an animated audio bar visualizer on a canvas. The
+ * `processing` mode animates a synthetic wave with no microphone access, so it
+ * is safe to demo in Storybook. The `active` mode requests microphone
+ * permission at runtime and is not exercised here.
+ */
+const meta: Meta<typeof LiveWaveform> = {
+  title: 'UI/LiveWaveform',
+  component: LiveWaveform,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    barWidth: { control: { type: 'range', min: 1, max: 10, step: 1 } },
+    barGap: { control: { type: 'range', min: 0, max: 8, step: 1 } },
+    barRadius: { control: { type: 'range', min: 0, max: 6, step: 0.5 } },
+    height: { control: { type: 'number' } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LiveWaveform>;
+
+/** Synthetic "thinking" animation — no mic required. */
+export const Processing: Story = {
+  args: {
+    processing: true,
+    height: 64,
+    barColor: '#6366f1',
+  },
+  render: (args) => (
+    <div className="w-80 text-primary">
+      <LiveWaveform {...args} />
+    </div>
+  ),
+};
+
+/** Idle: nothing is drawn until `active` or `processing` is set. */
+export const Idle: Story = {
+  args: { height: 64 },
+  render: (args) => (
+    <div className="w-80 rounded-md border border-dashed border-border p-2">
+      <LiveWaveform {...args} />
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/popover.stories.tsx
+++ b/packages/research-agent-ui/src/ui/popover.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { Button } from './button';
+
+/**
+ * `Popover` (Radix) is the floating panel used for lightweight menus and
+ * inline settings that don't warrant a full modal.
+ */
+const meta: Meta<typeof Popover> = {
+  title: 'UI/Popover',
+  component: Popover,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64">
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Search options</p>
+          <p className="text-sm text-muted-foreground">
+            Configure how deeply the agent researches before answering.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/tooltip.stories.tsx
+++ b/packages/research-agent-ui/src/ui/tooltip.stories.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Info } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
+import { Button } from './button';
+
+/**
+ * `Tooltip` (Radix) shows a short hint on hover/focus. The library default
+ * `delayDuration` is `0`, so tips appear immediately. Wrap a trigger with
+ * `TooltipTrigger asChild` to keep your own element as the anchor.
+ */
+const meta: Meta<typeof Tooltip> = {
+  title: 'UI/Tooltip',
+  component: Tooltip,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const OnButton: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Hover me</Button>
+      </TooltipTrigger>
+      <TooltipContent>Helpful hint</TooltipContent>
+    </Tooltip>
+  ),
+};
+
+/** Tooltip with a keyboard-shortcut hint, mirroring the article toolbar. */
+export const WithShortcut: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Info">
+          <Info className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <span className="flex items-center gap-1.5">
+          More info
+          <kbd className="rounded bg-primary-foreground/20 px-1 py-0.5 text-[10px] font-semibold">
+            Alt+I
+          </kbd>
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+/** Placement on all four sides. */
+export const Sides: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+        <Tooltip key={side}>
+          <TooltipTrigger asChild>
+            <Button variant="outline" size="sm">{side}</Button>
+          </TooltipTrigger>
+          <TooltipContent side={side}>Tooltip on {side}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/visually-hidden.stories.tsx
+++ b/packages/research-agent-ui/src/ui/visually-hidden.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { VisuallyHidden } from './visually-hidden';
+import { Button } from './button';
+import { X } from 'lucide-react';
+
+/**
+ * `VisuallyHidden` hides content visually while keeping it available to screen
+ * readers. Use it to give icon-only controls an accessible name, or to label a
+ * dialog whose title is not shown.
+ */
+const meta: Meta<typeof VisuallyHidden> = {
+  title: 'UI/VisuallyHidden',
+  component: VisuallyHidden,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof VisuallyHidden>;
+
+/**
+ * The icon button has no visible text, but screen readers announce
+ * "Close panel" from the visually-hidden label.
+ */
+export const AccessibleIconButton: Story = {
+  render: () => (
+    <Button variant="ghost" size="icon">
+      <X className="size-4" />
+      <VisuallyHidden>Close panel</VisuallyHidden>
+    </Button>
+  ),
+};
+
+/** The text is present in the DOM (and read aloud) but not painted. */
+export const HiddenText: Story = {
+  render: () => (
+    <p className="text-sm">
+      Visible text
+      <VisuallyHidden> — plus this hidden note for assistive tech</VisuallyHidden>
+    </p>
+  ),
+};


### PR DESCRIPTION
## Summary

This PR adds keyboard shortcut support to the article toolbar and establishes a comprehensive Storybook for the `research-agent-ui` package, enabling isolated component development and testing without requiring a live backend.

## Key Changes

### Keyboard Shortcuts for Article Toolbar
- **New exports from `ArticleActionButtons.tsx`:**
  - `ARTICLE_TOOLBAR_SHORTCUTS`: A centralized, single-source-of-truth object defining all toolbar action shortcuts (Alt+A for Ask, Alt+S for Suggest, etc., with Escape for Close)
  - `ArticleToolbarAction`: Type for toolbar action names
  - `formatToolbarShortcut()`: Platform-aware formatter that renders shortcuts as "⌥A" on macOS and "Alt+A" elsewhere
  - `ToolbarTip`: New wrapper component that adds hover tooltips showing action labels and keyboard shortcuts to toolbar buttons

- **Updated `ArticleExtractPanel.tsx`:**
  - Wired up global keyboard event listeners that map shortcuts to their corresponding toolbar actions
  - Maintains a ref to the latest action handlers so shortcuts always call current closures
  - Lowered `MIN_FONT_SCALE` from 0.8 to 0.5 for better zoom control

### Storybook Setup
- **New documentation:** `STORYBOOK.md` with comprehensive guide on running, writing, testing, and hosting Storybook stories
- **Storybook configuration:** Updated `.storybook/main.ts` with Tailwind CSS integration and alias resolution
- **Next.js stub:** Added `.storybook/next-link-stub.tsx` to allow stories to render outside the Next.js app context
- **20+ new story files** covering:
  - UI primitives: `Button`, `Badge`, `Dialog`, `Dropdown`, `Popover`, `Tooltip`, `Loader`, `LiveWaveform`, `GlowingEffect`, `VisuallyHidden`
  - Article reader: `ArticleActionButtons`, `ArticleAIResponse`, `ArticleFollowupQuestions`, `ArticlePromptInput`, `ArticlePanelHeader`
  - Chat: `MessageReasoningPanel`, `ThinkTagProcessor`
  - Actions: `CopyMessageButton`, `WebCitationBadge`, `HistoryChatItem`
  - Misc: `ConfigError`, `Footer`

### Markdown-to-HTML Converter Refactor
- **New function in `html-utils.ts`:** `convertMarkdownToFormattedHTML()` — a dependency-free, regex-based Markdown converter that replaces the previous inline implementation
- Supports block elements (headers, code blocks, blockquotes, lists, horizontal rules, paragraphs) and inline elements (bold, italic, strikethrough, code, images, links)
- Properly escapes HTML characters and handles code blocks/inline code by extracting them first to prevent Markdown parsing of their contents
- Updated `url-to-html.ts` to use the new converter

## Notable Implementation Details

- Shortcuts are defined once in `ARTICLE_TOOLBAR_SHORTCUTS` and shared between tooltip hints and the panel's key handler, preventing drift
- The `ToolbarTip` component wraps each button to provide consistent tooltip styling with keyboard shortcut hints
- Storybook stories use mock data only and are wrapped in necessary providers (e.g., `TooltipProvider`, `ExtractPanelProvider`) so components work in isolation
- The new Markdown converter uses placeholder substitution to safely handle code blocks and inline code without parsing their contents as Markdown

https://claude.ai/code/session_014bHsv32djBvMS5H1PF5Pxc