### PR TITLE
Extract settings schema to data layer; introduce shadcn-settings renderer

### DIFF
--- a/apps/qwksearch-web/components/Settings/SettingsContent.tsx
+++ b/apps/qwksearch-web/components/Settings/SettingsContent.tsx
@@ -13,7 +13,8 @@ import {
   Brain,
 } from 'lucide-react';
 import Account from './Sections/Account';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Fuse from 'fuse.js';
 import { AnchorTitle, highlightAnchor } from './anchors';
 import grab from 'grab-url';
 import { toast } from 'sonner';
@@ -128,8 +129,27 @@ const SettingsContent = ({
   const [selectedSection, setSelectedSection] = useState(
     sections.find((s) => s.key === initialKey)!,
   );
+  const [searchQuery, setSearchQuery] = useState('');
 
   const isFirstUrlSync = useRef(true);
+
+  // Fuzzy-search index over the settings menu items so the sidebar can be
+  // filtered down as the user types.
+  const fuse = useMemo(
+    () =>
+      new Fuse(sections, {
+        keys: ['name', 'description'],
+        threshold: 0.4,
+        ignoreLocation: true,
+      }),
+    [],
+  );
+
+  const filteredSections = useMemo(() => {
+    const query = searchQuery.trim();
+    if (!query) return sections;
+    return fuse.search(query).map((result) => result.item);
+  }, [fuse, searchQuery]);
 
   useEffect(() => {
     setSelectedSection(sections.find((s) => s.key === activeSection)!);
@@ -224,22 +244,42 @@ const SettingsContent = ({
             Back
           </p>
         </button>
-        <div className="flex flex-col items-start space-y-1 mt-8">
-          {sections.map((section) => (
-            <button
-              key={section.dataAdd}
-              className={cn(
-                `flex flex-row items-center space-x-2 px-2 py-1.5 rounded-lg w-full text-sm hover:bg-light-200 hover:dark:bg-dark-200 transition duration-200 active:scale-95`,
-                activeSection === section.key
-                  ? 'bg-light-200 dark:bg-dark-200 text-black/90 dark:text-white/90'
-                  : ' text-black/70 dark:text-white/70',
-              )}
-              onClick={() => setActiveSection(section.key)}
-            >
-              <section.icon size={17} />
-              <p>{section.name}</p>
-            </button>
-          ))}
+        <div className="relative mt-8">
+          <Search
+            size={15}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-black/40 dark:text-white/40 pointer-events-none"
+          />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search settings"
+            aria-label="Search settings"
+            className="w-full bg-light-200 dark:bg-dark-200 text-black/90 dark:text-white/90 placeholder:text-black/40 dark:placeholder:text-white/40 text-sm rounded-lg pl-8 pr-2 py-1.5 outline-none focus:ring-1 focus:ring-black/10 dark:focus:ring-white/10"
+          />
+        </div>
+        <div className="flex flex-col items-start space-y-1 mt-3">
+          {filteredSections.length === 0 ? (
+            <p className="text-xs text-black/50 dark:text-white/50 px-2 py-1.5">
+              No settings match &ldquo;{searchQuery.trim()}&rdquo;.
+            </p>
+          ) : (
+            filteredSections.map((section) => (
+              <button
+                key={section.dataAdd}
+                className={cn(
+                  `flex flex-row items-center space-x-2 px-2 py-1.5 rounded-lg w-full text-sm hover:bg-light-200 hover:dark:bg-dark-200 transition duration-200 active:scale-95`,
+                  activeSection === section.key
+                    ? 'bg-light-200 dark:bg-dark-200 text-black/90 dark:text-white/90'
+                    : ' text-black/70 dark:text-white/70',
+                )}
+                onClick={() => setActiveSection(section.key)}
+              >
+                <section.icon size={17} />
+                <p>{section.name}</p>
+              </button>
+            ))
+          )}
         </div>
       </div>
       <div className="w-full flex flex-col overflow-hidden">

--- a/apps/qwksearch-web/components/Settings/SettingsContent.tsx
+++ b/apps/qwksearch-web/components/Settings/SettingsContent.tsx
@@ -37,81 +37,45 @@ import FileSources from './Sections/FileSources';
 import AIRewriteModes from './Sections/AIRewriteModes';
 import VoiceSection from './Sections/Voice';
 import SkillsAndMemory from './Sections/SkillsAndMemory';
+import { settingsSections } from 'research-agent-ui/settings';
+import type { ComponentType } from 'react';
 
-const sections = [
-  {
-    key: 'account',
-    name: 'Account',
-    description: 'Manage your profile, password, and linked accounts.',
-    icon: UserCircle,
-    component: Account,
-    dataAdd: 'account',
-  },
-  {
-    key: 'models',
-    name: 'Language Models',
-    description: 'Connect to AI services and manage connections.',
-    icon: BrainCog,
-    component: Models,
-    dataAdd: 'modelProviders',
-  },
-  {
-    key: 'mcpservers',
-    name: 'Connectors',
-    description: 'Configure Model Context Protocol servers.',
-    icon: Server,
-    component: MCPServers,
-    dataAdd: 'mcpServers',
-  },
-  {
-    key: 'skills-memory',
-    name: 'Skills & Memory',
-    description: 'Manage agent skills and view your stored memories.',
-    icon: Brain,
-    component: SkillsAndMemory,
-    dataAdd: 'skillsMemory',
-  },
-  {
-    key: 'searchEngines',
-    name: 'Search Sources',
-    description: 'Manage search engine sources by category.',
-    icon: Search,
-    component: SearchEngines,
-    dataAdd: 'searchEngines',
-  },
-  {
-    key: 'search',
-    name: 'Search Settings',
-    description: 'Configure search parameters.',
-    icon: Search,
-    component: SearchSection,
-    dataAdd: 'search',
-  },
-  {
-    key: 'fileSources',
-    name: 'Cloud Storage',
-    description: 'Manage storage sources (SSH, S3, R2, B2, Google Docs, Turso DB).',
-    icon: HardDrive,
-    component: FileSources,
-    dataAdd: 'storage',
-  },
-  {
-    key: 'aiRewriteModes',
-    name: 'Rewrite Modes',
-    description: 'Customize AI rewrite prompts and add your own modes.',
-    icon: Wand2,
-    component: AIRewriteModes,
-    dataAdd: 'rewritePrompts',
-  },
-  {
-    key: 'voice',
-    name: 'Voice Settings',
-    description: 'Configure text-to-speech with Kokoro.js or Cloudflare TTS.',
-    icon: Volume2,
-    component: VoiceSection,
-    dataAdd: 'voice',
-  },
-];
+// The section list (order, labels, descriptions, icon names) is declared as
+// data in research-agent-ui. The React components and lucide icons stay here in
+// the app and are keyed back onto that schema.
+const SECTION_COMPONENTS: Record<string, ComponentType<any>> = {
+  account: Account,
+  models: Models,
+  mcpservers: MCPServers,
+  'skills-memory': SkillsAndMemory,
+  searchEngines: SearchEngines,
+  search: SearchSection,
+  fileSources: FileSources,
+  aiRewriteModes: AIRewriteModes,
+  voice: VoiceSection,
+};
+
+const SECTION_ICONS: Record<string, ComponentType<any>> = {
+  UserCircle,
+  BrainCog,
+  Server,
+  Brain,
+  Search,
+  HardDrive,
+  Wand2,
+  Volume2,
+};
+
+const sections = settingsSections
+  .filter((section) => SECTION_COMPONENTS[section.key])
+  .map((section) => ({
+    key: section.key,
+    name: section.name,
+    description: section.description,
+    icon: SECTION_ICONS[section.icon] ?? Search,
+    component: SECTION_COMPONENTS[section.key],
+    dataAdd: section.dataAdd,
+  }));
 
 export { sections };
 

--- a/apps/qwksearch-web/components/Settings/SettingsField.tsx
+++ b/apps/qwksearch-web/components/Settings/SettingsField.tsx
@@ -1,30 +1,47 @@
-import {
-  PasswordUIConfigField,
-  SelectUIConfigField,
-  StringUIConfigField,
-  SwitchUIConfigField,
-  TextareaUIConfigField,
-  ThemeUIConfigField,
-  UIConfigField,
-} from '../../lib/config/types';
-import { useState, useEffect } from 'react';
+'use client';
+
+import { UIConfigField } from '../../lib/config/types';
+import { useEffect, useState } from 'react';
 import grab from 'grab-url';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from '../ui/select';
 import { toast } from 'sonner';
 import { useTheme } from 'next-themes';
-import { Eye, EyeOff, Loader2, Moon, Sun } from 'lucide-react';
-import { Switch } from '@/components/ui/switch';
+import { Link2, Moon, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { AnchorTitle } from './anchors';
+import { copyAnchorLink } from './anchors';
+import {
+  SettingsField as SettingsFieldRenderer,
+  type SettingsClassNames,
+  type SettingsFieldRenderProps,
+  type SettingsFieldRenderers,
+  type SettingsValue,
+} from 'shadcn-settings';
 
 const fieldAnchorId = (dataAdd: string, fieldKey: string) =>
   `${dataAdd}-${fieldKey}`;
+
+// Class-name overrides that keep the shadcn-settings renderer looking like the
+// rest of the app (light-200 / dark-primary tokens, muted helper text).
+const APP_FIELD_CLASSNAMES: SettingsClassNames = {
+  root: 'rounded-xl border border-light-200 bg-light-primary/80 dark:border-dark-200 dark:bg-dark-primary/80',
+  title: 'text-black dark:text-white',
+  description: 'text-black/50 dark:text-white/50',
+};
+
+const emitClientConfigChanged = () => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('client-config-changed'));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Theme picker — app-specific variant injected into the shared renderer.
+// ---------------------------------------------------------------------------
 
 const themeNames = [
   "modern-minimal", "elegant-luxury", "cyberpunk", "twitter",
@@ -67,437 +84,11 @@ const themeColors: Record<string, { primary: string; secondary: string }> = {
 const formatThemeName = (name: string) =>
   name.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 
-const FieldLinks = ({ links }: { links?: { name: string; url: string }[] }) => {
-  if (!links?.length) return null;
-  return (
-    <div className="flex flex-wrap gap-2 mt-1">
-      {links.map((link) => (
-        <a
-          key={link.url}
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-[11px] lg:text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 underline"
-        >
-          {link.name}
-        </a>
-      ))}
-    </div>
-  );
-};
-
-const emitClientConfigChanged = () => {
-  if (typeof window !== 'undefined') {
-    window.dispatchEvent(new Event('client-config-changed'));
-  }
-};
-
-const SettingsSelect = ({
-  field,
-  value,
-  setValue,
-  dataAdd,
-}: {
-  field: SelectUIConfigField;
-  value?: any;
-  setValue: (value: any) => void;
-  dataAdd: string;
-}) => {
-  const [loading, setLoading] = useState(false);
-  const { setTheme } = useTheme();
-
-  const handleSave = async (newValue: any) => {
-    setLoading(true);
-    setValue(newValue);
-    try {
-      if (field.scope === 'client') {
-        localStorage.setItem(field.key, newValue);
-        if (field.key === 'theme') {
-          setTheme(newValue);
-        }
-        emitClientConfigChanged();
-      } else {
-        await grab('config', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            key: `${dataAdd}.${field.key}`,
-            value: newValue,
-          }),
-        });
-      }
-    } catch (error) {
-      console.error('Error saving config:', error);
-      toast.error('Failed to save configuration.');
-    } finally {
-      setTimeout(() => setLoading(false), 150);
-    }
-  };
-
-  return (
-    <section
-      id={fieldAnchorId(dataAdd, field.key)}
-      className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
-    >
-      <div className="space-y-3 lg:space-y-5">
-        <div>
-          <h4 className="text-sm lg:text-sm text-black dark:text-white">
-            <AnchorTitle anchorId={fieldAnchorId(dataAdd, field.key)}>
-              {field.name}
-            </AnchorTitle>
-          </h4>
-          <p className="text-[11px] lg:text-xs text-black/50 dark:text-white/50">
-            {field.description}
-          </p>
-          <FieldLinks links={field.links} />
-        </div>
-        <Select
-          value={value}
-          onValueChange={(newValue) => handleSave(newValue)}
-          disabled={loading}
-        >
-          <SelectTrigger className="w-full bg-light-primary dark:bg-dark-primary border-light-200 dark:border-dark-200 text-black dark:text-white">
-            <SelectValue placeholder="Select an option" />
-          </SelectTrigger>
-          <SelectContent className="bg-light-primary dark:bg-dark-primary border-light-200 dark:border-dark-200">
-            {field.options
-              .filter((option) => option.value !== '')
-              .map((option) => (
-                <SelectItem
-                  key={option.value}
-                  value={option.value}
-                  className="text-black dark:text-white focus:bg-light-200 dark:focus:bg-dark-200"
-                >
-                  {option.name}
-                </SelectItem>
-              ))}
-          </SelectContent>
-        </Select>
-      </div>
-    </section>
-  );
-};
-
-const SettingsInput = ({
-  field,
-  value,
-  setValue,
-  dataAdd,
-}: {
-  field: StringUIConfigField;
-  value?: any;
-  setValue: (value: any) => void;
-  dataAdd: string;
-}) => {
-  const [loading, setLoading] = useState(false);
-
-  const handleSave = async (newValue: any) => {
-    setLoading(true);
-    setValue(newValue);
-    try {
-      if (field.scope === 'client') {
-        localStorage.setItem(field.key, newValue);
-        emitClientConfigChanged();
-      } else {
-        await grab('config', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            key: `${dataAdd}.${field.key}`,
-            value: newValue,
-          }),
-        });
-      }
-    } catch (error) {
-      console.error('Error saving config:', error);
-      toast.error('Failed to save configuration.');
-    } finally {
-      setTimeout(() => setLoading(false), 150);
-    }
-  };
-
-  return (
-    <section
-      id={fieldAnchorId(dataAdd, field.key)}
-      className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
-    >
-      <div className="space-y-3 lg:space-y-5">
-        <div>
-          <h4 className="text-sm lg:text-sm text-black dark:text-white">
-            <AnchorTitle anchorId={fieldAnchorId(dataAdd, field.key)}>
-              {field.name}
-            </AnchorTitle>
-          </h4>
-          <p className="text-[11px] lg:text-xs text-black/50 dark:text-white/50">
-            {field.description}
-          </p>
-          <FieldLinks links={field.links} />
-        </div>
-        <div className="relative">
-          <input
-            value={value ?? field.default ?? ''}
-            onChange={(event) => setValue(event.target.value)}
-            onBlur={(event) => handleSave(event.target.value)}
-            className="w-full rounded-lg border border-light-200 dark:border-dark-200 bg-light-primary dark:bg-dark-primary px-3 py-2 lg:px-4 lg:py-3 pr-10 !text-xs lg:!text-[13px] text-black/80 dark:text-white/80 placeholder:text-black/40 dark:placeholder:text-white/40 focus-visible:outline-none focus-visible:border-light-300 dark:focus-visible:border-dark-300 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-            placeholder={field.placeholder}
-            type="text"
-            disabled={loading}
-          />
-          {loading && (
-            <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-black/40 dark:text-white/40">
-              <Loader2 className="h-4 w-4 animate-spin" />
-            </span>
-          )}
-        </div>
-      </div>
-    </section>
-  );
-};
-
-const SettingsPasswordInput = ({
-  field,
-  value,
-  setValue,
-  dataAdd,
-}: {
-  field: PasswordUIConfigField;
-  value?: any;
-  setValue: (value: any) => void;
-  dataAdd: string;
-}) => {
-  const [loading, setLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-
-  const handleSave = async (newValue: any) => {
-    setLoading(true);
-    setValue(newValue);
-    try {
-      if (field.scope === 'client') {
-        localStorage.setItem(field.key, newValue);
-        emitClientConfigChanged();
-      } else {
-        await grab('config', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ key: `${dataAdd}.${field.key}`, value: newValue }),
-        });
-      }
-    } catch (error) {
-      console.error('Error saving config:', error);
-      toast.error('Failed to save configuration.');
-    } finally {
-      setTimeout(() => setLoading(false), 150);
-    }
-  };
-
-  return (
-    <section
-      id={fieldAnchorId(dataAdd, field.key)}
-      className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
-    >
-      <div className="space-y-3 lg:space-y-5">
-        <div>
-          <h4 className="text-sm lg:text-sm text-black dark:text-white">
-            <AnchorTitle anchorId={fieldAnchorId(dataAdd, field.key)}>
-              {field.name}
-            </AnchorTitle>
-          </h4>
-          <p className="text-[11px] lg:text-xs text-black/50 dark:text-white/50">
-            {field.description}
-          </p>
-          <FieldLinks links={field.links} />
-        </div>
-        <div className="relative">
-          <input
-            value={value ?? field.default ?? ''}
-            onChange={(event) => setValue(event.target.value)}
-            onBlur={(event) => handleSave(event.target.value)}
-            className="w-full rounded-lg border border-light-200 dark:border-dark-200 bg-light-primary dark:bg-dark-primary px-3 py-2 lg:px-4 lg:py-3 pr-16 !text-xs lg:!text-[13px] text-black/80 dark:text-white/80 placeholder:text-black/40 dark:placeholder:text-white/40 focus-visible:outline-none focus-visible:border-light-300 dark:focus-visible:border-dark-300 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-            placeholder={field.placeholder}
-            type={showPassword ? 'text' : 'password'}
-            disabled={loading}
-          />
-          <button
-            type="button"
-            onClick={() => setShowPassword((v) => !v)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-black/40 hover:text-black/70 dark:text-white/40 dark:hover:text-white/70 transition-colors"
-            title={showPassword ? 'Hide' : 'Show'}
-          >
-            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-          </button>
-          {loading && (
-            <span className="pointer-events-none absolute right-8 top-1/2 -translate-y-1/2 text-black/40 dark:text-white/40">
-              <Loader2 className="h-4 w-4 animate-spin" />
-            </span>
-          )}
-        </div>
-      </div>
-    </section>
-  );
-};
-
-const SettingsTextarea = ({
-  field,
-  value,
-  setValue,
-  dataAdd,
-}: {
-  field: TextareaUIConfigField;
-  value?: any;
-  setValue: (value: any) => void;
-  dataAdd: string;
-}) => {
-  const [loading, setLoading] = useState(false);
-
-  const handleSave = async (newValue: any) => {
-    setLoading(true);
-    setValue(newValue);
-    try {
-      if (field.scope === 'client') {
-        localStorage.setItem(field.key, newValue);
-        emitClientConfigChanged();
-      } else {
-        await grab('config', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            key: `${dataAdd}.${field.key}`,
-            value: newValue,
-          }),
-        });
-      }
-    } catch (error) {
-      console.error('Error saving config:', error);
-      toast.error('Failed to save configuration.');
-    } finally {
-      setTimeout(() => setLoading(false), 150);
-    }
-  };
-
-  return (
-    <section
-      id={fieldAnchorId(dataAdd, field.key)}
-      className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
-    >
-      <div className="space-y-3 lg:space-y-5">
-        <div>
-          <h4 className="text-sm lg:text-sm text-black dark:text-white">
-            <AnchorTitle anchorId={fieldAnchorId(dataAdd, field.key)}>
-              {field.name}
-            </AnchorTitle>
-          </h4>
-          <p className="text-[11px] lg:text-xs text-black/50 dark:text-white/50">
-            {field.description}
-          </p>
-          <FieldLinks links={field.links} />
-        </div>
-        <div className="relative">
-          <textarea
-            value={value ?? field.default ?? ''}
-            onChange={(event) => setValue(event.target.value)}
-            onBlur={(event) => handleSave(event.target.value)}
-            className="w-full rounded-lg border border-light-200 dark:border-dark-200 bg-light-primary dark:bg-dark-primary px-3 py-2 lg:px-4 lg:py-3 pr-10 !text-xs lg:!text-[13px] text-black/80 dark:text-white/80 placeholder:text-black/40 dark:placeholder:text-white/40 focus-visible:outline-none focus-visible:border-light-300 dark:focus-visible:border-dark-300 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-            placeholder={field.placeholder}
-            rows={4}
-            disabled={loading}
-          />
-          {loading && (
-            <span className="pointer-events-none absolute right-3 translate-y-3 text-black/40 dark:text-white/40">
-              <Loader2 className="h-4 w-4 animate-spin" />
-            </span>
-          )}
-        </div>
-      </div>
-    </section>
-  );
-};
-
-const SettingsSwitch = ({
-  field,
-  value,
-  setValue,
-  dataAdd,
-}: {
-  field: SwitchUIConfigField;
-  value?: any;
-  setValue: (value: any) => void;
-  dataAdd: string;
-}) => {
-  const [loading, setLoading] = useState(false);
-
-  const handleSave = async (newValue: boolean) => {
-    setLoading(true);
-    setValue(newValue);
-    try {
-      if (field.scope === 'client') {
-        localStorage.setItem(field.key, String(newValue));
-        emitClientConfigChanged();
-      } else {
-        await grab('config', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            key: `${dataAdd}.${field.key}`,
-            value: newValue,
-          }),
-        });
-      }
-    } catch (error) {
-      console.error('Error saving config:', error);
-      toast.error('Failed to save configuration.');
-    } finally {
-      setTimeout(() => setLoading(false), 150);
-    }
-  };
-
-  const isChecked = value === true || value === 'true';
-
-  return (
-    <section
-      id={fieldAnchorId(dataAdd, field.key)}
-      className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
-    >
-      <div className="flex flex-row items-center space-x-3 lg:space-x-5 w-full justify-between">
-        <div>
-          <h4 className="text-sm lg:text-sm text-black dark:text-white">
-            <AnchorTitle anchorId={fieldAnchorId(dataAdd, field.key)}>
-              {field.name}
-            </AnchorTitle>
-          </h4>
-          <p className="text-[11px] lg:text-xs text-black/50 dark:text-white/50">
-            {field.description}
-          </p>
-          <FieldLinks links={field.links} />
-        </div>
-        <Switch
-          checked={isChecked}
-          onCheckedChange={handleSave}
-          disabled={loading}
-          className="h-6 w-12"
-        />
-      </div>
-    </section>
-  );
-};
-
 const SettingsThemeSelect = ({
   field,
-  setValue,
-  dataAdd,
-}: {
-  field: ThemeUIConfigField;
-  value?: any;
-  setValue: (value: any) => void;
-  dataAdd: string;
-}) => {
+  anchorId,
+  titleAddon,
+}: SettingsFieldRenderProps) => {
   const { theme, setTheme } = useTheme();
   const [colorTheme, setColorTheme] = useState("modern-minimal");
   const [mounted, setMounted] = useState(false);
@@ -510,7 +101,6 @@ const SettingsThemeSelect = ({
 
   const handleColorThemeChange = (newTheme: string) => {
     setColorTheme(newTheme);
-    setValue(newTheme);
     localStorage.setItem("color-theme", newTheme);
     document.cookie = `color-theme=${newTheme}; path=/; max-age=31536000`;
     themeNames.forEach(t => document.documentElement.classList.remove(`theme-${t}`));
@@ -524,16 +114,15 @@ const SettingsThemeSelect = ({
 
   return (
     <section
-      id={fieldAnchorId(dataAdd, field.key)}
+      id={anchorId}
       className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
     >
       <div className="space-y-3 lg:space-y-5">
         <div className="flex items-center justify-between">
           <div>
-            <h4 className="text-sm text-black dark:text-white">
-              <AnchorTitle anchorId={fieldAnchorId(dataAdd, field.key)}>
-                {field.name}
-              </AnchorTitle>
+            <h4 className="flex items-center gap-1.5 text-sm text-black dark:text-white">
+              {field.name}
+              {titleAddon}
             </h4>
             <p className="text-[11px] lg:text-xs text-black/50 dark:text-white/50">
               {field.description}
@@ -597,6 +186,28 @@ const SettingsThemeSelect = ({
   );
 };
 
+const CUSTOM_RENDERERS: SettingsFieldRenderers = {
+  theme: SettingsThemeSelect,
+};
+
+// A small copy-link button rendered next to each field's title, matching the
+// previous AnchorTitle affordance.
+const AnchorLinkButton = ({ anchorId }: { anchorId: string }) => (
+  <button
+    type="button"
+    onClick={() => copyAnchorLink(anchorId)}
+    title="Copy link to this section"
+    className="group/anchor inline-flex cursor-pointer items-center"
+  >
+    <Link2
+      size={12}
+      className="shrink-0 opacity-0 transition-opacity group-hover/anchor:opacity-60"
+    />
+  </button>
+);
+
+// ---------------------------------------------------------------------------
+
 const SettingsField = ({
   field,
   value,
@@ -606,66 +217,49 @@ const SettingsField = ({
   value: any;
   dataAdd: string;
 }) => {
-  const [val, setVal] = useState(value);
+  const [val, setVal] = useState<SettingsValue>(value);
+  const { setTheme } = useTheme();
+  const anchorId = fieldAnchorId(dataAdd, field.key);
 
-  switch (field.type) {
-    case 'theme':
-      return (
-        <SettingsThemeSelect
-          field={field}
-          value={val}
-          setValue={setVal}
-          dataAdd={dataAdd}
-        />
-      );
-    case 'select':
-      return (
-        <SettingsSelect
-          field={field}
-          value={val}
-          setValue={setVal}
-          dataAdd={dataAdd}
-        />
-      );
-    case 'string':
-      return (
-        <SettingsInput
-          field={field}
-          value={val}
-          setValue={setVal}
-          dataAdd={dataAdd}
-        />
-      );
-    case 'password':
-      return (
-        <SettingsPasswordInput
-          field={field}
-          value={val}
-          setValue={setVal}
-          dataAdd={dataAdd}
-        />
-      );
-    case 'textarea':
-      return (
-        <SettingsTextarea
-          field={field}
-          value={val}
-          setValue={setVal}
-          dataAdd={dataAdd}
-        />
-      );
-    case 'switch':
-      return (
-        <SettingsSwitch
-          field={field}
-          value={val}
-          setValue={setVal}
-          dataAdd={dataAdd}
-        />
-      );
-    default:
-      return <div>Unsupported field type: {field.type}</div>;
-  }
+  // Persist a committed value: client-scoped fields write to localStorage,
+  // server-scoped fields POST to the config API. Errors are surfaced via a
+  // toast and never rejected, so the renderer's spinner always clears.
+  const handleCommit = async (newValue: SettingsValue) => {
+    try {
+      if (field.scope === 'client') {
+        localStorage.setItem(field.key, String(newValue ?? ''));
+        if (field.key === 'theme' && typeof newValue === 'string') {
+          setTheme(newValue);
+        }
+        emitClientConfigChanged();
+      } else {
+        await grab('config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            key: `${dataAdd}.${field.key}`,
+            value: newValue,
+          }),
+        });
+      }
+    } catch (error) {
+      console.error('Error saving config:', error);
+      toast.error('Failed to save configuration.');
+    }
+  };
+
+  return (
+    <SettingsFieldRenderer
+      field={field as unknown as SettingsFieldRenderProps['field']}
+      value={val}
+      onChange={setVal}
+      onCommit={handleCommit}
+      anchorId={anchorId}
+      titleAddon={<AnchorLinkButton anchorId={anchorId} />}
+      classNames={APP_FIELD_CLASSNAMES}
+      renderers={CUSTOM_RENDERERS}
+    />
+  );
 };
 
 export default SettingsField;

--- a/apps/qwksearch-web/lib/config/index.ts
+++ b/apps/qwksearch-web/lib/config/index.ts
@@ -8,6 +8,10 @@ import { getModelProvidersUIConfigSection } from "chat-agent-toolkit/models/prov
 import { getMCPServersUIConfigSection } from "../mcp-servers";
 import { getEnv } from "./env";
 import { ALL_ENGINES } from "search-web-api/search/search-engines-registry-list.js";
+// App-specific settings schema now lives as data in research-agent-ui; the
+// config manager "requests" it here instead of declaring the fields inline.
+import { searchSettingsFields } from "research-agent-ui/settings";
+import type { UIConfigField } from "./types";
 
 // Simple browser-compatible deterministic hash
 const hashObj = (obj: { [key: string]: any }) => {
@@ -41,123 +45,10 @@ class ConfigManager {
     preferences: [],
     modelProviders: [],
     mcpServers: [],
-    search: [
-      {
-        name: "Background Art",
-        key: "showBackgroundArt",
-        type: "switch",
-        required: false,
-        description: "Show a random artistic background on the chat homepage.",
-        default: true,
-        scope: "client",
-      },
-      {
-        name: "TTS Voice",
-        key: "ttsSpeaker",
-        type: "select",
-        required: false,
-        description: "Voice used for read-aloud text-to-speech.",
-        default: "angus",
-        scope: "client",
-        options: [
-          { name: "Angus", value: "angus" },
-          { name: "Asteria", value: "asteria" },
-          { name: "Arcas", value: "arcas" },
-          { name: "Orion", value: "orion" },
-          { name: "Orpheus", value: "orpheus" },
-          { name: "Athena", value: "athena" },
-          { name: "Luna", value: "luna" },
-          { name: "Zeus", value: "zeus" },
-          { name: "Perseus", value: "perseus" },
-          { name: "Helios", value: "helios" },
-          { name: "Hera", value: "hera" },
-          { name: "Stella", value: "stella" },
-        ],
-      },
-      {
-        name: "System Instructions",
-        key: "systemInstructions",
-        type: "textarea",
-        required: false,
-        description: "Add custom behavior or tone for the model.",
-        placeholder:
-          'e.g., "Respond in a friendly and concise tone" or "Use British English and format answers as bullet points."',
-        scope: "client",
-      },
-      {
-        name: "Follow-up Questions",
-        key: "maxFollowupQuestions",
-        type: "select",
-        options: [
-          { name: "2 questions", value: "2" },
-          { name: "3 questions", value: "3" },
-          { name: "4 questions (default)", value: "4" },
-          { name: "5 questions", value: "5" },
-          { name: "6 questions", value: "6" },
-        ],
-        required: false,
-        description: "Number of follow-up question suggestions to generate after each chat response.",
-        default: "4",
-        scope: "client",
-      },
-      {
-        name: "SearXNG URL",
-        key: "searxngURL",
-        type: "string",
-        required: false,
-        description: "The URL of your SearXNG instance",
-        placeholder: "http://localhost:4000",
-        default: "",
-        scope: "server",
-        env: "SEARXNG_API_URL",
-      },
-      {
-        name: "Proxy URL",
-        key: "proxyURL",
-        type: "string",
-        required: false,
-        description: "Optional HTTP/HTTPS/SOCKS5 proxy for outbound search and scrape requests. Format: http://user:pass@host:port or socks5://host:port",
-        placeholder: "http://user:pass@proxy.example.com:8080",
-        default: "",
-        scope: "server",
-        env: "PROXY_URL",
-        links: [
-          { name: "Webshare", url: "https://www.webshare.io/?referral_code=proxy" },
-          { name: "Bright Data", url: "https://brightdata.com" },
-          { name: "ProxyMesh", url: "https://proxymesh.com" },
-          { name: "Free Proxy List", url: "https://free-proxy-list.net" },
-        ],
-      },
-      {
-        name: "Tavily API Key",
-        key: "tavilyApiKey",
-        type: "password",
-        required: false,
-        description:
-          "Optional. Enter your own Tavily API key to override the site default. Leave blank to use the site-provided key.",
-        placeholder: "tvly-...",
-        default: "",
-        scope: "server",
-        env: "TAVILY_API_KEY",
-      },
-      {
-        name: "Scrape timeout (seconds)",
-        key: "sourceScrapeTimeout",
-        type: "select",
-        options: [
-          { name: "3 seconds", value: "3" },
-          { name: "5 seconds (default)", value: "5" },
-          { name: "10 seconds", value: "10" },
-          { name: "15 seconds", value: "15" },
-          { name: "20 seconds", value: "20" },
-        ],
-        required: false,
-        description:
-          "Maximum time to wait when scraping each source URL. Slower timeouts allow more content but increase response time.",
-        default: "5",
-        scope: "server",
-      },
-    ],
+    // Search-section fields are declared as JSON data in research-agent-ui and
+    // requested here (see ./settings in that package). The shape matches
+    // UIConfigField, so we cast the imported schema to the app's union.
+    search: searchSettingsFields as unknown as UIConfigField[],
   };
 
   constructor() {

--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../react-weather-forecast && bun run build && cd ../research-agent-ui && bun run build",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../research-agent-ui && bun run build",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",
@@ -89,6 +89,7 @@
     "react-weather-forecast": "workspace:*",
     "research-agent-ui": "workspace:*",
     "shadcn-app-dock": "workspace:*",
+    "shadcn-settings": "workspace:*",
     "shadcn-theme-menu": "^1.1.13",
     "search-web-api": "workspace:*",
     "sonner": "^2.0.7",

--- a/packages/research-agent-ui/package.json
+++ b/packages/research-agent-ui/package.json
@@ -31,10 +31,18 @@
     "./file-sources": {
       "types": "./src/lib/file-sources.ts",
       "import": "./src/lib/file-sources.ts"
+    },
+    "./settings": {
+      "types": "./src/settings/index.ts",
+      "import": "./src/settings/index.ts"
+    },
+    "./settings/*": {
+      "import": "./src/settings/*"
     }
   },
   "files": [
     "dist",
+    "src/settings",
     "README.md"
   ],
   "sideEffects": false,

--- a/packages/research-agent-ui/src/settings/index.ts
+++ b/packages/research-agent-ui/src/settings/index.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview App-specific settings schema, declared as data.
+ *
+ * These JSON files are the single source of truth for *which* settings the app
+ * exposes and how each one should be described and edited. The consuming app
+ * "requests" this information at build/runtime and hands it to a renderer (see
+ * the `shadcn-settings` package) that turns each declaration into a control.
+ *
+ * Keeping the schema here — separate from both the server config manager that
+ * reads/writes the values and the components that render them — means the list
+ * of settings can change without touching rendering or persistence code.
+ */
+import sectionsJson from "./sections.json";
+import searchJson from "./search.json";
+
+/** The kind of control a setting is edited with. */
+export type SettingsFieldType =
+  | "string"
+  | "password"
+  | "textarea"
+  | "select"
+  | "switch"
+  | "theme";
+
+/** Where a setting's value lives: browser `localStorage` or the server config. */
+export type SettingsFieldScope = "client" | "server";
+
+export interface SettingsFieldOption {
+  name: string;
+  value: string;
+}
+
+export interface SettingsFieldLink {
+  name: string;
+  url: string;
+}
+
+/**
+ * A single declarative setting. This is intentionally structurally compatible
+ * with `shadcn-settings`' field type so the schema can be passed straight to
+ * the renderer, and with the app's own `UIConfigField` union.
+ */
+export interface SettingsFieldSchema {
+  name: string;
+  key: string;
+  type: SettingsFieldType;
+  required: boolean;
+  description: string;
+  scope: SettingsFieldScope;
+  default?: string | boolean;
+  placeholder?: string;
+  env?: string;
+  options?: SettingsFieldOption[];
+  links?: SettingsFieldLink[];
+}
+
+/** Metadata describing one entry in the settings sidebar/menu. */
+export interface SettingsSectionSchema {
+  /** Stable id used for routing and the active-tab state. */
+  key: string;
+  /** Human-readable label shown in the menu and header. */
+  name: string;
+  /** One-line summary shown under the header. */
+  description: string;
+  /** lucide-react icon name; the app maps this to a component. */
+  icon: string;
+  /** Config namespace this section reads/writes (`config.values[dataAdd]`). */
+  dataAdd: string;
+}
+
+/** Ordered list of settings sections (menu items). */
+export const settingsSections: SettingsSectionSchema[] =
+  sectionsJson as unknown as SettingsSectionSchema[];
+
+/** Field declarations for the "Search Settings" section. */
+export const searchSettingsFields: SettingsFieldSchema[] =
+  searchJson as unknown as SettingsFieldSchema[];
+
+/** Every field group keyed by the section `dataAdd` it belongs to. */
+export const settingsFieldsBySection: Record<string, SettingsFieldSchema[]> = {
+  search: searchSettingsFields,
+};
+
+/**
+ * Return the full app settings schema. Named like a request because the app
+ * asks this module for "the setting info" rather than declaring it inline.
+ */
+export function getSettingsSchema(): {
+  sections: SettingsSectionSchema[];
+  fieldsBySection: Record<string, SettingsFieldSchema[]>;
+} {
+  return {
+    sections: settingsSections,
+    fieldsBySection: settingsFieldsBySection,
+  };
+}

--- a/packages/research-agent-ui/src/settings/search.json
+++ b/packages/research-agent-ui/src/settings/search.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "Background Art",
+    "key": "showBackgroundArt",
+    "type": "switch",
+    "required": false,
+    "description": "Show a random artistic background on the chat homepage.",
+    "default": true,
+    "scope": "client"
+  },
+  {
+    "name": "TTS Voice",
+    "key": "ttsSpeaker",
+    "type": "select",
+    "required": false,
+    "description": "Voice used for read-aloud text-to-speech.",
+    "default": "angus",
+    "scope": "client",
+    "options": [
+      { "name": "Angus", "value": "angus" },
+      { "name": "Asteria", "value": "asteria" },
+      { "name": "Arcas", "value": "arcas" },
+      { "name": "Orion", "value": "orion" },
+      { "name": "Orpheus", "value": "orpheus" },
+      { "name": "Athena", "value": "athena" },
+      { "name": "Luna", "value": "luna" },
+      { "name": "Zeus", "value": "zeus" },
+      { "name": "Perseus", "value": "perseus" },
+      { "name": "Helios", "value": "helios" },
+      { "name": "Hera", "value": "hera" },
+      { "name": "Stella", "value": "stella" }
+    ]
+  },
+  {
+    "name": "System Instructions",
+    "key": "systemInstructions",
+    "type": "textarea",
+    "required": false,
+    "description": "Add custom behavior or tone for the model.",
+    "placeholder": "e.g., \"Respond in a friendly and concise tone\" or \"Use British English and format answers as bullet points.\"",
+    "scope": "client"
+  },
+  {
+    "name": "Follow-up Questions",
+    "key": "maxFollowupQuestions",
+    "type": "select",
+    "options": [
+      { "name": "2 questions", "value": "2" },
+      { "name": "3 questions", "value": "3" },
+      { "name": "4 questions (default)", "value": "4" },
+      { "name": "5 questions", "value": "5" },
+      { "name": "6 questions", "value": "6" }
+    ],
+    "required": false,
+    "description": "Number of follow-up question suggestions to generate after each chat response.",
+    "default": "4",
+    "scope": "client"
+  },
+  {
+    "name": "SearXNG URL",
+    "key": "searxngURL",
+    "type": "string",
+    "required": false,
+    "description": "The URL of your SearXNG instance",
+    "placeholder": "http://localhost:4000",
+    "default": "",
+    "scope": "server",
+    "env": "SEARXNG_API_URL"
+  },
+  {
+    "name": "Proxy URL",
+    "key": "proxyURL",
+    "type": "string",
+    "required": false,
+    "description": "Optional HTTP/HTTPS/SOCKS5 proxy for outbound search and scrape requests. Format: http://user:pass@host:port or socks5://host:port",
+    "placeholder": "http://user:pass@proxy.example.com:8080",
+    "default": "",
+    "scope": "server",
+    "env": "PROXY_URL",
+    "links": [
+      { "name": "Webshare", "url": "https://www.webshare.io/?referral_code=proxy" },
+      { "name": "Bright Data", "url": "https://brightdata.com" },
+      { "name": "ProxyMesh", "url": "https://proxymesh.com" },
+      { "name": "Free Proxy List", "url": "https://free-proxy-list.net" }
+    ]
+  },
+  {
+    "name": "Tavily API Key",
+    "key": "tavilyApiKey",
+    "type": "password",
+    "required": false,
+    "description": "Optional. Enter your own Tavily API key to override the site default. Leave blank to use the site-provided key.",
+    "placeholder": "tvly-...",
+    "default": "",
+    "scope": "server",
+    "env": "TAVILY_API_KEY"
+  },
+  {
+    "name": "Scrape timeout (seconds)",
+    "key": "sourceScrapeTimeout",
+    "type": "select",
+    "options": [
+      { "name": "3 seconds", "value": "3" },
+      { "name": "5 seconds (default)", "value": "5" },
+      { "name": "10 seconds", "value": "10" },
+      { "name": "15 seconds", "value": "15" },
+      { "name": "20 seconds", "value": "20" }
+    ],
+    "required": false,
+    "description": "Maximum time to wait when scraping each source URL. Slower timeouts allow more content but increase response time.",
+    "default": "5",
+    "scope": "server"
+  }
+]

--- a/packages/research-agent-ui/src/settings/sections.json
+++ b/packages/research-agent-ui/src/settings/sections.json
@@ -1,0 +1,65 @@
+[
+  {
+    "key": "account",
+    "name": "Account",
+    "description": "Manage your profile, password, and linked accounts.",
+    "icon": "UserCircle",
+    "dataAdd": "account"
+  },
+  {
+    "key": "models",
+    "name": "Language Models",
+    "description": "Connect to AI services and manage connections.",
+    "icon": "BrainCog",
+    "dataAdd": "modelProviders"
+  },
+  {
+    "key": "mcpservers",
+    "name": "Connectors",
+    "description": "Configure Model Context Protocol servers.",
+    "icon": "Server",
+    "dataAdd": "mcpServers"
+  },
+  {
+    "key": "skills-memory",
+    "name": "Skills & Memory",
+    "description": "Manage agent skills and view your stored memories.",
+    "icon": "Brain",
+    "dataAdd": "skillsMemory"
+  },
+  {
+    "key": "searchEngines",
+    "name": "Search Sources",
+    "description": "Manage search engine sources by category.",
+    "icon": "Search",
+    "dataAdd": "searchEngines"
+  },
+  {
+    "key": "search",
+    "name": "Search Settings",
+    "description": "Configure search parameters.",
+    "icon": "Search",
+    "dataAdd": "search"
+  },
+  {
+    "key": "fileSources",
+    "name": "Cloud Storage",
+    "description": "Manage storage sources (SSH, S3, R2, B2, Google Docs, Turso DB).",
+    "icon": "HardDrive",
+    "dataAdd": "storage"
+  },
+  {
+    "key": "aiRewriteModes",
+    "name": "Rewrite Modes",
+    "description": "Customize AI rewrite prompts and add your own modes.",
+    "icon": "Wand2",
+    "dataAdd": "rewritePrompts"
+  },
+  {
+    "key": "voice",
+    "name": "Voice Settings",
+    "description": "Configure text-to-speech with Kokoro.js or Cloudflare TTS.",
+    "icon": "Volume2",
+    "dataAdd": "voice"
+  }
+]

--- a/packages/shadcn-settings/README.md
+++ b/packages/shadcn-settings/README.md
@@ -1,0 +1,148 @@
+# shadcn-settings
+
+Schema-driven **settings form renderer** for React, built on
+[shadcn/ui](https://ui.shadcn.com) + Radix primitives.
+
+Describe your settings as plain data (typically JSON), hand the list to
+`<SettingsList />` with `getValue` / `onCommit` callbacks, and it renders the
+controls for you — no per-field JSX. It knows nothing about *where* your values
+live (localStorage, an API, a config file), so the same schema drives
+rendering, persistence and search independently.
+
+- **Field variants** — `string`, `password` (show/hide), `textarea`, `select`,
+  `switch`.
+- **Layout variants** — `card`, `inline`, `ghost` per field.
+- **Bring your own types** — inject extra `renderers` (e.g. a `theme` picker)
+  or override a built-in.
+- **Optimistic + async commits** — edits fire `onChange` immediately and
+  `onCommit` on blur/change; async commits show a spinner automatically.
+- **Style-agnostic** — ships shadcn token defaults, and every slot accepts a
+  `classNames` override so it matches your app's design.
+
+## Install
+
+```bash
+npm install shadcn-settings
+# peer deps: react, react-dom
+```
+
+Uses shadcn/ui theme tokens (`--border`, `--card`, `--primary`,
+`--muted-foreground`, …). If your app already uses shadcn/ui, no extra setup is
+needed.
+
+## Quick start
+
+```tsx
+import { SettingsList, type SettingsFieldSchema } from "shadcn-settings";
+
+const fields: SettingsFieldSchema[] = [
+  {
+    name: "Background Art",
+    key: "showBackgroundArt",
+    type: "switch",
+    description: "Show a random artistic background on the homepage.",
+    default: true,
+  },
+  {
+    name: "SearXNG URL",
+    key: "searxngURL",
+    type: "string",
+    placeholder: "http://localhost:4000",
+  },
+];
+
+export function Settings() {
+  return (
+    <SettingsList
+      fields={fields}
+      getValue={(field) => localStorage.getItem(field.key) ?? field.default}
+      onCommit={(field, value) =>
+        localStorage.setItem(field.key, String(value))
+      }
+    />
+  );
+}
+```
+
+## Schema
+
+Each entry is a `SettingsFieldSchema`:
+
+| key           | type                                        | notes                                   |
+| ------------- | ------------------------------------------- | --------------------------------------- |
+| `name`        | `string`                                    | Label                                   |
+| `key`         | `string`                                    | Persistence key / React key             |
+| `type`        | `"string" \| "password" \| "textarea" \| "select" \| "switch"` | or a custom type you register |
+| `description` | `string?`                                   | Helper text                             |
+| `placeholder` | `string?`                                   | Text inputs                             |
+| `default`     | `string \| boolean?`                        | Used when the value is `undefined`      |
+| `options`     | `{ name, value }[]?`                        | `select` only                           |
+| `links`       | `{ name, url }[]?`                           | Reference links under the description   |
+
+Extra keys (`scope`, `env`, …) pass through untouched, so you can carry your own
+metadata on each field.
+
+## Rendering a single field
+
+```tsx
+import { SettingsField } from "shadcn-settings";
+
+<SettingsField field={field} value={value} onCommit={save} variant="inline" />;
+```
+
+## Custom / overriding field types
+
+Pass a `renderers` map. The special `"unknown"` key replaces the fallback used
+for unregistered types.
+
+```tsx
+<SettingsList
+  fields={fields}
+  getValue={getValue}
+  onCommit={onCommit}
+  renderers={{
+    theme: ({ field, value, onCommit }) => (
+      <MyThemePicker value={value} onChange={onCommit} label={field.name} />
+    ),
+  }}
+/>
+```
+
+A custom renderer receives `SettingsFieldRenderProps`: `field`, `value`,
+`onChange`, `onCommit`, `variant`, `anchorId`, `titleAddon`, `classNames`,
+`disabled`.
+
+## Matching your design
+
+Every field accepts `classNames` overrides:
+
+```tsx
+<SettingsList
+  /* … */
+  variant="card"
+  classNames={{
+    root: "rounded-xl border-light-200 bg-light-primary/80 dark:border-dark-200",
+    title: "text-black dark:text-white",
+    description: "text-black/50 dark:text-white/50",
+  }}
+/>
+```
+
+Slots: `root`, `header`, `title`, `description`, `control`.
+
+## API
+
+- `SettingsList` — renders an ordered schema. Props: `fields`, `getValue`,
+  `onCommit`, `onChange?`, `variant?`, `renderers?`, `anchorId?`,
+  `renderTitleAddon?`, `classNames?`, `className?`.
+- `SettingsField` — renders one field; dispatches on `field.type`.
+- `FieldShell` — the label/description/control chrome, if you build a field
+  from scratch.
+- `StringField`, `PasswordField`, `TextareaField`, `SelectField`,
+  `SwitchField` — the individual variants.
+- `Select*`, `Switch` — the underlying shadcn/ui primitives.
+- `useCommit` — the async-commit-with-spinner hook.
+
+## License
+
+rights.institute/PROSPER

--- a/packages/shadcn-settings/package.json
+++ b/packages/shadcn-settings/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "shadcn-settings",
+  "description": "Prop-driven, schema-based settings form renderer built on shadcn/ui — string, password, textarea, select and switch field variants with card, inline and ghost layouts",
+  "version": "0.1.0",
+  "author": "vtempest",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
+    "directory": "packages/shadcn-settings"
+  },
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "vite build && tsc --project tsconfig.build.json",
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "bun run build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "settings",
+    "preferences",
+    "config-form",
+    "schema-driven",
+    "shadcn",
+    "react"
+  ],
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "dependencies": {
+    "@radix-ui/react-select": "^2.3.0",
+    "@radix-ui/react-switch": "^1.3.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.17.0",
+    "tailwind-merge": "^3.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/coverage-v8": "^4.0.18",
+    "jsdom": "^28.1.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.7.2",
+    "vite": "^8.1.3",
+    "vitest": "^4.0.18"
+  },
+  "license": "rights.institute/PROSPER"
+}

--- a/packages/shadcn-settings/src/components/field-shell.tsx
+++ b/packages/shadcn-settings/src/components/field-shell.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../lib/utils";
+import type {
+  SettingsClassNames,
+  SettingsFieldLink,
+  SettingsFieldVariant,
+} from "../types";
+
+/**
+ * The visual chrome shared by every field: an optional bordered container, the
+ * label/description header, reference links, and a slot for the control. The
+ * `layout` prop decides where the control sits relative to the header.
+ */
+const shellVariants = cva("scroll-mt-4 transition-colors", {
+  variants: {
+    variant: {
+      card: "rounded-xl border border-border bg-card/80 p-4 lg:p-6",
+      inline: "rounded-lg border border-border bg-card/50 px-4 py-3",
+      ghost: "py-2",
+    },
+  },
+  defaultVariants: {
+    variant: "card",
+  },
+});
+
+function FieldLinks({ links }: { links?: SettingsFieldLink[] }) {
+  if (!links?.length) return null;
+  return (
+    <div className="mt-1 flex flex-wrap gap-2">
+      {links.map((link) => (
+        <a
+          key={link.url}
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[11px] text-blue-500 underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 lg:text-xs"
+        >
+          {link.name}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export interface FieldShellProps
+  extends VariantProps<typeof shellVariants> {
+  anchorId?: string;
+  title: string;
+  description?: string;
+  links?: SettingsFieldLink[];
+  titleAddon?: React.ReactNode;
+  classNames?: SettingsClassNames;
+  /** `stacked` puts the control under the header; `row` puts it beside it. */
+  layout?: "stacked" | "row";
+  children: React.ReactNode;
+}
+
+function Header({
+  title,
+  description,
+  links,
+  titleAddon,
+  classNames,
+}: Pick<
+  FieldShellProps,
+  "title" | "description" | "links" | "titleAddon" | "classNames"
+>) {
+  return (
+    <div className={cn(classNames?.header)}>
+      <h4
+        className={cn(
+          "flex items-center gap-1.5 text-sm text-foreground",
+          classNames?.title,
+        )}
+      >
+        {title}
+        {titleAddon}
+      </h4>
+      {description ? (
+        <p
+          className={cn(
+            "text-[11px] text-muted-foreground lg:text-xs",
+            classNames?.description,
+          )}
+        >
+          {description}
+        </p>
+      ) : null}
+      <FieldLinks links={links} />
+    </div>
+  );
+}
+
+export function FieldShell({
+  anchorId,
+  title,
+  description,
+  links,
+  titleAddon,
+  classNames,
+  variant,
+  layout = "stacked",
+  children,
+}: FieldShellProps) {
+  const header = (
+    <Header
+      title={title}
+      description={description}
+      links={links}
+      titleAddon={titleAddon}
+      classNames={classNames}
+    />
+  );
+
+  return (
+    <section
+      id={anchorId}
+      className={cn(shellVariants({ variant }), classNames?.root)}
+    >
+      {layout === "row" ? (
+        <div className="flex w-full flex-row items-center justify-between gap-3 lg:gap-5">
+          {header}
+          <div className={cn("flex-shrink-0", classNames?.control)}>
+            {children}
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3 lg:space-y-5">
+          {header}
+          <div className={cn("relative", classNames?.control)}>{children}</div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export type { SettingsFieldVariant };

--- a/packages/shadcn-settings/src/components/fields/select-field.tsx
+++ b/packages/shadcn-settings/src/components/fields/select-field.tsx
@@ -1,0 +1,62 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { FieldShell } from "../field-shell";
+import { useCommit } from "../../lib/use-commit";
+import type { SettingsFieldRenderProps, SettingsValue } from "../../types";
+
+/** Dropdown control for the `select` variant. Commits on change. */
+export function SelectField({
+  field,
+  value,
+  onChange,
+  onCommit,
+  variant,
+  anchorId,
+  titleAddon,
+  classNames,
+  disabled,
+}: SettingsFieldRenderProps) {
+  const { committing, commit } = useCommit(onCommit);
+  const fallback = typeof field.default === "string" ? field.default : undefined;
+  const current = (value as string | undefined) ?? fallback;
+  const options = (field.options ?? []).filter((o) => o.value !== "");
+
+  const handleChange = (next: string) => {
+    onChange?.(next as SettingsValue);
+    void commit(next as SettingsValue);
+  };
+
+  return (
+    <FieldShell
+      anchorId={anchorId}
+      title={field.name}
+      description={field.description}
+      links={field.links}
+      titleAddon={titleAddon}
+      classNames={classNames}
+      variant={variant}
+    >
+      <Select
+        value={current}
+        onValueChange={handleChange}
+        disabled={disabled || committing}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select an option" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </FieldShell>
+  );
+}

--- a/packages/shadcn-settings/src/components/fields/switch-field.tsx
+++ b/packages/shadcn-settings/src/components/fields/switch-field.tsx
@@ -1,0 +1,48 @@
+import { Switch } from "../ui/switch";
+import { FieldShell } from "../field-shell";
+import { useCommit } from "../../lib/use-commit";
+import type { SettingsFieldRenderProps, SettingsValue } from "../../types";
+
+/** Toggle control for the `switch` variant. Laid out as a row. Commits on change. */
+export function SwitchField({
+  field,
+  value,
+  onChange,
+  onCommit,
+  variant,
+  anchorId,
+  titleAddon,
+  classNames,
+  disabled,
+}: SettingsFieldRenderProps) {
+  const { committing, commit } = useCommit(onCommit);
+  const checked =
+    value === true ||
+    value === "true" ||
+    (value === undefined && field.default === true);
+
+  const handleChange = (next: boolean) => {
+    onChange?.(next as SettingsValue);
+    void commit(next as SettingsValue);
+  };
+
+  return (
+    <FieldShell
+      anchorId={anchorId}
+      title={field.name}
+      description={field.description}
+      links={field.links}
+      titleAddon={titleAddon}
+      classNames={classNames}
+      variant={variant}
+      layout="row"
+    >
+      <Switch
+        checked={checked}
+        onCheckedChange={handleChange}
+        disabled={disabled || committing}
+        className="h-6 w-12"
+      />
+    </FieldShell>
+  );
+}

--- a/packages/shadcn-settings/src/components/fields/text-field.tsx
+++ b/packages/shadcn-settings/src/components/fields/text-field.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { useCommit } from "../../lib/use-commit";
+import { FieldShell } from "../field-shell";
+import type { SettingsFieldRenderProps, SettingsValue } from "../../types";
+
+const inputClass =
+  "w-full rounded-lg border border-input bg-background px-3 py-2 pr-10 !text-xs text-foreground placeholder:text-muted-foreground transition-colors focus-visible:outline-none focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-60 lg:px-4 lg:py-3 lg:!text-[13px]";
+
+interface TextControlProps extends SettingsFieldRenderProps {
+  multiline?: boolean;
+  secret?: boolean;
+}
+
+/**
+ * Shared text control backing the `string`, `password` and `textarea`
+ * variants. Edits are optimistic (`onChange`) and committed on blur
+ * (`onCommit`), matching a "save when you click away" settings pattern.
+ */
+function TextControl({
+  field,
+  value,
+  onChange,
+  onCommit,
+  variant,
+  anchorId,
+  titleAddon,
+  classNames,
+  disabled,
+  multiline = false,
+  secret = false,
+}: TextControlProps) {
+  const { committing, commit } = useCommit(onCommit);
+  const [showSecret, setShowSecret] = React.useState(false);
+  const fallback = typeof field.default === "string" ? field.default : "";
+  const current = (value as string | undefined) ?? fallback;
+  const isDisabled = disabled || committing;
+
+  const handleChange = (next: string) => onChange?.(next as SettingsValue);
+  const handleBlur = (next: string) => commit(next as SettingsValue);
+
+  return (
+    <FieldShell
+      anchorId={anchorId}
+      title={field.name}
+      description={field.description}
+      links={field.links}
+      titleAddon={titleAddon}
+      classNames={classNames}
+      variant={variant}
+    >
+      {multiline ? (
+        <textarea
+          value={current}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={(e) => handleBlur(e.target.value)}
+          placeholder={field.placeholder}
+          rows={4}
+          disabled={isDisabled}
+          className={inputClass}
+        />
+      ) : (
+        <input
+          value={current}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={(e) => handleBlur(e.target.value)}
+          placeholder={field.placeholder}
+          type={secret && !showSecret ? "password" : "text"}
+          disabled={isDisabled}
+          className={cn(inputClass, secret && "pr-16")}
+        />
+      )}
+
+      {secret && !multiline ? (
+        <button
+          type="button"
+          onClick={() => setShowSecret((v) => !v)}
+          title={showSecret ? "Hide" : "Show"}
+          className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {showSecret ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+        </button>
+      ) : null}
+
+      {committing ? (
+        <span
+          className={cn(
+            "pointer-events-none absolute text-muted-foreground",
+            multiline
+              ? "right-3 translate-y-3"
+              : "top-1/2 -translate-y-1/2",
+            secret && !multiline ? "right-8" : "right-3",
+          )}
+        >
+          <Loader2 className="h-4 w-4 animate-spin" />
+        </span>
+      ) : null}
+    </FieldShell>
+  );
+}
+
+export function StringField(props: SettingsFieldRenderProps) {
+  return <TextControl {...props} />;
+}
+
+export function PasswordField(props: SettingsFieldRenderProps) {
+  return <TextControl {...props} secret />;
+}
+
+export function TextareaField(props: SettingsFieldRenderProps) {
+  return <TextControl {...props} multiline />;
+}

--- a/packages/shadcn-settings/src/components/settings-field.tsx
+++ b/packages/shadcn-settings/src/components/settings-field.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { FieldShell } from "./field-shell";
+import { StringField, PasswordField, TextareaField } from "./fields/text-field";
+import { SelectField } from "./fields/select-field";
+import { SwitchField } from "./fields/switch-field";
+import type {
+  SettingsFieldRenderProps,
+  SettingsFieldRenderer,
+  SettingsFieldRenderers,
+} from "../types";
+
+/** The variants shipped with this package. */
+export const builtinRenderers: SettingsFieldRenderers = {
+  string: StringField as SettingsFieldRenderer,
+  password: PasswordField as SettingsFieldRenderer,
+  textarea: TextareaField as SettingsFieldRenderer,
+  select: SelectField as SettingsFieldRenderer,
+  switch: SwitchField as SettingsFieldRenderer,
+};
+
+/** Rendered when a field's `type` has no registered renderer. */
+function UnknownField({
+  field,
+  variant,
+  anchorId,
+  classNames,
+}: SettingsFieldRenderProps) {
+  return (
+    <FieldShell
+      anchorId={anchorId}
+      title={field.name}
+      description={field.description}
+      classNames={classNames}
+      variant={variant}
+    >
+      <p className="text-xs text-muted-foreground">
+        Unsupported field type: {String(field.type)}
+      </p>
+    </FieldShell>
+  );
+}
+
+export interface SettingsFieldProps extends SettingsFieldRenderProps {
+  /**
+   * Extra or overriding renderers merged over the built-ins. Use the special
+   * `"unknown"` key to customise the fallback, or add a new `type` (e.g.
+   * `"theme"`) the schema uses.
+   */
+  renderers?: SettingsFieldRenderers;
+}
+
+/**
+ * Renders a single settings field by dispatching on `field.type`. Unknown
+ * types fall back to the `unknown` renderer.
+ */
+export function SettingsField({ renderers, ...props }: SettingsFieldProps) {
+  const registry = React.useMemo(
+    () => ({ ...builtinRenderers, ...renderers }),
+    [renderers],
+  );
+  const Renderer =
+    registry[props.field.type] ?? registry.unknown ?? UnknownField;
+  return <Renderer {...props} />;
+}

--- a/packages/shadcn-settings/src/components/settings-list.tsx
+++ b/packages/shadcn-settings/src/components/settings-list.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { cn } from "../lib/utils";
+import { SettingsField } from "./settings-field";
+import type {
+  SettingsClassNames,
+  SettingsFieldRenderers,
+  SettingsFieldSchema,
+  SettingsFieldVariant,
+  SettingsValue,
+} from "../types";
+
+export interface SettingsListProps {
+  /** The fields to render, in order. */
+  fields: SettingsFieldSchema[];
+  /**
+   * Current value for a field. Return `undefined` to fall back to the field's
+   * own `default`. Called per-field so client/server-scoped reads can differ.
+   */
+  getValue: (field: SettingsFieldSchema) => SettingsValue;
+  /** Persist a committed value for a field. May be async. */
+  onCommit: (
+    field: SettingsFieldSchema,
+    value: SettingsValue,
+  ) => void | Promise<void>;
+  /** Optional optimistic per-field change handler (pre-commit). */
+  onChange?: (field: SettingsFieldSchema, value: SettingsValue) => void;
+  /** Layout variant applied to every field. */
+  variant?: SettingsFieldVariant;
+  /** Extra/override renderers (e.g. a `theme` variant). */
+  renderers?: SettingsFieldRenderers;
+  /** Build a DOM id for a field container (anchoring/deep links). */
+  anchorId?: (field: SettingsFieldSchema) => string;
+  /** Render a node beside a field's title (e.g. a copy-link button). */
+  renderTitleAddon?: (field: SettingsFieldSchema) => React.ReactNode;
+  /** Per-field class-name overrides. */
+  classNames?: SettingsClassNames;
+  /** Class name for the wrapping list container. */
+  className?: string;
+}
+
+/**
+ * Renders an ordered list of settings fields from a schema. Each field's value
+ * and persistence are supplied by the host via `getValue`/`onCommit`, so this
+ * component stays agnostic about where values live (localStorage, an API, …).
+ */
+export function SettingsList({
+  fields,
+  getValue,
+  onCommit,
+  onChange,
+  variant,
+  renderers,
+  anchorId,
+  renderTitleAddon,
+  classNames,
+  className,
+}: SettingsListProps) {
+  return (
+    <div className={cn("flex-1 space-y-6 overflow-y-auto px-6 py-6", className)}>
+      {fields.map((field) => (
+        <SettingsField
+          key={field.key}
+          field={field}
+          value={getValue(field)}
+          onChange={
+            onChange ? (value) => onChange(field, value) : undefined
+          }
+          onCommit={(value) => onCommit(field, value)}
+          variant={variant}
+          renderers={renderers}
+          anchorId={anchorId?.(field)}
+          titleAddon={renderTitleAddon?.(field)}
+          classNames={classNames}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/shadcn-settings/src/components/ui/select.tsx
+++ b/packages/shadcn-settings/src/components/ui/select.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+/** shadcn/ui select built on `@radix-ui/react-select`. */
+export const Select = SelectPrimitive.Root;
+export const SelectGroup = SelectPrimitive.Group;
+export const SelectValue = SelectPrimitive.Value;
+
+export const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm",
+      "placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring",
+      "disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+export const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-72 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+export const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/packages/shadcn-settings/src/components/ui/switch.tsx
+++ b/packages/shadcn-settings/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import { cn } from "../../lib/utils";
+
+/** shadcn/ui switch built on `@radix-ui/react-switch`. */
+export const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-[1.15rem] w-8 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-sm transition-colors outline-none",
+      "focus-visible:ring-2 focus-visible:ring-ring/50",
+      "data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        "pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform",
+        "data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = "Switch";

--- a/packages/shadcn-settings/src/index.ts
+++ b/packages/shadcn-settings/src/index.ts
@@ -1,0 +1,45 @@
+/**
+ * shadcn-settings — schema-driven settings form renderer for shadcn/ui.
+ *
+ * Feed it a list of plain-data field declarations plus `getValue`/`onCommit`
+ * callbacks and it renders the controls (string, password, textarea, select,
+ * switch) with card / inline / ghost layout variants. Bring your own field
+ * types by passing extra `renderers`.
+ */
+export { SettingsList } from "./components/settings-list";
+export type { SettingsListProps } from "./components/settings-list";
+
+export { SettingsField, builtinRenderers } from "./components/settings-field";
+export type { SettingsFieldProps } from "./components/settings-field";
+
+export { FieldShell } from "./components/field-shell";
+export type { FieldShellProps } from "./components/field-shell";
+
+// Individual field renderers, exported so hosts can compose them directly.
+export {
+  StringField,
+  PasswordField,
+  TextareaField,
+} from "./components/fields/text-field";
+export { SelectField } from "./components/fields/select-field";
+export { SwitchField } from "./components/fields/switch-field";
+
+// shadcn/ui primitives used by the fields, re-exported for reuse.
+export * from "./components/ui/select";
+export { Switch } from "./components/ui/switch";
+
+export { cn } from "./lib/utils";
+export { useCommit } from "./lib/use-commit";
+
+export type {
+  SettingsFieldType,
+  SettingsFieldOption,
+  SettingsFieldLink,
+  SettingsFieldSchema,
+  SettingsValue,
+  SettingsFieldVariant,
+  SettingsClassNames,
+  SettingsFieldRenderProps,
+  SettingsFieldRenderer,
+  SettingsFieldRenderers,
+} from "./types";

--- a/packages/shadcn-settings/src/lib/use-commit.ts
+++ b/packages/shadcn-settings/src/lib/use-commit.ts
@@ -1,0 +1,39 @@
+import * as React from "react";
+import type { SettingsValue } from "../types";
+
+/**
+ * Wraps an `onCommit` callback with a `committing` flag so field controls can
+ * show a spinner / disable themselves while an async save is in flight. Safe
+ * against unmounts and tolerant of a synchronous (void) callback.
+ */
+export function useCommit(
+  onCommit?: (value: SettingsValue) => void | Promise<void>,
+) {
+  const [committing, setCommitting] = React.useState(false);
+  const mounted = React.useRef(true);
+  React.useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const commit = React.useCallback(
+    async (value: SettingsValue) => {
+      if (!onCommit) return;
+      setCommitting(true);
+      try {
+        await onCommit(value);
+      } finally {
+        // Brief floor so very fast saves still register visually, matching the
+        // original settings UI behaviour.
+        window.setTimeout(() => {
+          if (mounted.current) setCommitting(false);
+        }, 150);
+      }
+    },
+    [onCommit],
+  );
+
+  return { committing, commit };
+}

--- a/packages/shadcn-settings/src/lib/utils.ts
+++ b/packages/shadcn-settings/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge conditional class names, de-duplicating Tailwind utilities. */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/shadcn-settings/src/types.ts
+++ b/packages/shadcn-settings/src/types.ts
@@ -1,0 +1,117 @@
+import type { ComponentType, ReactNode } from "react";
+
+/** The built-in control variants this package knows how to render. */
+export type SettingsFieldType =
+  | "string"
+  | "password"
+  | "textarea"
+  | "select"
+  | "switch";
+
+/** An option in a `select` field. */
+export interface SettingsFieldOption {
+  name: string;
+  value: string;
+}
+
+/** A labelled external link rendered under a field's description. */
+export interface SettingsFieldLink {
+  name: string;
+  url: string;
+}
+
+/**
+ * A declarative description of one setting. Schemas are plain data (usually
+ * JSON) so the same field list can drive rendering, persistence and search.
+ *
+ * `type` is typed as `string` rather than the built-in union so a host app can
+ * declare custom field types and supply matching renderers via
+ * {@link SettingsFieldRenderers}; unknown types fall back to the
+ * `unknown`-type renderer.
+ */
+export interface SettingsFieldSchema {
+  /** Human-readable label. */
+  name: string;
+  /** Stable key used for persistence and as the React key. */
+  key: string;
+  /** Control variant, e.g. `"string"` | `"select"` | a custom type. */
+  type: SettingsFieldType | (string & {});
+  /** Short helper text shown under the label. */
+  description?: string;
+  /** Placeholder for text-like inputs. */
+  placeholder?: string;
+  /** Default value used when no value has been set. */
+  default?: string | boolean;
+  /** Options for `select` fields. */
+  options?: SettingsFieldOption[];
+  /** Reference links rendered under the description. */
+  links?: SettingsFieldLink[];
+  /** Whether the field must be filled (advisory; not enforced here). */
+  required?: boolean;
+  /** Free-form scope tag carried through untouched (e.g. client/server). */
+  scope?: string;
+  /** Allow schema authors to attach extra metadata. */
+  [extra: string]: unknown;
+}
+
+/** The value types a field control can hold. */
+export type SettingsValue = string | boolean | number | undefined;
+
+/** Visual layout of a field. */
+export type SettingsFieldVariant = "card" | "inline" | "ghost";
+
+/** Per-slot class-name overrides so a host app can match its own design. */
+export interface SettingsClassNames {
+  /** The outer field container. */
+  root?: string;
+  /** The label/description header block. */
+  header?: string;
+  /** The label text. */
+  title?: string;
+  /** The description text. */
+  description?: string;
+  /** The control (input/select/switch) wrapper. */
+  control?: string;
+}
+
+/** Props every field renderer receives from the dispatcher. */
+export interface SettingsFieldRenderProps<
+  F extends SettingsFieldSchema = SettingsFieldSchema,
+> {
+  field: F;
+  /** Current value (falls back to `field.default` when undefined). */
+  value: SettingsValue;
+  /**
+   * Optimistic local update — fires on every keystroke/toggle so controlled
+   * hosts can mirror the value immediately.
+   */
+  onChange?: (value: SettingsValue) => void;
+  /**
+   * Persist a value. May be async; the field shows a spinner while the
+   * returned promise is pending. Text inputs commit on blur, selects/switches
+   * commit immediately.
+   */
+  onCommit?: (value: SettingsValue) => void | Promise<void>;
+  /** Layout variant. */
+  variant?: SettingsFieldVariant;
+  /** Stable DOM id for the field container (anchoring/deep links). */
+  anchorId?: string;
+  /** Extra node rendered next to the title (e.g. a copy-link button). */
+  titleAddon?: ReactNode;
+  /** Class-name overrides. */
+  classNames?: SettingsClassNames;
+  /** Disable the control. */
+  disabled?: boolean;
+}
+
+/** A component that renders one field type. */
+export type SettingsFieldRenderer<
+  F extends SettingsFieldSchema = SettingsFieldSchema,
+> = ComponentType<SettingsFieldRenderProps<F>>;
+
+/**
+ * Map of field `type` → renderer. Merged over the built-ins, so a host can
+ * override a built-in variant or add a brand-new one (e.g. `"theme"`). The
+ * special `"unknown"` key handles any type with no registered renderer.
+ */
+export type SettingsFieldRenderers = Record<string, SettingsFieldRenderer>;

--- a/packages/shadcn-settings/test/settings-field.test.tsx
+++ b/packages/shadcn-settings/test/settings-field.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SettingsField } from "../src/components/settings-field";
+import { SettingsList } from "../src/components/settings-list";
+import type { SettingsFieldSchema } from "../src/types";
+
+describe("SettingsField", () => {
+  it("renders a string field and commits on blur", () => {
+    const field: SettingsFieldSchema = {
+      name: "SearXNG URL",
+      key: "searxngURL",
+      type: "string",
+      description: "The URL of your SearXNG instance",
+    };
+    const onCommit = vi.fn();
+    render(
+      <SettingsField field={field} value="" onCommit={onCommit} />,
+    );
+
+    expect(screen.getByText("SearXNG URL")).toBeDefined();
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "http://localhost:4000" } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith("http://localhost:4000");
+  });
+
+  it("renders a switch field and commits on toggle", () => {
+    const field: SettingsFieldSchema = {
+      name: "Background Art",
+      key: "showBackgroundArt",
+      type: "switch",
+      default: true,
+    };
+    const onCommit = vi.fn();
+    render(
+      <SettingsField field={field} value={undefined} onCommit={onCommit} />,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onCommit).toHaveBeenCalledWith(false);
+  });
+
+  it("falls back to the unknown renderer for unregistered types", () => {
+    const field: SettingsFieldSchema = {
+      name: "Theme",
+      key: "theme",
+      type: "theme",
+    };
+    render(<SettingsField field={field} value={undefined} />);
+    expect(screen.getByText(/Unsupported field type: theme/)).toBeDefined();
+  });
+
+  it("uses an injected custom renderer for a new type", () => {
+    const field: SettingsFieldSchema = {
+      name: "Theme",
+      key: "theme",
+      type: "theme",
+    };
+    render(
+      <SettingsField
+        field={field}
+        value={undefined}
+        renderers={{
+          theme: ({ field }) => <div>custom:{field.name}</div>,
+        }}
+      />,
+    );
+    expect(screen.getByText("custom:Theme")).toBeDefined();
+  });
+});
+
+describe("SettingsList", () => {
+  it("renders every field and wires commit to the right field", () => {
+    const fields: SettingsFieldSchema[] = [
+      { name: "A", key: "a", type: "string" },
+      { name: "B", key: "b", type: "string" },
+    ];
+    const onCommit = vi.fn();
+    render(
+      <SettingsList
+        fields={fields}
+        getValue={() => ""}
+        onCommit={onCommit}
+      />,
+    );
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(2);
+    fireEvent.change(inputs[1], { target: { value: "x" } });
+    fireEvent.blur(inputs[1]);
+    expect(onCommit).toHaveBeenCalledWith(fields[1], "x");
+  });
+});

--- a/packages/shadcn-settings/tsconfig.build.json
+++ b/packages/shadcn-settings/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "vite.config.ts", "test"]
+}

--- a/packages/shadcn-settings/tsconfig.json
+++ b/packages/shadcn-settings/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shadcn-settings/vite.config.ts
+++ b/packages/shadcn-settings/vite.config.ts
@@ -1,0 +1,48 @@
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+// Library build: emits ESM + CJS. Type declarations are produced separately by
+// `tsc --project tsconfig.build.json` (see package.json build script).
+export default defineConfig({
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    lib: {
+      entry: fileURLToPath(new URL("./src/index.ts", import.meta.url)),
+      name: "ShadcnSettings",
+      formats: ["es", "cjs"],
+      fileName: (format) => `index.${format === "es" ? "mjs" : "cjs"}`,
+    },
+    rollupOptions: {
+      // Externalize React and the shadcn/radix runtime deps so they resolve to
+      // the single instance owned by the consuming app.
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "@radix-ui/react-select",
+        "@radix-ui/react-switch",
+        "class-variance-authority",
+        "clsx",
+        "lucide-react",
+        "tailwind-merge",
+      ],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+          "react/jsx-runtime": "jsxRuntime",
+          "@radix-ui/react-select": "RadixSelect",
+          "@radix-ui/react-switch": "RadixSwitch",
+          "class-variance-authority": "cva",
+          clsx: "clsx",
+          "lucide-react": "LucideReact",
+          "tailwind-merge": "tailwindMerge",
+        },
+        banner: '"use client";',
+      },
+    },
+  },
+  plugins: [react()],
+});

--- a/packages/shadcn-settings/vitest.config.ts
+++ b/packages/shadcn-settings/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom", // package renders React components
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      exclude: [
+        "node_modules/**",
+        "dist/**",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Refactors the settings system to separate schema (data) from rendering and persistence logic. Introduces `shadcn-settings`, a new reusable schema-driven settings form renderer package, and moves app-specific settings declarations into `research-agent-ui` as JSON data files.

## Key Changes

- **New `shadcn-settings` package**: A schema-driven form renderer for React/shadcn/ui that handles `string`, `password`, `textarea`, `select`, and `switch` field types with `card`, `inline`, and `ghost` layout variants. Supports custom renderers and async commit callbacks.

- **Settings schema extracted to data**: Moved hardcoded field definitions from `ConfigManager` into JSON files in `research-agent-ui/src/settings/`:
  - `sections.json` — metadata for the settings sidebar (name, description, icon, dataAdd key)
  - `search.json` — field definitions for search/preferences settings
  - `index.ts` — TypeScript interfaces and exports for the schema

- **SettingsField refactored**: Replaced ~400 lines of per-field component code (SettingsSelect, SettingsInput, SettingsPasswordInput, SettingsTextarea, SettingsSwitch, SettingsTheme) with a single `SettingsField` component that delegates to the `shadcn-settings` renderer, injecting app-specific variants (e.g., theme picker) via a `renderers` prop.

- **SettingsContent simplified**: Now loads section metadata from `research-agent-ui/settings` and maps component/icon names back to React imports, decoupling the section list from the rendering code.

- **Added `'use client'` directive**: SettingsField is now a client component to support hooks and event listeners.

## Implementation Details

- The `shadcn-settings` renderer is layout-agnostic and style-agnostic, using shadcn token defaults (`--border`, `--card`, etc.) with full `classNames` override support.
- Field controls use optimistic updates (`onChange`) with deferred commits (`onCommit` on blur/change), showing spinners during async saves.
- The theme picker remains an app-specific custom renderer injected into the shared field renderer.
- Settings schema is now a single source of truth for field order, labels, descriptions, and options — independent of rendering or persistence code.

https://claude.ai/code/session_01AiTeu9tKZ7v4yCZcXUDfu7