### PR TITLE
fix(uploads): pass uploaded files to the LLM and enable file-only sends

### DIFF
--- a/apps/qwksearch-web/lib/uploads/__tests__/upload-to-llm.test.ts
+++ b/apps/qwksearch-web/lib/uploads/__tests__/upload-to-llm.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Guards the "uploaded file reaches the LLM" behaviour and the
+ * composer/home-page UI affordances that go with it:
+ *
+ *  1. `rerankDocs` (chat-agent-toolkit) must fold uploaded file content into
+ *     the answer context for every query — including the "summarize"
+ *     shortcut that previously dropped attachments.
+ *  2. `canSubmitMessage` must enable the composer's submit control when a file
+ *     is attached even with no typed text.
+ *  3. `formatRelativeTime` must render home-page history times without a
+ *     trailing "ago".
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  registerUploadFileLoader,
+  rerankDocs,
+  processDocs,
+} from 'chat-agent-toolkit';
+// Pure UI helpers imported directly from the research-agent-ui source.
+import { canSubmitMessage } from '../../../../../packages/research-agent-ui/src/lib/composer';
+import { formatRelativeTime } from '../../../../../packages/research-agent-ui/src/lib/relative-time';
+
+afterEach(() => {
+  // Reset the module-level loader so tests don't leak into one another.
+  registerUploadFileLoader(async () => null);
+});
+
+describe('rerankDocs: uploaded files reach the LLM context', () => {
+  it('includes extracted file content for a normal query', async () => {
+    registerUploadFileLoader(async (fileId: string) => ({
+      title: 'Report',
+      content: `EXTRACTED_${fileId}`,
+    }));
+
+    const result = await rerankDocs('analyze', [], ['f1'], 'balanced');
+
+    expect(result[0].pageContent).toBe('EXTRACTED_f1');
+    expect(result[0].metadata.url).toBe('File');
+    expect(processDocs(result)).toContain('EXTRACTED_f1');
+  });
+
+  it('keeps uploaded file content for a "summarize" query (regression)', async () => {
+    registerUploadFileLoader(async () => ({
+      title: 'Notes',
+      content: 'FILE_BODY',
+    }));
+
+    const webDocs = [
+      { pageContent: 'WEB_BODY', metadata: { title: 'Web', url: 'https://x.test' } },
+    ];
+
+    const result = await rerankDocs('summarize', webDocs, ['f1'], 'balanced');
+
+    // File content is present and ordered ahead of web results.
+    expect(result[0].pageContent).toBe('FILE_BODY');
+    expect(processDocs(result)).toContain('FILE_BODY');
+  });
+
+  it('resolves uploads for a "summarize" query with no web docs', async () => {
+    registerUploadFileLoader(async () => ({ title: 'Doc', content: 'ONLY_FILE' }));
+
+    const result = await rerankDocs('Summarize', [], ['only'], 'balanced');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pageContent).toBe('ONLY_FILE');
+  });
+});
+
+describe('canSubmitMessage: file-only sends are valid', () => {
+  it('is false with no text and no files', () => {
+    expect(canSubmitMessage('', [])).toBe(false);
+    expect(canSubmitMessage('   ', [])).toBe(false);
+    expect(canSubmitMessage('', undefined)).toBe(false);
+  });
+
+  it('is true with text only', () => {
+    expect(canSubmitMessage('hello', [])).toBe(true);
+  });
+
+  it('is true with an attached file and no text', () => {
+    expect(canSubmitMessage('', ['file-1'])).toBe(true);
+    expect(canSubmitMessage('   ', ['file-1'])).toBe(true);
+  });
+});
+
+describe('formatRelativeTime: no trailing "ago"', () => {
+  const NOW = Date.now();
+
+  afterEach(() => vi.useRealTimers());
+
+  it('omits "ago" for every bucket', () => {
+    expect(formatRelativeTime(NOW - 30 * 1000)).toBe('30 sec');
+    expect(formatRelativeTime(NOW - 3 * 60 * 1000)).toBe('3 min');
+    expect(formatRelativeTime(NOW - 2 * 60 * 60 * 1000)).toBe('2 hr');
+    expect(formatRelativeTime(NOW - 3 * 24 * 60 * 60 * 1000)).toBe('3 days');
+    expect(formatRelativeTime(NOW - 1 * 24 * 60 * 60 * 1000)).toBe('1 day');
+  });
+
+  it('keeps "just now" and handles invalid input', () => {
+    expect(formatRelativeTime(NOW)).toBe('just now');
+    expect(formatRelativeTime('not-a-date')).toBe('');
+  });
+});

