### PR TITLE
Add Site Links submenu to CategoryDock dropdown

### DIFF
--- a/apps/qwksearch-web/components/layout/CategoryDock.tsx
+++ b/apps/qwksearch-web/components/layout/CategoryDock.tsx
@@ -1,16 +1,22 @@
 "use client"
 
 import Image from "next/image"
+import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { Settings, LogIn, LogOut } from "lucide-react"
+import { Settings, LogIn, LogOut, Link2 } from "lucide-react"
+import * as LucideIcons from "lucide-react"
 import {
   CategoryDock as BaseCategoryDock,
   type DockNavItem,
   ThemeMenu,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from "shadcn-app-dock"
 import { useSession, useChat } from "research-agent-ui"
+import { listFooterLinks } from "@/lib/config/site"
 import iconRead from "../icons/icon-read.svg"
 import iconConfigure from "../icons/icon-configure.svg"
 
@@ -58,6 +64,33 @@ export function CategoryDock() {
               <Settings className="mr-2 h-3.5 w-3.5" />
               <span className="text-sm">Settings</span>
             </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="cursor-pointer py-1 h-7">
+                <Link2 className="mr-2 h-3.5 w-3.5" />
+                <span className="text-sm">Site Links</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {listFooterLinks.map(({ url, text, icon }) => {
+                  const IconComponent = icon ? (LucideIcons as any)[icon] : null
+                  const isExternal = url.startsWith("http")
+                  return (
+                    <DropdownMenuItem key={url} asChild className="cursor-pointer py-1 h-7">
+                      {isExternal ? (
+                        <a href={url} target="_blank" rel="noopener noreferrer">
+                          {IconComponent && <IconComponent className="mr-2 h-3.5 w-3.5" />}
+                          <span className="text-sm">{text}</span>
+                        </a>
+                      ) : (
+                        <Link href={url}>
+                          {IconComponent && <IconComponent className="mr-2 h-3.5 w-3.5" />}
+                          <span className="text-sm">{text}</span>
+                        </Link>
+                      )}
+                    </DropdownMenuItem>
+                  )
+                })}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
             {isAuthenticated ? (
               <DropdownMenuItem onClick={() => signOut()} className="cursor-pointer py-1 h-7">
                 <LogOut className="mr-2 h-3.5 w-3.5" />

--- a/packages/shadcn-app-dock/src/index.ts
+++ b/packages/shadcn-app-dock/src/index.ts
@@ -19,4 +19,10 @@ export {
 // Primitives re-exported so consumers can build `menu.renderContent` without
 // re-importing shadcn components.
 export { Dock, DockIcon, DockItem, DockLabel, dockVariants } from "./components/dock"
-export { DropdownMenuItem, DropdownMenuSeparator } from "./components/dropdown-menu"
+export {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+} from "./components/dropdown-menu"


### PR DESCRIPTION
## Summary
Added a new "Site Links" submenu to the CategoryDock dropdown menu that displays configurable footer links with icon support.

## Key Changes
- **CategoryDock component**: Added a new `DropdownMenuSub` section that renders site links from the `listFooterLinks` configuration
  - Dynamically loads Lucide icons based on the icon name specified in the link configuration
  - Handles both external links (opening in new tab) and internal Next.js links
  - Maintains consistent styling with existing menu items
  
- **shadcn-app-dock exports**: Exported additional dropdown menu sub-components (`DropdownMenuSub`, `DropdownMenuSubTrigger`, `DropdownMenuSubContent`) to support nested menu structures

## Implementation Details
- Links are sourced from `@/lib/config/site` via the `listFooterLinks` function
- External URLs (starting with "http") are rendered as anchor tags with `target="_blank"` and `rel="noopener noreferrer"`
- Internal URLs use Next.js `Link` component for client-side navigation
- Icons are dynamically resolved from the lucide-react library using the icon name from the configuration
- Maintains consistent UI with existing menu items (py-1 h-7 styling and icon sizing)

https://claude.ai/code/session_01MZHn2rr3w1yCoJ1Ziruiag