### PR TITLE
Add multimodal support for image uploads in chat

### DIFF
--- a/apps/qwksearch-web/app/api/doc/uploads/route.ts
+++ b/apps/qwksearch-web/app/api/doc/uploads/route.ts
@@ -20,7 +20,7 @@ import {
   MAX_FILES_PER_REQUEST,
   SUPPORTED_UPLOAD_EXTENSIONS,
   URL_UPLOAD_EXTENSION,
-  extractUploadText,
+  buildExtractedUpload,
   storeUpload,
   getExtractedUpload,
   getUserUploads,
@@ -107,7 +107,7 @@ async function handleFileUpload(req: Request, userId: string | null) {
       const fileId = newFileId();
       const buffer = Buffer.from(await file.arrayBuffer());
 
-      const content = await extractUploadText(buffer, file.name, fileExtension);
+      const extracted = await buildExtractedUpload(buffer, file.name, fileExtension);
 
       await storeUpload({
         fileId,
@@ -116,7 +116,7 @@ async function handleFileUpload(req: Request, userId: string | null) {
         size: file.size,
         userId,
         originalBuffer: buffer,
-        extracted: { title: file.name, content },
+        extracted,
       });
 
       processedFiles.push({

--- a/apps/qwksearch-web/lib/chat/upload-file-loader.ts
+++ b/apps/qwksearch-web/lib/chat/upload-file-loader.ts
@@ -24,6 +24,11 @@ export function ensureUploadFileLoaderRegistered(): void {
   registerUploadFileLoader(async (fileId: string) => {
     const extracted = await getExtractedUpload(fileId);
     if (!extracted) return null;
-    return { title: extracted.title, content: extracted.content };
+    return {
+      title: extracted.title,
+      content: extracted.content,
+      ...(extracted.mediaType ? { mediaType: extracted.mediaType } : {}),
+      ...(extracted.image ? { image: extracted.image } : {}),
+    };
   });
 }

--- a/apps/qwksearch-web/lib/uploads/__tests__/index.test.ts
+++ b/apps/qwksearch-web/lib/uploads/__tests__/index.test.ts
@@ -83,13 +83,18 @@ import {
   originalObjectKey,
   extractedObjectKey,
   extractUploadText,
+  buildExtractedUpload,
   storeUpload,
   getExtractedUpload,
   getUserUploadQuota,
   deleteUploadObjects,
+  imageMediaType,
+  isImageExtension,
   MAX_FILE_SIZE_BYTES,
+  MAX_INLINE_IMAGE_BYTES,
   USER_STORAGE_QUOTA_BYTES,
   SUPPORTED_UPLOAD_EXTENSIONS,
+  SUPPORTED_IMAGE_EXTENSIONS,
 } from '../index'
 
 beforeEach(() => {
@@ -149,6 +154,53 @@ describe('extractUploadText', () => {
     const { convertPDFToHTML } = await import('extract-pdf')
     ;(convertPDFToHTML as any).mockRejectedValueOnce(new Error('boom'))
     expect(await extractUploadText(Buffer.from('%PDF'), 'a.pdf', 'pdf')).toBe('')
+  })
+})
+
+describe('image helpers', () => {
+  it('accepts image extensions for upload', () => {
+    expect(SUPPORTED_UPLOAD_EXTENSIONS).toContain('png')
+    expect(SUPPORTED_UPLOAD_EXTENSIONS).toContain('jpg')
+    expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('webp')
+  })
+
+  it('maps extensions to image MIME types', () => {
+    expect(imageMediaType('png')).toBe('image/png')
+    expect(imageMediaType('JPG')).toBe('image/jpeg')
+    expect(imageMediaType('jpeg')).toBe('image/jpeg')
+    expect(imageMediaType('svg')).toBe('image/svg+xml')
+  })
+
+  it('recognises image extensions', () => {
+    expect(isImageExtension('PNG')).toBe(true)
+    expect(isImageExtension('pdf')).toBe(false)
+  })
+})
+
+describe('buildExtractedUpload', () => {
+  it('extracts text for documents (no image fields)', async () => {
+    const out = await buildExtractedUpload(
+      Buffer.from('hello world', 'utf-8'),
+      'notes.txt',
+      'txt',
+    )
+    expect(out).toEqual({ title: 'notes.txt', content: 'hello world' })
+  })
+
+  it('inlines a small image as a base64 data URL with its mediaType', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    const out = await buildExtractedUpload(bytes, 'pic.png', 'png')
+    expect(out.title).toBe('pic.png')
+    expect(out.content).toBe('')
+    expect(out.mediaType).toBe('image/png')
+    expect(out.image).toBe(`data:image/png;base64,${bytes.toString('base64')}`)
+  })
+
+  it('omits inline data for images above the size cap', async () => {
+    const big = Buffer.alloc(MAX_INLINE_IMAGE_BYTES + 1)
+    const out = await buildExtractedUpload(big, 'huge.jpg', 'jpg')
+    expect(out.mediaType).toBe('image/jpeg')
+    expect(out.image).toBeUndefined()
   })
 })
 

--- a/apps/qwksearch-web/lib/uploads/__tests__/upload-to-llm.test.ts
+++ b/apps/qwksearch-web/lib/uploads/__tests__/upload-to-llm.test.ts
@@ -15,6 +15,7 @@ import {
   registerUploadFileLoader,
   rerankDocs,
   processDocs,
+  loadUploadImages,
 } from 'chat-agent-toolkit';
 // Pure UI helpers imported directly from the research-agent-ui source.
 import { canSubmitMessage } from '../../../../../packages/research-agent-ui/src/lib/composer';
@@ -63,6 +64,43 @@ describe('rerankDocs: uploaded files reach the LLM context', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].pageContent).toBe('ONLY_FILE');
+  });
+});
+
+describe('image uploads reach the LLM as image content', () => {
+  it('resolves image attachments (mediaType + data URL) via loadUploadImages', async () => {
+    registerUploadFileLoader(async (fileId: string) => ({
+      title: 'Screenshot',
+      content: '',
+      mediaType: 'image/png',
+      image: `data:image/png;base64,IMG_${fileId}`,
+    }));
+
+    const images = await loadUploadImages(['img1']);
+
+    expect(images).toEqual([
+      { mediaType: 'image/png', image: 'data:image/png;base64,IMG_img1' },
+    ]);
+  });
+
+  it('ignores documents (no image field) when collecting images', async () => {
+    registerUploadFileLoader(async () => ({ title: 'Doc', content: 'TEXT_ONLY' }));
+
+    expect(await loadUploadImages(['d1'])).toEqual([]);
+  });
+
+  it('keeps image uploads out of the text docs (no empty file docs)', async () => {
+    registerUploadFileLoader(async () => ({
+      title: 'Photo',
+      content: '',
+      mediaType: 'image/jpeg',
+      image: 'data:image/jpeg;base64,AAAA',
+    }));
+
+    const result = await rerankDocs('describe', [], ['pic'], 'balanced');
+
+    // The image produces no text doc; it is passed separately as an image part.
+    expect(result).toHaveLength(0);
   });
 });
 