--- a/packages/chat-agent-toolkit/src/tools/search/doc-utils.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/doc-utils.ts
@@ -112,18 +112,23 @@ export async function rerankDocs(
     filesData = results.filter((r) => r !== null);
   }
 
+  // Uploaded files must always reach the LLM. Build their docs up front so
+  // every return path below keeps them in the answer context.
+  const fileDocs: Document[] = filesData.map((fileData) => ({
+    pageContent: fileData.content,
+    metadata: { title: fileData.title, url: "File" },
+  }));
+
   if (query.toLocaleLowerCase() === "summarize") {
-    return docs.slice(0, 15);
+    // Skip web-result reranking for an explicit "summarize" request, but keep
+    // the uploaded file content — otherwise attachments are silently dropped
+    // and never analysed.
+    return [...fileDocs, ...docs].slice(0, 15);
   }
 
   const docsWithContent = docs.filter(
     (doc) => doc.pageContent && doc.pageContent.length > 0,
   );
-
-  const fileDocs: Document[] = filesData.map((fileData) => ({
-    pageContent: fileData.content,
-    metadata: { title: fileData.title, url: "File" },
-  }));
 
   // Combine file docs with web results, cap at 15
   return [...fileDocs, ...docsWithContent].slice(0, 15);

--- a/packages/chat-agent-toolkit/test/upload-analysis-integration.test.ts
+++ b/packages/chat-agent-toolkit/test/upload-analysis-integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview End-to-end test: an uploaded file's extracted content must
+ * reach the LLM when a chat request carries `fileIds`.
+ *
+ * This exercises the real `MetaSearchAgent.searchAndAnswer` pipeline (the same
+ * path the `/api/agent/chat` handler drives) with the `ai` SDK mocked, and
+ * asserts that the system prompt handed to `streamText` contains the extracted
+ * upload content resolved through the registered upload loader.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/** Captures the arguments the pipeline passes to the mocked `ai` SDK. */
+const streamTextCalls: Array<{ system?: string; messages?: unknown }> = [];
+
+vi.mock('ai', () => ({
+  // Query rephrasing step (only used when searchWeb is enabled).
+  generateText: vi.fn(async () => ({ text: '<question>\nnot_needed\n</question>' })),
+  // Answer streaming step — record the system prompt so we can assert the
+  // uploaded file content was folded into the LLM context.
+  streamText: vi.fn((opts: { system?: string; messages?: unknown }) => {
+    streamTextCalls.push({ system: opts.system, messages: opts.messages });
+    return {
+      textStream: (async function* () {
+        yield 'Here is the analysis.';
+      })(),
+    };
+  }),
+}));
+
+import MetaSearchAgent from '../src/tools/search/metaSearchAgent';
+import { registerUploadFileLoader } from '../src/tools/search/doc-utils';
+
+/** Runs the agent and resolves with the concatenated response text. */
+function runAgent(agent: MetaSearchAgent, fileIds: string[], message: string) {
+  return new Promise<{ response: string; sources: unknown[] }>(
+    async (resolve, reject) => {
+      const emitter = await agent.searchAndAnswer(
+        message,
+        [],
+        {} as never,
+        'balanced',
+        fileIds,
+        '',
+      );
+      let response = '';
+      let sources: unknown[] = [];
+      emitter.on('data', (data: string) => {
+        const parsed = JSON.parse(data);
+        if (parsed.type === 'response') response += parsed.data;
+        if (parsed.type === 'sources') sources = parsed.data;
+      });
+      emitter.on('end', () => resolve({ response, sources }));
+      emitter.on('error', (e: string) => reject(new Error(e)));
+    },
+  );
+}
+
+describe('MetaSearchAgent: uploaded files reach the LLM', () => {
+  beforeEach(() => {
+    streamTextCalls.length = 0;
+  });
+
+  it('passes extracted upload content into the answer prompt (no web search)', async () => {
+    registerUploadFileLoader(async (fileId) => ({
+      title: 'Quarterly Report',
+      content: `EXTRACTED_${fileId}_CONTENT`,
+    }));
+
+    const agent = new MetaSearchAgent({
+      searchWeb: false,
+      rerank: true,
+      rerankThreshold: 0,
+      queryGeneratorPrompt: '',
+      queryGeneratorFewShots: [],
+      responsePrompt: 'System instructions: {systemInstructions}\nContext:\n{context}',
+      activeEngines: [],
+    });
+
+    const { response, sources } = await runAgent(
+      agent,
+      ['file-xyz'],
+      'Analyze the uploaded file(s) and summarize the key points.',
+    );
+
+    // The pipeline streamed the mocked answer back to the client.
+    expect(response).toBe('Here is the analysis.');
+
+    // The uploaded file was surfaced as a source (url "File").
+    expect(sources).toEqual([
+      expect.objectContaining({
+        pageContent: 'EXTRACTED_file-xyz_CONTENT',
+        metadata: expect.objectContaining({ title: 'Quarterly Report', url: 'File' }),
+      }),
+    ]);
+
+    // Most importantly: the extracted content is present in the system prompt
+    // handed to the LLM, i.e. it actually reaches the model.
+    expect(streamTextCalls).toHaveLength(1);
+    expect(streamTextCalls[0].system).toContain('EXTRACTED_file-xyz_CONTENT');
+  });
+
+  it('includes upload content even when the effective query is "summarize"', async () => {
+    registerUploadFileLoader(async () => ({
+      title: 'Notes',
+      content: 'SUMMARIZE_ME_FILE_BODY',
+    }));
+
+    const agent = new MetaSearchAgent({
+      searchWeb: false,
+      rerank: true,
+      rerankThreshold: 0,
+      queryGeneratorPrompt: '',
+      queryGeneratorFewShots: [],
+      responsePrompt: 'Context:\n{context}',
+      activeEngines: [],
+    });
+
+    await runAgent(agent, ['note-1'], 'summarize');
+
+    expect(streamTextCalls).toHaveLength(1);
+    expect(streamTextCalls[0].system).toContain('SUMMARIZE_ME_FILE_BODY');
+  });
+});

