### PR TITLE
Add settings modal for desktop screens

### DIFF
--- a/apps/qwksearch-web/components/Settings/SettingsModal.tsx
+++ b/apps/qwksearch-web/components/Settings/SettingsModal.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { configureResearchAgentUI } from 'research-agent-ui';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import SettingsContent from './SettingsContent';
+
+// Matches the Tailwind `lg` breakpoint that SettingsContent already uses for
+// its two-column desktop layout; below this we navigate to the /settings route.
+const DESKTOP_QUERY = '(min-width: 1024px)';
+
+const isDesktop = () =>
+  typeof window !== 'undefined' && window.matchMedia(DESKTOP_QUERY).matches;
+
+interface SettingsModalContextValue {
+  /**
+   * Attempts to open settings in the modal. Returns `true` when handled (large
+   * desktop screens) so the caller skips route navigation, or `false` when the
+   * caller should fall back to navigating to `/settings` (small screens).
+   */
+  openSettings: (section?: string) => boolean;
+  closeSettings: () => void;
+}
+
+const SettingsModalContext = createContext<SettingsModalContextValue | null>(null);
+
+export function useSettingsModal(): SettingsModalContextValue {
+  const ctx = useContext(SettingsModalContext);
+  if (!ctx) {
+    throw new Error('useSettingsModal must be used within a SettingsModalProvider');
+  }
+  return ctx;
+}
+
+export function SettingsModalProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [section, setSection] = useState<string | undefined>(undefined);
+
+  const openSettings = useCallback((next?: string) => {
+    if (!isDesktop()) return false;
+    setSection(next);
+    setOpen(true);
+    return true;
+  }, []);
+
+  const closeSettings = useCallback(() => setOpen(false), []);
+
+  // Let the shared research-agent-ui package (e.g. the input box's settings
+  // menu item) route through the modal on desktop instead of navigating.
+  useEffect(() => {
+    configureResearchAgentUI({ onOpenSettings: openSettings });
+    return () => configureResearchAgentUI({ onOpenSettings: undefined });
+  }, [openSettings]);
+
+  return (
+    <SettingsModalContext.Provider value={{ openSettings, closeSettings }}>
+      {children}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          hideCloseButton
+          className="p-0 gap-0 max-w-4xl w-[calc(100%-2rem)] h-[85vh] overflow-hidden"
+        >
+          <DialogTitle className="sr-only">Settings</DialogTitle>
+          {open && (
+            <div className="flex h-full w-full flex-col overflow-hidden">
+              {/* Re-mount per section so deep links pick the right initial tab */}
+              <SettingsContent
+                key={section ?? 'default'}
+                onClose={closeSettings}
+                initialSection={section}
+              />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </SettingsModalContext.Provider>
+  );
+}

--- a/apps/qwksearch-web/components/layout/CategoryDock.tsx
+++ b/apps/qwksearch-web/components/layout/CategoryDock.tsx
@@ -17,6 +17,7 @@ import {
 } from "shadcn-app-dock"
 import { useSession, useChat } from "research-agent-ui"
 import { listFooterLinks } from "@/lib/config/site"
+import { useSettingsModal } from "@/components/Settings/SettingsModal"
 import iconRead from "../icons/icon-read.svg"
 import iconConfigure from "../icons/icon-configure.svg"
 
@@ -34,6 +35,7 @@ export function CategoryDock() {
   const router = useRouter()
   const { isAuthenticated, signIn, signOut } = useSession()
   const { newChat } = useChat()
+  const { openSettings } = useSettingsModal()
 
   const isOnResearch = pathname === "/" || pathname.startsWith("/c")
 
@@ -60,7 +62,14 @@ export function CategoryDock() {
       menu: {
         renderContent: () => (
           <>
-            <DropdownMenuItem onClick={() => router.push("/settings")} className="cursor-pointer py-1 h-7">
+            <DropdownMenuItem
+              onClick={() => {
+                // Open settings in a modal on large desktop screens; otherwise
+                // navigate to the /settings route.
+                if (!openSettings()) router.push("/settings")
+              }}
+              className="cursor-pointer py-1 h-7"
+            >
               <Settings className="mr-2 h-3.5 w-3.5" />
               <span className="text-sm">Settings</span>
             </DropdownMenuItem>

--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -13,6 +13,7 @@ import { Toaster } from 'sonner';
 import { authClient } from '@/lib/auth/client';
 import { CategoryDock } from '@/components/layout/CategoryDock';
 import { CookieConsent } from '@/components/layout/CookieConsent';
+import { SettingsModalProvider } from '@/components/Settings/SettingsModal';
 import {
   APP_NAME,
   DEFAULT_SUMMARIZE_PROMPT,
@@ -57,12 +58,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <ExtractPanelProvider>
           <ChatProvider>
             <CategoryDockProvider>
-              <div className="w-screen h-screen overflow-auto pb-[calc(60px+env(safe-area-inset-bottom,0px))] md:pb-0">
-                <CategoryDock />
-                <main className="bg-light-primary dark:bg-dark-primary min-h-screen">
-                  {children}
-                </main>
-              </div>
+              <SettingsModalProvider>
+                <div className="w-screen h-screen overflow-auto pb-[calc(60px+env(safe-area-inset-bottom,0px))] md:pb-0">
+                  <CategoryDock />
+                  <main className="bg-light-primary dark:bg-dark-primary min-h-screen">
+                    {children}
+                  </main>
+                </div>
+              </SettingsModalProvider>
             </CategoryDockProvider>
             <Toaster
               toastOptions={{

--- a/packages/research-agent-ui/src/components/FileUpload/FileUploadDropdown.tsx
+++ b/packages/research-agent-ui/src/components/FileUpload/FileUploadDropdown.tsx
@@ -35,6 +35,7 @@ import { categories } from '../SearchConfig/categories';
 import { ModelSelectorSubmenu } from '../SearchConfig/ModelSelectorSubmenu';
 import { exportAsMarkdown, exportAsDocx, exportAsPdf, exportToGoogleDocs } from '../../lib/export';
 import { useSession } from '../../hooks/useSession';
+import { researchAgentUIConfig } from '../../config';
 
 interface FileUploadDropdownProps {
   onFileSelect: (files: FileList | File[]) => void;
@@ -535,7 +536,14 @@ const FileUploadDropdown: React.FC<FileUploadDropdownProps> = ({
               <span>History</span>
             </DropdownMenuItem>
 
-            <DropdownMenuItem onSelect={() => router.push('/settings')} className="gap-2">
+            <DropdownMenuItem
+              onSelect={() => {
+                // On large desktop screens the app opens settings in a modal
+                // (onOpenSettings returns true); otherwise fall back to the route.
+                if (!researchAgentUIConfig.onOpenSettings?.()) router.push('/settings');
+              }}
+              className="gap-2"
+            >
               <Settings className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
               <span>Settings</span>
             </DropdownMenuItem>

--- a/packages/research-agent-ui/src/config.ts
+++ b/packages/research-agent-ui/src/config.ts
@@ -37,6 +37,15 @@ export interface ResearchAgentUIConfig {
   googleApiKey: string;
   /** Whether to auto-trigger image/video media search after a response completes. */
   getAutoMediaSearch: () => boolean;
+  /**
+   * Requests that the settings UI be opened. Lets the consuming app render
+   * settings in a modal (e.g. on large desktop screens) instead of navigating
+   * to the `/settings` route. Return `true` when the request was handled — the
+   * caller then skips route navigation; return `false`/`undefined` to fall back
+   * to navigating to the settings page (e.g. on small screens). `section`
+   * optionally deep-links to a specific settings tab.
+   */
+  onOpenSettings?: (section?: string) => boolean;
 }
 
 export const researchAgentUIConfig: ResearchAgentUIConfig = {


### PR DESCRIPTION
## Summary
Implements a responsive settings UI that displays in a modal dialog on large desktop screens while falling back to route-based navigation on smaller screens.

## Key Changes
- **New `SettingsModalProvider` component** (`SettingsModal.tsx`): Provides context for managing a settings modal dialog that only activates on screens ≥1024px (Tailwind `lg` breakpoint). Includes:
  - `useSettingsModal()` hook for accessing `openSettings()` and `closeSettings()` functions
  - Responsive behavior: returns `true` when modal is handled on desktop, `false` to trigger route navigation on mobile
  - Integration with `research-agent-ui` package to route its settings requests through the modal

- **Updated `Providers.tsx`**: Wraps the application layout with `SettingsModalProvider` to enable modal functionality across the app

- **Updated `CategoryDock.tsx`**: Modified settings menu item to attempt opening the modal first via `openSettings()`, falling back to `/settings` route navigation if not on a large desktop screen

- **Updated `research-agent-ui` package**:
  - Added `onOpenSettings` callback to `ResearchAgentUIConfig` interface to allow consuming apps to handle settings requests
  - Modified `FileUploadDropdown.tsx` settings menu item to use the configured callback, enabling modal-first behavior in the shared UI package

## Implementation Details
- Modal uses a fixed max-width of 4xl and takes up 85vh of viewport height
- Settings content is re-mounted per section to ensure deep links pick the correct initial tab
- Desktop detection uses `window.matchMedia()` to respect the same breakpoint as the existing two-column settings layout
- Graceful fallback ensures settings remain accessible on all screen sizes

https://claude.ai/code/session_01Tk779p2hzZ8tMtgNozVDRt