--- a/apps/qwksearch-web/lib/uploads/index.ts
+++ b/apps/qwksearch-web/lib/uploads/index.ts
@@ -32,8 +32,8 @@ export const MAX_FILES_PER_REQUEST = 10;
 /** Per-user storage quota across all uploads (1 GB). */
 export const USER_STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024;
 
-/** File extensions accepted for upload and text extraction. */
-export const SUPPORTED_UPLOAD_EXTENSIONS = [
+/** Document extensions whose text content is extracted for the LLM. */
+export const SUPPORTED_DOCUMENT_EXTENSIONS = [
   "pdf",
   "docx",
   "txt",
@@ -42,8 +42,48 @@ export const SUPPORTED_UPLOAD_EXTENSIONS = [
   "htm",
 ] as const;
 
+/** Image extensions passed to the LLM directly as image content. */
+export const SUPPORTED_IMAGE_EXTENSIONS = [
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "avif",
+] as const;
+
+/** File extensions accepted for upload (documents + images). */
+export const SUPPORTED_UPLOAD_EXTENSIONS = [
+  ...SUPPORTED_DOCUMENT_EXTENSIONS,
+  ...SUPPORTED_IMAGE_EXTENSIONS,
+] as const;
+
 /** Extension recorded for context files created from an extracted URL. */
 export const URL_UPLOAD_EXTENSION = "url";
+
+/**
+ * Maximum original image size inlined into the extracted payload as a data URL
+ * for the LLM (8 MB). Larger images are still stored and listed but not sent
+ * to the model, since most providers reject very large image payloads.
+ */
+export const MAX_INLINE_IMAGE_BYTES = 8 * 1024 * 1024;
+
+/** Returns the image MIME type for a supported image extension. */
+export function imageMediaType(fileExtension: string): string {
+  const ext = fileExtension.toLowerCase();
+  if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
+  if (ext === "svg") return "image/svg+xml";
+  return `image/${ext}`;
+}
+
+/** Whether an extension is a supported image type. */
+export function isImageExtension(fileExtension: string): boolean {
+  return (SUPPORTED_IMAGE_EXTENSIONS as readonly string[]).includes(
+    fileExtension.toLowerCase(),
+  );
+}
 
 /** R2 object key of the original uploaded file. */
 export const originalObjectKey = (fileId: string, fileExtension: string) =>
@@ -59,6 +99,13 @@ export interface ExtractedUpload {
   content: string;
   /** Set when the upload was created by extracting a typed-in URL. */
   url?: string;
+  /** MIME type for image uploads (e.g. `"image/png"`). */
+  mediaType?: string;
+  /**
+   * `data:` URL of an image upload, passed to the LLM as image content.
+   * Absent for documents and for images above {@link MAX_INLINE_IMAGE_BYTES}.
+   */
+  image?: string;
 }
 
 /** Per-user storage usage snapshot. */
@@ -222,6 +269,31 @@ export async function extractUploadText(
   }
 }
 
+/**
+ * Builds the stored {@link ExtractedUpload} payload for an uploaded file.
+ *
+ * Documents get their extracted text as `content`. Images get a `mediaType`
+ * and, when small enough, a base64 `data:` URL in `image` so the chat pipeline
+ * can pass them to the LLM as image content.
+ */
+export async function buildExtractedUpload(
+  buffer: Buffer,
+  fileName: string,
+  fileExtension: string,
+): Promise<ExtractedUpload> {
+  if (isImageExtension(fileExtension)) {
+    const mediaType = imageMediaType(fileExtension);
+    const extracted: ExtractedUpload = { title: fileName, content: "", mediaType };
+    if (buffer.length <= MAX_INLINE_IMAGE_BYTES) {
+      extracted.image = `data:${mediaType};base64,${buffer.toString("base64")}`;
+    }
+    return extracted;
+  }
+
+  const content = await extractUploadText(buffer, fileName, fileExtension);
+  return { title: fileName, content };
+}
+
 // ---------------------------------------------------------------------------
 // Quota accounting (D1 `uploads` table)
 // ---------------------------------------------------------------------------
@@ -351,6 +423,8 @@ export async function getExtractedUpload(
       title: parsed.title || "Uploaded Document",
       content: parsed.content || "",
       ...(parsed.url ? { url: parsed.url } : {}),
+      ...(parsed.mediaType ? { mediaType: parsed.mediaType } : {}),
+      ...(parsed.image ? { image: parsed.image } : {}),
     };
   } catch (error) {
     console.error(`[getExtractedUpload] Failed for ${fileId}:`, error);

--- a/packages/chat-agent-toolkit/src/tools/search/doc-utils.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/doc-utils.ts
@@ -36,14 +36,30 @@ export function normalizeSourcesOutput(output: unknown, query: string): Document
   return buildFallbackDocs(query);
 }
 