--- a/packages/chat-agent-toolkit/test/upload-file-loader.test.ts
+++ b/packages/chat-agent-toolkit/test/upload-file-loader.test.ts
@@ -68,4 +68,38 @@ describe('rerankDocs with an uploaded file loader', () => {
     const result = await rerankDocs('analyze', [], [], 'balanced');
     expect(result).toEqual([]);
   });
+
+  it('keeps uploaded file content for a "summarize" query', async () => {
+    // Regression: a "summarize" query (typed by the user, or emitted by the
+    // query rephraser for link-only requests) used to early-return only the
+    // web docs, dropping uploaded attachments before they reached the LLM.
+    registerUploadFileLoader(async (fileId) => ({
+      title: `Title ${fileId}`,
+      content: `FILE_${fileId}`,
+    }));
+
+    const webDocs: Document[] = [
+      { pageContent: 'WEB_BODY', metadata: { title: 'Web', url: 'https://x.test' } },
+    ];
+
+    const result = await rerankDocs('summarize', webDocs, ['abc'], 'balanced');
+
+    // File content comes first and is present in the LLM context.
+    expect(result[0].pageContent).toBe('FILE_abc');
+    const context = processDocs(result);
+    expect(context).toContain('FILE_abc');
+  });
+
+  it('resolves uploaded files for a "summarize" query even with no web docs', async () => {
+    registerUploadFileLoader(async (fileId) => ({
+      title: 'Uploaded',
+      content: `FILE_${fileId}`,
+    }));
+
+    const result = await rerankDocs('Summarize', [], ['only-file'], 'balanced');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pageContent).toBe('FILE_only-file');
+    expect(result[0].metadata.url).toBe('File');
+  });
 });

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatMessageInputBar.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatMessageInputBar.tsx
@@ -14,6 +14,7 @@ import Focus from '../SearchConfig/ResearchFocusToggleButton';
 import { useChat, Section } from '../../hooks/useChat';
 import { Popover, PopoverTrigger, PopoverContent } from '../../ui/popover';
 import { exportAsMarkdown, exportAsPdf } from '../../lib/export';
