### PR TITLE
Remove AgentSkills section and reorganize settings sections

### DIFF
--- a/apps/qwksearch-web/components/Settings/SettingsContent.tsx
+++ b/apps/qwksearch-web/components/Settings/SettingsContent.tsx
@@ -10,7 +10,6 @@ import {
   HardDrive,
   Wand2,
   Volume2,
-  Sparkles,
   Brain,
 } from 'lucide-react';
 import Account from './Sections/Account';
@@ -36,7 +35,6 @@ import RewritePrompts from './Sections/RewritePrompts';
 import FileSources from './Sections/FileSources';
 import AIRewriteModes from './Sections/AIRewriteModes';
 import VoiceSection from './Sections/Voice';
-import AgentSkills from './Sections/AgentSkills';
 import SkillsAndMemory from './Sections/SkillsAndMemory';
 
 const sections = [
@@ -47,22 +45,6 @@ const sections = [
     icon: UserCircle,
     component: Account,
     dataAdd: 'account',
-  },
-  {
-    key: 'skills-memory',
-    name: 'Skills & Memory',
-    description: 'Manage agent skills and view your stored memories.',
-    icon: Brain,
-    component: SkillsAndMemory,
-    dataAdd: 'skillsMemory',
-  },
-  {
-    key: 'agent-skills',
-    name: 'Agent Skills',
-    description: 'Manage which capabilities your research agent can use.',
-    icon: Sparkles,
-    component: AgentSkills,
-    dataAdd: 'agentSkills',
   },
   {
     key: 'models',
@@ -79,6 +61,14 @@ const sections = [
     icon: Server,
     component: MCPServers,
     dataAdd: 'mcpServers',
+  },
+  {
+    key: 'skills-memory',
+    name: 'Skills & Memory',
+    description: 'Manage agent skills and view your stored memories.',
+    icon: Brain,
+    component: SkillsAndMemory,
+    dataAdd: 'skillsMemory',
   },
   {
     key: 'searchEngines',


### PR DESCRIPTION
## Summary
This PR removes the deprecated AgentSkills settings section and reorganizes the settings sections layout by moving Skills & Memory to appear after MCP Servers.

## Key Changes
- Removed the `AgentSkills` component import and its corresponding settings section
- Removed the `Sparkles` icon import from lucide-react (no longer needed)
- Removed the "Agent Skills" settings section entry from the sections array
- Reorganized the sections array by moving "Skills & Memory" section to appear after "MCP Servers" instead of at the beginning

## Implementation Details
- The Skills & Memory functionality is retained and continues to be available in the settings
- Only the separate Agent Skills section has been removed, consolidating agent capability management into the Skills & Memory section
- The reordering improves the logical flow of settings by grouping integration-related settings (MCP Servers) before agent configuration (Skills & Memory)

https://claude.ai/code/session_013Ds7oTSntUSrbs1gDg461V