+/** The payload resolved for an uploaded fileId. */
+export interface LoadedUpload {
+  title: string;
+  content: string;
+  /** MIME type for image uploads (e.g. `"image/png"`). */
+  mediaType?: string;
+  /** `data:`/`http(s)` URL of an image upload, passed to the LLM as image content. */
+  image?: string;
+}
+
+/** An image attachment resolved from an uploaded fileId. */
+export interface UploadImageAttachment {
+  mediaType: string;
+  /** `data:`/`http(s)` URL of the image, ready for an AI SDK image content part. */
+  image: string;
+}
+
 /**
- * Resolves an uploaded fileId to its extracted `{ title, content }` payload.
- * Hosts register a loader (e.g. reading the native R2 binding) so the search
- * pipeline does not depend on filesystem or credential-based access.
+ * Resolves an uploaded fileId to its extracted payload. Hosts register a loader
+ * (e.g. reading the native R2 binding) so the search pipeline does not depend
+ * on filesystem or credential-based access. Image uploads additionally carry
+ * `mediaType` and `image` so they can be passed to the LLM directly.
  */
-export type UploadFileLoader = (
-  fileId: string,
-) => Promise<{ title: string; content: string } | null>;
+export type UploadFileLoader = (fileId: string) => Promise<LoadedUpload | null>;
 
 let uploadFileLoader: UploadFileLoader | null = null;
 
@@ -56,7 +72,7 @@ export function registerUploadFileLoader(loader: UploadFileLoader): void {
   uploadFileLoader = loader;
 }
 