+import { canSubmitMessage } from '../../lib/composer';
 
 /**
  * Input bar component for sending chat messages.
@@ -24,13 +25,17 @@ import { exportAsMarkdown, exportAsPdf } from '../../lib/export';
  * @returns {JSX.Element} The rendered message input bar
  */
 const MessageInput = () => {
-  const { loading, sendMessage, stopStreaming, sections } = useChat();
+  const { loading, sendMessage, stopStreaming, sections, fileIds } = useChat();
 
   const [copilotEnabled, setCopilotEnabled] = useState(false);
   const [message, setMessage] = useState('');
   const [textareaRows, setTextareaRows] = useState(1);
   const [mode, setMode] = useState<'multi' | 'single'>('single');
   const [title, setTitle] = useState<string>('');
+
+  // Submit is valid when there is text OR at least one attached file, so a
+  // follow-up can be sent with only an uploaded image/PDF and no text.
+  const canSubmit = canSubmitMessage(message, fileIds);
 
   useEffect(() => {
     if (textareaRows >= 2 && message && mode === 'single') {
@@ -79,12 +84,14 @@ const MessageInput = () => {
       onSubmit={(e) => {
         if (loading) return;
         e.preventDefault();
+        if (!canSubmit) return;
         sendMessage(message);
         setMessage('');
       }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' && !e.shiftKey && !loading) {
           e.preventDefault();
+          if (!canSubmit) return;
           sendMessage(message);
           setMessage('');
         }
@@ -158,7 +165,7 @@ const MessageInput = () => {
             </button>
           ) : (
             <button
-              disabled={message.trim().length === 0}
+              disabled={!canSubmit}
               className="bg-primary text-primary-foreground disabled:text-muted-foreground hover:bg-primary/85 transition duration-100 disabled:bg-muted rounded-full p-2"
             >
               <ArrowUp size={17} />
@@ -221,7 +228,7 @@ const MessageInput = () => {
               </button>
             ) : (
               <button
-                disabled={message.trim().length === 0}
+                disabled={!canSubmit}
                 className="bg-primary text-primary-foreground disabled:text-muted-foreground hover:bg-primary/85 transition duration-100 disabled:bg-muted rounded-full p-2"
               >
                 <ArrowUp size={17} />

--- a/packages/research-agent-ui/src/components/ChatConversation/EmptyStateChatMessageInput.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/EmptyStateChatMessageInput.tsx
@@ -10,6 +10,7 @@ import Optimization from '../SearchConfig/SearchOptimizationSelector';
 import Attach from '../FileUpload/FileAttachmentButton';
 import { useChat } from '../../hooks/useChat';
 import ModelSelector from '../SearchConfig/ChatModelSelector';
+import { canSubmitMessage } from '../../lib/composer';
 
 /**
  * Specialized input component for the empty chat state (homepage).
@@ -19,10 +20,14 @@ import ModelSelector from '../SearchConfig/ChatModelSelector';
  * @returns {JSX.Element} The rendered empty state input
  */
 const EmptyChatMessageInput = () => {
-  const { sendMessage } = useChat();
+  const { sendMessage, fileIds } = useChat();
 
   /* const [copilotEnabled, setCopilotEnabled] = useState(false); */
   const [message, setMessage] = useState('');
+
+  // Submit is valid when there is text OR at least one attached file, so a
+  // file-only send (upload an image/PDF with no text) is allowed.
+  const canSubmit = canSubmitMessage(message, fileIds);
 
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -54,12 +59,14 @@ const EmptyChatMessageInput = () => {
     <form
       onSubmit={(e) => {
         e.preventDefault();
+        if (!canSubmit) return;
         sendMessage(message);
         setMessage('');
       }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' && !e.shiftKey) {
           e.preventDefault();
+          if (!canSubmit) return;
           sendMessage(message);
           setMessage('');
         }
@@ -84,7 +91,7 @@ const EmptyChatMessageInput = () => {
               <Attach />
             </div>
             <button
-              disabled={message.trim().length === 0}
+              disabled={!canSubmit}
               className="bg-primary text-primary-foreground disabled:text-muted-foreground disabled:bg-muted hover:bg-primary/85 transition duration-100 rounded-full p-2"
             >
               <ArrowRight className="bg-background" size={17} />

--- a/packages/research-agent-ui/src/lib/composer.ts
+++ b/packages/research-agent-ui/src/lib/composer.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared logic for chat message composers.
+ */
+
+/**
+ * Whether a composer has enough to submit. A request is valid when the user
+ * typed some text **or** attached at least one file (uploaded image, PDF, or
+ * document). A file-only send is treated by the server as "analyse the
+ * uploaded file(s)", so the submit control must become enabled once a file is
+ * attached even with no text.
+ *
+ * @param message - Raw textarea value (may be empty/whitespace).
+ * @param fileIds - Ids of files attached to the current chat.
+ * @returns `true` when the message can be sent.
+ */
+export function canSubmitMessage(
+  message: string,
+  fileIds: readonly string[] | undefined,
+): boolean {
+  const hasText = (message ?? "").trim().length > 0;
+  const hasFiles = Array.isArray(fileIds) && fileIds.length > 0;
+  return hasText || hasFiles;
+}

--- a/packages/research-agent-ui/src/lib/relative-time.ts
+++ b/packages/research-agent-ui/src/lib/relative-time.ts
@@ -1,7 +1,7 @@
 /**
- * Formats a timestamp as a compact "time ago" string (e.g. "5 min ago",
- * "2 hr ago", "3 days ago"). Used by chat history to show how long ago a
- * conversation was last active.
+ * Formats a timestamp as a compact relative string (e.g. "5 min", "2 hr",
+ * "3 days"). Used by the home page chat history chips to show how long ago a
+ * conversation was last active, without a trailing "ago".
  */
 export function formatRelativeTime(input: string | number | Date): string {
   const then = new Date(input).getTime();
@@ -9,23 +9,23 @@ export function formatRelativeTime(input: string | number | Date): string {
 
   const seconds = Math.round((Date.now() - then) / 1000);
   if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds} sec ago`;
+  if (seconds < 60) return `${seconds} sec`;
 
   const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes} min ago`;
+  if (minutes < 60) return `${minutes} min`;
 
   const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours} hr ago`;
+  if (hours < 24) return `${hours} hr`;
 
   const days = Math.round(hours / 24);
-  if (days < 7) return `${days} day${days === 1 ? "" : "s"} ago`;
+  if (days < 7) return `${days} day${days === 1 ? "" : "s"}`;
 
   const weeks = Math.round(days / 7);
-  if (weeks < 5) return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+  if (weeks < 5) return `${weeks} week${weeks === 1 ? "" : "s"}`;
 
   const months = Math.round(days / 30);
-  if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+  if (months < 12) return `${months} month${months === 1 ? "" : "s"}`;
 
   const years = Math.round(days / 365);
-  return `${years} year${years === 1 ? "" : "s"} ago`;
+  return `${years} year${years === 1 ? "" : "s"}`;
 }


### PR DESCRIPTION
## Summary

Uploaded documents could be silently dropped before reaching the model, and the composer wouldn't let you submit a file with no text. This fixes both, plus a small home-page copy tweak.

### 1. Uploads now reach the LLM for analysis
In `rerankDocs` (`packages/chat-agent-toolkit/src/tools/search/doc-utils.ts`), a `"summarize"` query early-returned **only the web docs** (`docs.slice(0, 15)`), discarding the upload content it had just loaded. This triggered whenever a user uploaded a file and typed "summarize", or when the query-rephraser emitted `"summarize"` for link-only requests — the attachment never entered the LLM context.

Fix: build the uploaded-file docs *before* the summarize check so every return path keeps them in the answer context (file docs stay ordered ahead of web results).

### 2. Submit button turns valid with only a file attached
`EmptyStateChatMessageInput.tsx` and `ChatMessageInputBar.tsx` gated the submit control on `message.trim().length === 0` alone, so attaching an image/PDF with no text left the button disabled. Added a shared pure helper `canSubmitMessage(message, fileIds)` (valid when there is text **or** ≥1 attached file) and wired it into both composers' button `disabled` state and their submit/Enter handlers. (The main `ChatInputBox` already handled this.)

### 3. Home-page history times
`formatRelativeTime` now renders `"3 min"`, `"2 hr"`, `"3 days"` instead of `"… ago"` (keeps `"just now"`). Used only by the home-page history chips.

## Tests
- **Toolkit:** `rerankDocs` regression for the summarize case + a `MetaSearchAgent` integration test that drives the real pipeline (mocking the `ai` SDK) and asserts the extracted upload content appears in the system prompt sent to the model.
- **Web app** (the suite CI runs): `rerankDocs` upload coverage, `canSubmitMessage`, and `formatRelativeTime`.

All new tests pass and typecheck is clean on the changed files. Pre-existing failures in `notebooklm/credentials.test.ts` (KV binding) and `openrouter-default-model.test.js` (network) are unrelated — those files are untouched and fail independently.

## Note on scope
Image files (`png`/`jpg`) aren't in the supported upload/extraction list (`pdf, docx, txt, md, html, htm`), so an image upload wouldn't produce extractable text today. The submit-validity fix works for any attachment, but true image/vision analysis would be a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGVGHDLb712S5cPxWfBMx2)_