-async function downloadExtractedContent(fileId: string, r2Credentials: R2CredentialsInput): Promise<{ title: string; content: string } | null> {
+async function downloadExtractedContent(fileId: string, r2Credentials: R2CredentialsInput): Promise<LoadedUpload | null> {
   try {
     const { manageStorage } = await import("manage-storage");
     const config = {
@@ -69,11 +85,67 @@ async function downloadExtractedContent(fileId: string, r2Credentials: R2Credent
     const extractedKey = `${fileId}-extracted.json`;
     const data = await manageStorage("download", { ...config, key: extractedKey });
     const parsed = JSON.parse(data);
-    return { title: parsed.title || "Uploaded Document", content: parsed.content || "" };
+    return {
+      title: parsed.title || "Uploaded Document",
+      content: parsed.content || "",
+      ...(parsed.mediaType ? { mediaType: parsed.mediaType } : {}),
+      ...(parsed.image ? { image: parsed.image } : {}),
+    };
   } catch (error) {
     console.error(`[rerankDocs] Failed to download extracted content for fileId ${fileId}:`, error);
     return null;
   }
+}
+
+/**
+ * Resolves a single uploaded fileId via the registered loader (preferred) or
+ * the R2 credentials fallback. Returns `null` when neither can resolve it.
+ */
+async function resolveUpload(
+  fileId: string,
+  r2Credentials?: R2CredentialsInput,
+): Promise<LoadedUpload | null> {
+  if (uploadFileLoader) {
+    try {
+      const loaded = await uploadFileLoader(fileId);
+      if (loaded) return loaded;
+    } catch (error) {
+      console.error(
+        `[resolveUpload] Registered upload loader failed for fileId ${fileId}:`,
+        error,
+      );
+    }
+  }
+  if (r2Credentials) {
+    return downloadExtractedContent(fileId, r2Credentials);
+  }
+  return null;
+}
+
+/**
+ * Resolves image attachments for the given uploaded fileIds so they can be
+ * passed to the LLM as image content parts. Non-image uploads (documents) and
+ * images stored without inline data are skipped.
+ */
+export async function loadUploadImages(
+  fileIds: string[],
+  r2Credentials?: R2CredentialsInput,
+): Promise<UploadImageAttachment[]> {
+  if (!fileIds || fileIds.length === 0) return [];
+
+  const resolved = await Promise.all(
+    fileIds.map((fileId) => resolveUpload(fileId, r2Credentials)),
+  );
+
+  return resolved
+    .filter(
+      (r): r is LoadedUpload =>
+        r !== null && typeof r.image === "string" && r.image.length > 0,
+    )
+    .map((r) => ({
+      mediaType: r.mediaType || "image/png",
+      image: r.image as string,
+    }));
 }
 
 export async function rerankDocs(
@@ -87,37 +159,25 @@ export async function rerankDocs(
     return docs;
   }
 
-  let filesData: { title: string; content: string }[] = [];
+  let filesData: LoadedUpload[] = [];
 
   if (fileIds.length > 0) {
     const results = await Promise.all(
-      fileIds.map(async (fileId) => {
-        if (uploadFileLoader) {
-          try {
-            const loaded = await uploadFileLoader(fileId);
-            if (loaded) return loaded;
-          } catch (error) {
-            console.error(
-              `[rerankDocs] Registered upload loader failed for fileId ${fileId}:`,
-              error,
-            );
-          }
-        }
-        if (r2Credentials) {
-          return downloadExtractedContent(fileId, r2Credentials);
-        }
-        return null;
-      }),
+      fileIds.map((fileId) => resolveUpload(fileId, r2Credentials)),
     );
-    filesData = results.filter((r) => r !== null);
+    filesData = results.filter((r): r is LoadedUpload => r !== null);
   }
 
-  // Uploaded files must always reach the LLM. Build their docs up front so
-  // every return path below keeps them in the answer context.
-  const fileDocs: Document[] = filesData.map((fileData) => ({
-    pageContent: fileData.content,
-    metadata: { title: fileData.title, url: "File" },
-  }));
+  // Uploaded documents must always reach the LLM. Build their docs up front so
+  // every return path below keeps them in the answer context. Image uploads
+  // carry no text content — they are passed separately as image parts (see
+  // loadUploadImages) — so they are excluded here to avoid empty docs.
+  const fileDocs: Document[] = filesData
+    .filter((fileData) => fileData.content && fileData.content.length > 0)
+    .map((fileData) => ({
+      pageContent: fileData.content,
+      metadata: { title: fileData.title, url: "File" },
+    }));
 
   if (query.toLocaleLowerCase() === "summarize") {
     // Skip web-result reranking for an explicit "summarize" request, but keep

--- a/packages/chat-agent-toolkit/src/tools/search/index.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/index.ts
@@ -10,5 +10,5 @@ export { default as generateSuggestions } from "./suggestionGeneratorAgent";
 export { groupAndSummarizeDocs } from "./link-summarizer";
 export type { Document } from "./document";
 export { splitTextIntoChunks } from "./document";
-export { buildFallbackDocs, rerankDocs, processDocs, normalizeSourcesOutput, registerUploadFileLoader } from "./doc-utils";
-export type { UploadFileLoader } from "./doc-utils";
+export { buildFallbackDocs, rerankDocs, processDocs, normalizeSourcesOutput, registerUploadFileLoader, loadUploadImages } from "./doc-utils";
+export type { UploadFileLoader, LoadedUpload, UploadImageAttachment } from "./doc-utils";

--- a/packages/chat-agent-toolkit/src/tools/search/metaSearchAgent.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/metaSearchAgent.ts
@@ -35,6 +35,7 @@ import {
   rerankDocs,
   processDocs,
   normalizeSourcesOutput,
+  loadUploadImages,
   type R2CredentialsInput,
 } from "./doc-utils";
 import { groupAndSummarizeDocs } from "./link-summarizer";
@@ -378,11 +379,26 @@ class MetaSearchAgent implements MetaSearchAgentType {
         date: new Date().toISOString(),
       });
 
+      // Resolve any uploaded images so they are passed to the LLM directly as
+      // image content parts (alongside the text query). Documents already
+      // reach the model as text context via processDocs above.
+      const imageAttachments = await loadUploadImages(fileIds, r2Credentials);
+      const userContent =
+        imageAttachments.length > 0
+          ? [
+              { type: "text" as const, text: message },
+              ...imageAttachments.map((img) => ({
+                type: "image" as const,
+                image: img.image,
+              })),
+            ]
+          : message;
+
       const result = streamText({
         model: llm,
         temperature: 0.7,
         system: systemPrompt,
-        messages: [...history, { role: "user", content: message }],
+        messages: [...history, { role: "user", content: userContent }],
       });
 
       let responseChunkCount = 0;

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatWindow.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatWindow.tsx
@@ -38,12 +38,26 @@ export interface AssistantMessage extends BaseMessage {
 }
 
 /**
+ * A file attached to a chat message, shown inline in the conversation flow.
+ */
+export interface MessageFile {
+  /** Original file name (e.g. "report.pdf"). */
+  fileName: string;
+  /** File extension without the dot (e.g. "pdf", "png"). */
+  fileExtension: string;
+  /** Unique identifier of the uploaded file. */
+  fileId: string;
+}
+
+/**
  * Represents a message sent by the user.
  */
 export interface UserMessage extends BaseMessage {
   role: 'user';
   /** The text content of the user message */
   content: string;
+  /** Files the user attached to this message, if any. */
+  files?: MessageFile[];
 }
 
 /**

--- a/packages/research-agent-ui/src/components/ChatConversation/MessageBubble/MessageAttachments.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/MessageBubble/MessageAttachments.tsx
@@ -1,0 +1,123 @@
+/**
+ * Renders the files a user attached to a message inline in the conversation
+ * flow. Each attachment is shown as a compact chip with a file-type icon,
+ * name and extension, plus a trash button that asks for confirmation before
+ * permanently deleting the upload.
+ */
+'use client';
+
+import React, { useState } from 'react';
+import { FileText, Image as ImageIcon, Link2, Loader2, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '../../../ui/dialog';
+import { useChat } from '../../../hooks/useChat';
+import type { MessageFile } from '../ChatWindow';
+
+const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'avif'];
+
+/** Picks an icon for a file based on its extension. */
+const iconForExtension = (ext: string): React.ReactNode => {
+  const lower = (ext || '').toLowerCase();
+  if (IMAGE_EXTS.includes(lower)) return <ImageIcon size={15} />;
+  if (lower === 'url') return <Link2 size={15} />;
+  return <FileText size={15} />;
+};
+
+/** A single attachment chip with its own delete-confirmation dialog. */
+const AttachmentChip = ({ file }: { file: MessageFile }) => {
+  const { deleteAttachedFile } = useChat();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deleteAttachedFile(file.fileId);
+      setConfirmOpen(false);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="group inline-flex max-w-full items-center gap-2 rounded-lg border border-border bg-secondary/40 py-1.5 pl-2.5 pr-1.5 text-sm">
+        <span className="text-muted-foreground">{iconForExtension(file.fileExtension)}</span>
+        <span className="min-w-0 truncate font-medium text-foreground" title={file.fileName}>
+          {file.fileName}
+        </span>
+        {file.fileExtension && file.fileExtension !== 'url' && (
+          <span className="hidden shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground sm:inline">
+            {file.fileExtension}
+          </span>
+        )}
+        <button
+          type="button"
+          aria-label={`Delete ${file.fileName}`}
+          onClick={() => setConfirmOpen(true)}
+          className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-red-500/10 hover:text-red-500"
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!deleting) setConfirmOpen(open);
+        }}
+      >
+        <DialogContent className="w-full max-w-md rounded-2xl">
+          <DialogTitle className="text-lg font-medium leading-6">
+            Delete file
+          </DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">
+            Are you sure you want to delete{' '}
+            <span className="font-medium text-foreground">{file.fileName}</span>? This
+            removes it from the conversation and permanently deletes the upload.
+          </DialogDescription>
+          <div className="mt-6 flex flex-row items-center justify-end gap-4">
+            <button
+              type="button"
+              onClick={() => !deleting && setConfirmOpen(false)}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="inline-flex items-center gap-1.5 text-sm text-red-500 transition-colors hover:text-red-600 disabled:opacity-60"
+            >
+              {deleting && <Loader2 size={14} className="animate-spin" />}
+              Delete
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+/**
+ * Displays the list of files attached to a user message. Renders nothing when
+ * there are no attachments.
+ */
+const MessageAttachments = ({ files }: { files?: MessageFile[] }) => {
+  if (!files || files.length === 0) return null;
+
+  return (
+    <div className="ml-10 mt-2 flex flex-wrap gap-2">
+      {files.map((file) => (
+        <AttachmentChip key={file.fileId} file={file} />
+      ))}
+    </div>
+  );
+};
+
+export default MessageAttachments;

--- a/packages/research-agent-ui/src/components/ChatConversation/MessageBubble/UserMessageHeader.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/MessageBubble/UserMessageHeader.tsx
@@ -8,6 +8,7 @@ import { ChevronDown, ChevronRight, Check, ClipboardList, Pencil } from 'lucide-
 import { cn, formatMessageTime } from '../../../lib/utils';
 import { Section } from '../../../hooks/useChat';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../ui/tooltip';
+import MessageAttachments from './MessageAttachments';
 
 interface UserMessageHeaderProps {
     section: Section;
@@ -113,6 +114,9 @@ const UserMessageHeader = ({
                     <TooltipContent side="bottom">Edit &amp; resubmit</TooltipContent>
                 </Tooltip>
             </div>
+
+            {/* Files attached to this message */}
+            <MessageAttachments files={section.userMessage.files} />
 
             {/* Inline edit form */}
             {isEditing && (

--- a/packages/research-agent-ui/src/components/FileUpload/useFileHandling.ts
+++ b/packages/research-agent-ui/src/components/FileUpload/useFileHandling.ts
@@ -10,7 +10,12 @@ import { AttachedFile, PastedContent } from "../../types/research";
 import type { ChatFile } from "../../types/chat";
 import { uploadFiles } from "qwksearch-api-client";
 
-const SUPPORTED_EXTS = ["pdf", "docx", "txt", "md", "html", "htm"];
+/** Document types whose text is extracted server-side. */
+const DOCUMENT_EXTS = ["pdf", "docx", "txt", "md", "html", "htm"];
+/** Image types uploaded and passed to the LLM as image content. */
+const IMAGE_EXTS = ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "avif"];
+/** All extensions uploaded to the server (documents + images). */
+const SUPPORTED_EXTS = [...DOCUMENT_EXTS, ...IMAGE_EXTS];
 
 /** Server-enforced limits, mirrored client-side for immediate feedback. */
 const MAX_FILES_PER_REQUEST = 10;

--- a/packages/research-agent-ui/src/hooks/useChat/ChatContext.tsx
+++ b/packages/research-agent-ui/src/hooks/useChat/ChatContext.tsx
@@ -86,6 +86,13 @@ export interface ChatContextValue {
   setFileIds: (fileIds: string[]) => void;
 
   /**
+   * Permanently deletes an uploaded file: removes it from the server, from the
+   * chat-level attachment lists, and from any message it was attached to.
+   * @param fileId - The ID of the uploaded file to delete
+   */
+  deleteAttachedFile: (fileId: string) => Promise<void>;
+
+  /**
    * Sends a message to the chat.
    * @param message - The message content to send
    * @param messageId - Optional custom message ID
@@ -170,6 +177,7 @@ export const chatContext = createContext<ChatContextValue>({
   sendMessage: async () => { },
   setFileIds: () => { },
   setFiles: () => { },
+  deleteAttachedFile: async () => { },
   setFocusMode: () => { },
   setCategory: () => { },
   setOptimizationMode: () => { },

--- a/packages/research-agent-ui/src/hooks/useChat/ChatProvider.tsx
+++ b/packages/research-agent-ui/src/hooks/useChat/ChatProvider.tsx
@@ -9,7 +9,9 @@
 
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { useParams, useSearchParams, useRouter } from 'next/navigation';
-import { ChatTurn } from '../../components/ChatConversation/ChatWindow';
+import { toast } from 'sonner';
+import { deleteUploadedFile } from 'qwksearch-api-client';
+import { ChatTurn, UserMessage } from '../../components/ChatConversation/ChatWindow';
 import { saveGuestChat, GuestChat, updateGuestChatTitle } from '../../lib/guest';
 import { generateChatTitle } from '../../lib/chatTitle';
 import { useSession } from '../useSession';
@@ -266,6 +268,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
           loading: state.loading,
           messages: state.messages,
           fileIds: state.fileIds,
+          files: state.files,
           focusMode: state.focusMode,
           category: state.category,
           optimizationMode: state.optimizationMode,
@@ -287,6 +290,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       state.loading,
       state.messages,
       state.fileIds,
+      state.files,
       state.focusMode,
       state.category,
       state.optimizationMode,
@@ -331,6 +335,46 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       handleSendMessage(message.content, message.messageId, true);
     },
     [state.messages, chatTurns, handleSendMessage],
+  );
+
+  /**
+   * Deletes an uploaded file everywhere it appears.
+   *
+   * Optimistically removes the file from the chat-level attachment lists and
+   * from any user message that referenced it, then deletes the underlying
+   * upload from the server. On server failure the local removal is kept (the
+   * file is already gone from the user's view) and an error toast is shown.
+   */
+  const handleDeleteAttachedFile = useCallback(
+    async (fileId: string) => {
+      // Remove from the chat-level attachment lists (composer + context).
+      setters.setFiles(state.files.filter((f) => f.fileId !== fileId));
+      setters.setFileIds(state.fileIds.filter((id) => id !== fileId));
+
+      // Remove from any message that carried this file inline.
+      setters.setMessages((prev) =>
+        prev.map((msg) => {
+          if (msg.role !== 'user') return msg;
+          const userMsg = msg as UserMessage;
+          if (!userMsg.files?.some((f) => f.fileId === fileId)) return msg;
+          return {
+            ...userMsg,
+            files: userMsg.files.filter((f) => f.fileId !== fileId),
+          };
+        }),
+      );
+
+      try {
+        const { error } = await deleteUploadedFile({ query: { fileId } });
+        if (error) {
+          throw new Error((error as { message?: string }).message ?? 'Delete failed');
+        }
+      } catch (err) {
+        console.error('[ChatProvider] Failed to delete uploaded file:', err);
+        toast.error('Removed from the chat, but the file could not be deleted from storage.');
+      }
+    },
+    [state.files, state.fileIds],
   );
 
   /**
@@ -386,6 +430,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     // Actions
     setFileIds: setters.setFileIds,
     setFiles: setters.setFiles,
+    deleteAttachedFile: handleDeleteAttachedFile,
     setFocusMode: setters.setFocusMode,
     setCategory: setters.setCategory,
     setOptimizationMode: setters.setOptimizationMode,

--- a/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
+++ b/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
@@ -13,7 +13,7 @@ import {
 } from "../../components/ChatConversation/ChatWindow";
 import { getSuggestions } from "../../lib/suggestions";
 import { researchAgentUIConfig } from "../../config";
-import { ChatModelProvider } from "../../types/chat";
+import { ChatModelProvider, ChatFile } from "../../types/chat";
 import { agentChat, saveMessage } from "qwksearch-api-client";
 
 const ARTICLE_PREFETCH_COUNT = 3;
@@ -65,6 +65,8 @@ export interface SendMessageDeps {
   messages: Message[];
   /** IDs of files attached to the chat */
   fileIds: string[];
+  /** Full metadata of files attached to the chat (for inline display). */
+  files: ChatFile[];
   /** Current search/focus mode */
   focusMode: string;
   /** Current category for search filtering */
@@ -133,6 +135,7 @@ export async function sendMessage(
     loading,
     messages,
     fileIds,
+    files,
     focusMode,
     category,
     optimizationMode,
@@ -195,6 +198,10 @@ export async function sendMessage(
   // Generate or use provided message ID
   const messageId = providedMessageId ?? generateMessageId();
 
+  // Snapshot the files attached at send time so they render inline with this
+  // specific user message (the chat-level attachment list is cleared after send).
+  const attachedFiles: ChatFile[] = Array.isArray(files) ? [...files] : [];
+
   // Add user message to chat immediately
   setMessages((prevMessages) => [
     ...prevMessages,
@@ -204,6 +211,7 @@ export async function sendMessage(
       chatId: chatId,
       role: "user",
       createdAt: new Date(),
+      ...(attachedFiles.length > 0 ? { files: attachedFiles } : {}),
     },
   ]);
 

--- a/packages/write-language/src/generate-response.attachments.test.ts
+++ b/packages/write-language/src/generate-response.attachments.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Verifies that file/image attachments are forwarded to the
+ * Vercel AI SDK as multimodal `messages` content parts, and that plain
+ * (attachment-free) calls keep using the simpler `prompt` form.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture the exact arguments passed to generateText so we can assert on the
+// shape of the request the SDK receives.
+const generateTextMock = vi.fn((_args: unknown) => Promise.resolve({ text: "ok" }));
+
+vi.mock("ai", () => ({
+  generateText: (args: unknown) => generateTextMock(args),
+  stepCountIs: (n: number) => n,
+  tool: (t: unknown) => t,
+}));
+
+// Return a truthy fake model so writeLanguageResponse proceeds to generateText.
+vi.mock("./provider-factory", () => ({
+  createLLMProvider: () => ({ id: "fake-model" }),
+}));
+
+// Avoid pulling the markdown/prism stack into the test.
+vi.mock("./utils/markdown-to-html", () => ({
+  convertMarkdownToHTMLEscaped: async (s: string) => s,
+}));
+
+import { writeLanguageResponse } from "./generate-response";
+
+afterEach(() => {
+  generateTextMock.mockClear();
+});
+
+describe("writeLanguageResponse attachments", () => {
+  const base = {
+    provider: "groq",
+    apiKey: "test-key",
+    agent: "question",
+    query: "Describe the attached file",
+    html: false,
+    applyContextLimit: false,
+  } as const;
+
+  it("sends a plain text prompt when there are no attachments", async () => {
+    await writeLanguageResponse({ ...base });
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const arg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(typeof arg.prompt).toBe("string");
+    expect(arg.messages).toBeUndefined();
+  });
+
+  it("sends an image attachment as an image content part", async () => {
+    await writeLanguageResponse({
+      ...base,
+      attachments: [
+        { mediaType: "image/png", data: "data:image/png;base64,AAAA" },
+      ],
+    });
+
+    const arg = generateTextMock.mock.calls[0][0] as any;
+    expect(arg.prompt).toBeUndefined();
+    expect(Array.isArray(arg.messages)).toBe(true);
+    const parts = arg.messages[0].content;
+    expect(parts[0]).toMatchObject({ type: "text" });
+    expect(parts[1]).toMatchObject({
+      type: "image",
+      image: "data:image/png;base64,AAAA",
+    });
+  });
+
+  it("sends a document attachment as a file content part with its mediaType", async () => {
+    await writeLanguageResponse({
+      ...base,
+      attachments: [
+        {
+          mediaType: "application/pdf",
+          data: "JVBERi0=",
+          filename: "report.pdf",
+        },
+      ],
+    });
+
+    const arg = generateTextMock.mock.calls[0][0] as any;
+    const parts = arg.messages[0].content;
+    expect(parts[1]).toMatchObject({
+      type: "file",
+      mediaType: "application/pdf",
+      data: "JVBERi0=",
+      filename: "report.pdf",
+    });
+  });
+
+  it("skips malformed attachments (missing data or mediaType)", async () => {
+    await writeLanguageResponse({
+      ...base,
+      attachments: [
+        { mediaType: "", data: "x" } as any,
+        { mediaType: "image/png" } as any,
+        { mediaType: "image/jpeg", data: "data:image/jpeg;base64,BBBB" },
+      ],
+    });
+
+    const arg = generateTextMock.mock.calls[0][0] as any;
+    const parts = arg.messages[0].content;
+    // 1 text part + 1 valid image part only.
+    expect(parts).toHaveLength(2);
+    expect(parts[1]).toMatchObject({ type: "image" });
+  });
+});

--- a/packages/write-language/src/generate-response.ts
+++ b/packages/write-language/src/generate-response.ts
@@ -13,12 +13,14 @@ import type {
   AgentTool,
   GenerateLanguageOptions,
   GenerateLanguageResult,
+  LanguageAttachment,
 } from "./generation-types";
 
 export type {
   LLMProviderName,
   GenerateLanguageOptions,
   GenerateLanguageResult,
+  LanguageAttachment,
 } from "./generation-types";
 export { convertMarkdownToHTMLEscaped } from "./utils/markdown-to-html";
 
@@ -61,6 +63,7 @@ export async function writeLanguageResponse(
     temperature = 1,
     html = true,
     applyContextLimit = true,
+    attachments,
     ...context
   } = options;
 
@@ -144,10 +147,23 @@ export async function writeLanguageResponse(
         : undefined;
 
     // \u2500\u2500 8. Invoke LLM via Vercel AI SDK generateText \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    // When files/images are attached, issue a multimodal `messages` request so
+    // the model receives the uploaded content directly. Otherwise fall back to
+    // the simpler `prompt` form.
+    const fileParts = buildAttachmentParts(attachments);
     const { text: rawReply } = await generateText({
       model: llm,
-      prompt,
       temperature,
+      ...(fileParts.length > 0
+        ? {
+            messages: [
+              {
+                role: "user" as const,
+                content: [{ type: "text" as const, text: prompt }, ...fileParts],
+              },
+            ],
+          }
+        : { prompt }),
       ...(tools && { tools, stopWhen: stepCountIs(10) }),
     });
 
@@ -170,6 +186,42 @@ export async function writeLanguageResponse(
             "Failed to generate response. Please try again later."),
     };
   }
+}
+
+/**
+ * Converts {@link LanguageAttachment}s into Vercel AI SDK message content
+ * parts. `image/*` attachments (or those with `kind: "image"`) become
+ * `image` parts; everything else becomes a `file` part carrying its
+ * `mediaType`. Attachments without usable data are skipped.
+ *
+ * @param attachments - File/image attachments from the caller
+ * @returns An array of AI SDK content parts (empty when none are supplied)
+ */
+function buildAttachmentParts(
+  attachments: LanguageAttachment[] | undefined,
+): Array<
+  | { type: "image"; image: LanguageAttachment["data"] }
+  | { type: "file"; data: LanguageAttachment["data"]; mediaType: string; filename?: string }
+> {
+  if (!Array.isArray(attachments) || attachments.length === 0) return [];
+
+  return attachments
+    .filter((a) => a && a.data != null && a.mediaType)
+    .map((a) => {
+      const isImage =
+        a.kind === "image" ||
+        (a.kind !== "file" && a.mediaType.toLowerCase().startsWith("image/"));
+
+      if (isImage) {
+        return { type: "image" as const, image: a.data };
+      }
+      return {
+        type: "file" as const,
+        data: a.data,
+        mediaType: a.mediaType,
+        ...(a.filename ? { filename: a.filename } : {}),
+      };
+    });
 }
 
 /**

--- a/packages/write-language/src/generation-types.ts
+++ b/packages/write-language/src/generation-types.ts
@@ -21,6 +21,31 @@ export type LLMProviderName =
   | (string & {}); // preserve autocomplete while allowing arbitrary strings
 
 /**
+ * A file or image attachment passed to the model alongside the text prompt.
+ *
+ * The Vercel AI SDK accepts these as multimodal message content parts:
+ * images become `{ type: "image", image }` parts and every other media type
+ * becomes a `{ type: "file", data, mediaType }` part. `data` may be a base64
+ * string, a `data:` URL, an `http(s)` URL, a `URL` instance, or raw bytes.
+ */
+export interface LanguageAttachment {
+  /** MIME type, e.g. `"image/png"`, `"application/pdf"`. */
+  mediaType: string;
+  /**
+   * The attachment payload: a base64 string, a `data:`/`http(s)` URL, a `URL`
+   * instance, or raw bytes (`Uint8Array`/`ArrayBuffer`).
+   */
+  data: string | Uint8Array | ArrayBuffer | URL;
+  /** Optional original filename (used by providers that surface it). */
+  filename?: string;
+  /**
+   * Force how the part is sent. Defaults to auto-detection from `mediaType`
+   * (`image/*` → image part, otherwise a file part).
+   */
+  kind?: "image" | "file";
+}
+
+/**
  * Configuration options for {@link writeLanguageResponse}.
  */
 export interface GenerateLanguageOptions {
@@ -47,6 +72,12 @@ export interface GenerateLanguageOptions {
   article?: string;
   /** Prior conversation history for context-aware agents */
   chat_history?: string;
+  /**
+   * File and image attachments to send to the model alongside the prompt.
+   * When present, the request is issued as a multimodal `messages` call so the
+   * model receives the uploaded files (images and documents) directly.
+   */
+  attachments?: LanguageAttachment[];
   /** Return `HTML` (`true`) or raw Markdown (`false`). Default: `true` */
   html?: boolean;
   /** Truncate the prompt to the model's context window length. Default: `true` */

--- a/packages/write-language/src/index.ts
+++ b/packages/write-language/src/index.ts
@@ -18,6 +18,7 @@ export type {
   LLMProviderName,
   GenerateLanguageOptions,
   GenerateLanguageResult,
+  LanguageAttachment,
 } from "./generate-response";
 
 export type {


### PR DESCRIPTION
## Summary
This PR extends the chat system to support image uploads as first-class multimodal content, allowing images to be passed directly to LLMs as image content parts alongside text prompts and documents.

## Key Changes

### Image Upload Infrastructure
- **New image extension support**: Added `SUPPORTED_IMAGE_EXTENSIONS` constant and helper functions (`imageMediaType`, `isImageExtension`) to distinguish image uploads from document uploads
- **Image inlining**: Implemented `MAX_INLINE_IMAGE_BYTES` (8 MB) limit and base64 data URL generation for images small enough to send directly to LLMs
- **Extracted payload enhancement**: Extended `ExtractedUpload` interface to include `mediaType` and `image` fields for image metadata and inline data

### Chat Agent Toolkit Updates
- **New interfaces**: Added `LoadedUpload` and `UploadImageAttachment` types to represent resolved uploads with image support
- **Image resolution**: Created `loadUploadImages()` function to extract image attachments from uploaded fileIds for passing to the LLM
- **Upload resolution refactor**: Extracted common upload resolution logic into `resolveUpload()` helper used by both `rerankDocs` and `loadUploadImages`
- **Document filtering**: Updated `rerankDocs` to exclude image uploads (which have no text content) from document context, preventing empty file docs

### Multimodal Message Support
- **Attachment types**: Added `LanguageAttachment` interface to `generation-types.ts` supporting images, documents, and arbitrary file types
- **Message building**: Implemented `buildAttachmentParts()` to convert attachments into Vercel AI SDK message content parts (image vs. file parts)
- **Conditional request format**: Modified `writeLanguageResponse()` to use multimodal `messages` format when attachments are present, falling back to simple `prompt` format otherwise
- **MetaSearchAgent integration**: Updated to resolve and pass image attachments as image content parts in the chat stream

### UI Components
- **Message attachments display**: Created `MessageAttachments` component to render file chips inline in conversation with delete functionality
- **File deletion**: Implemented `deleteAttachedFile()` in ChatProvider to remove files from server, chat state, and individual messages
- **File metadata**: Extended `UserMessage` interface with optional `files` array and added `MessageFile` type for attachment metadata

### Testing
- **Attachment handling tests**: Added comprehensive test suite (`generate-response.attachments.test.ts`) verifying multimodal message construction and attachment filtering
- **Image helper tests**: Added tests for image extension recognition, MIME type mapping, and `buildExtractedUpload()` behavior with size limits
- **Integration tests**: Extended upload-to-LLM tests to verify image attachments reach the LLM via `loadUploadImages()`

## Implementation Details
- Images are stored with their original binary data but only inlined as base64 data URLs if under the 8 MB threshold
- The upload extraction pipeline now handles both text extraction (documents) and image metadata/inlining (images) through a unified `buildExtractedUpload()` function
- File deletion is optimistic: files are removed from the UI immediately, with server deletion attempted afterward; failures show a toast but don't restore the UI state
- The LLM receives images as native image content parts (not wrapped in text) for better model handling

https://claude.ai/code/session_018c25T3iVYVPTrJytLitXj7