### PR TITLE
Remove generate_ai_response tool and update QwkSearch API calls

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../research-agent-ui && bun run build",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../research-agent-ui && bun run build",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",
@@ -77,7 +77,7 @@
     "onnxruntime-web": "^1.26.0",
     "prettier": "^3.8.4",
     "quantum-sphere-loading-icon": "^1.0.3",
-    "qwksearch-api-client": "^0.0.12",
+    "qwksearch-api-client": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-error-boundary": "^6.1.2",

--- a/packages/chat-agent-toolkit/package.json
+++ b/packages/chat-agent-toolkit/package.json
@@ -98,7 +98,7 @@
     "html-entities": "^2.6.0",
     "manage-storage": "^0.0.13",
     "marked": "^17.0.4",
-    "qwksearch-api-client": "^0.0.12",
+    "qwksearch-api-client": "workspace:*",
     "write-language": "^0.1.4",
     "zod": "^4.3.6"
   },

--- a/packages/chat-agent-toolkit/src/tools/qwksearch-api-tools.ts
+++ b/packages/chat-agent-toolkit/src/tools/qwksearch-api-tools.ts
@@ -39,14 +39,14 @@ export const AGENT_TOOLS = [
         const baseUrl = baseURL || QWKSEARCH_CONFIG.baseURL;
         const headers = apiKey || QWKSEARCH_CONFIG.apiKey ? { 'x-api-key': apiKey || QWKSEARCH_CONFIG.apiKey } : undefined;
 
-        const result = await QwkSearch.searchWeb({
+        const result = await QwkSearch.agentSearch({
           query: {
             q: query,
             cat: category,
             recency: recency,
             page: page,
             lang: language,
-            public: isPublic,
+            publicInstances: isPublic,
             timeout: timeout
           },
           baseUrl: baseUrl,
@@ -102,7 +102,7 @@ export const AGENT_TOOLS = [
         const baseUrl = baseURL || QWKSEARCH_CONFIG.baseURL;
         const headers = apiKey || QWKSEARCH_CONFIG.apiKey ? { 'x-api-key': apiKey || QWKSEARCH_CONFIG.apiKey } : undefined;
 
-        const result = await QwkSearch.extractContent({
+        const result = await QwkSearch.getArticle({
           query: {
             url: url,
             images: images,
@@ -162,90 +162,6 @@ export const AGENT_TOOLS = [
         return resultText;
       } catch (error) {
         return `Unable to extract content from "${url}". Error: ${error.message}`;
-      }
-    },
-  },
-  {
-    name: "generate_ai_response",
-    description:
-      "Generate AI language model responses using QwkSearch API with various agent templates. Supports multiple providers (Groq, OpenAI, Anthropic, etc.) and agent types for different tasks like summarization, question answering, and content generation.",
-    schema: z.object({
-      provider: z.enum(["groq", "openai", "anthropic", "together", "xai", "google", "perplexity", "cloudflare"]),
-      key: z.string().optional(),
-      agent: z.enum([
-        "question",
-        "summarize-bullets",
-        "summarize",
-        "suggest-followups",
-        "answer-cite-sources",
-        "query-resolution",
-        "knowledge-graph-nodes",
-        "summary-longtext"
-      ]).optional().default("question"),
-      model: z.string().optional().default("meta-llama/llama-4-maverick-17b-128e-instruct"),
-      temperature: z.number().min(0).max(2).optional().default(0.7),
-      html: z.boolean().optional().default(true),
-      query: z.string().optional(),
-      chat_history: z.string().optional(),
-      article: z.string().optional(),
-      baseURL: z.string().optional(),
-      apiKey: z.string().optional()
-    }),
-    func: async ({ provider, key, agent = "question", model = "meta-llama/llama-4-maverick-17b-128e-instruct", temperature = 0.7, html = true, query, chat_history, article, baseURL, apiKey }) => {
-      try {
-        // Use provided config or fall back to environment/defaults
-        const baseUrl = baseURL || QWKSEARCH_CONFIG.baseURL;
-        const headers = apiKey || QWKSEARCH_CONFIG.apiKey ? { 'x-api-key': apiKey || QWKSEARCH_CONFIG.apiKey } : undefined;
-
-        const requestBody = {
-          agent,
-          provider,
-          model,
-          html,
-          temperature
-        };
-
-        if (key) {
-          requestBody.key = key;
-        }
-
-        if (query) {
-          requestBody.query = query;
-        }
-
-        if (chat_history) {
-          requestBody.chat_history = chat_history;
-        }
-
-        if (article) {
-          requestBody.article = article;
-        }
-
-        const result = await QwkSearch.writeLanguage({
-          body: requestBody,
-          baseUrl: baseUrl,
-          ...(headers && { headers })
-        });
-
-        if (!result.data) {
-          return `No response generated. Please check your input parameters and try again.`;
-        }
-
-        let resultText = `AI Response (${agent} agent, ${provider} provider):\n\n`;
-
-        if (result.data.content) {
-          resultText += result.data.content;
-        }
-
-        if (result.data.extract) {
-          resultText += `\n\nStructured Extract:\n${JSON.stringify(result.data.extract, null, 2)}`;
-        }
-
-        resultText += `\n\nThis is the complete AI-generated response.`;
-
-        return resultText;
-      } catch (error) {
-        return `Unable to generate AI response. Error: ${error.message}`;
       }
     },
   },

--- a/packages/chat-agent-toolkit/test/extraction-integration.test.ts
+++ b/packages/chat-agent-toolkit/test/extraction-integration.test.ts
@@ -8,7 +8,7 @@ import { AGENT_TOOLS } from '../src/tools/qwksearch-api-tools';
 import * as QwkSearch from 'qwksearch-api-client';
 
 // Mock the QwkSearch API client
-vi.mock('qwksearch-api-client');
+vi.mock("qwksearch-api-client");
 
 describe('Web Extraction Integration Tests', () => {
   const extractPageTool = AGENT_TOOLS.find(t => t.name === 'extract_page');
@@ -37,7 +37,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://technews.com/ai-advances-2024',
@@ -72,7 +72,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://devblog.com/web-dev-guide'
@@ -99,7 +99,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://research.org/climate-report'
@@ -126,7 +126,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://journal.com/study'
@@ -162,7 +162,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://proghub.com/visual-guide',
@@ -189,7 +189,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://blog.com/post'
@@ -215,7 +215,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://example.com/long'
@@ -236,7 +236,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://example.com/special'
@@ -258,7 +258,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://example.fr/article'
@@ -279,7 +279,7 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool!.func({
         url: 'https://example.com/article?utm_source=test&utm_campaign=demo'
@@ -290,7 +290,7 @@ describe('Web Extraction Integration Tests', () => {
     });
 
     it('should handle timeout errors gracefully', async () => {
-      vi.mocked(QwkSearch.extractContent).mockRejectedValueOnce(
+      vi.mocked(QwkSearch.getArticle).mockRejectedValueOnce(
         new Error('Request timeout after 10 seconds')
       );
 
@@ -304,7 +304,7 @@ describe('Web Extraction Integration Tests', () => {
     });
 
     it('should handle 404 errors', async () => {
-      vi.mocked(QwkSearch.extractContent).mockRejectedValueOnce(
+      vi.mocked(QwkSearch.getArticle).mockRejectedValueOnce(
         new Error('404 Not Found')
       );
 
@@ -317,7 +317,7 @@ describe('Web Extraction Integration Tests', () => {
     });
 
     it('should handle network errors', async () => {
-      vi.mocked(QwkSearch.extractContent).mockRejectedValueOnce(
+      vi.mocked(QwkSearch.getArticle).mockRejectedValueOnce(
         new Error('Network connection failed')
       );
 
@@ -342,14 +342,14 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       await extractPageTool!.func({
         url: 'https://example.com',
         images: false
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith(
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             images: false
@@ -369,14 +369,14 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       await extractPageTool!.func({
         url: 'https://example.com',
         links: false
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith(
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             links: false
@@ -396,14 +396,14 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       await extractPageTool!.func({
         url: 'https://example.com',
         formatting: false
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith(
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             formatting: false
@@ -423,14 +423,14 @@ describe('Web Extraction Integration Tests', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       await extractPageTool!.func({
         url: 'https://example.com',
         timeout: 30
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith(
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             timeout: 30

--- a/packages/chat-agent-toolkit/test/qwksearch-tools.test.ts
+++ b/packages/chat-agent-toolkit/test/qwksearch-tools.test.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Unit tests for QwkSearch API tools
- * Tests web_search, extract_page, and generate_ai_response tools
+ * Tests web_search and extract_page tools
  */
 
 import { describe, it, expect, beforeAll, vi } from 'vitest';
@@ -9,20 +9,17 @@ import * as QwkSearch from 'qwksearch-api-client';
 
 // Mock the QwkSearch API client
 vi.mock('qwksearch-api-client', () => ({
-  searchWeb: vi.fn(),
-  extractContent: vi.fn(),
-  writeLanguage: vi.fn(),
+  agentSearch: vi.fn(),
+  getArticle: vi.fn(),
 }));
 
 describe('QwkSearch API Tools', () => {
   let webSearchTool: any;
   let extractPageTool: any;
-  let generateAiResponseTool: any;
 
   beforeAll(() => {
     webSearchTool = AGENT_TOOLS.find(t => t.name === 'web_search');
     extractPageTool = AGENT_TOOLS.find(t => t.name === 'extract_page');
-    generateAiResponseTool = AGENT_TOOLS.find(t => t.name === 'generate_ai_response');
   });
 
   describe('Tool Registration', () => {
@@ -36,12 +33,6 @@ describe('QwkSearch API Tools', () => {
       expect(extractPageTool).toBeDefined();
       expect(extractPageTool.name).toBe('extract_page');
       expect(extractPageTool.description).toContain('Extract and summarize content');
-    });
-
-    it('should have generate_ai_response tool registered', () => {
-      expect(generateAiResponseTool).toBeDefined();
-      expect(generateAiResponseTool.name).toBe('generate_ai_response');
-      expect(generateAiResponseTool.description).toContain('Generate AI language model responses');
     });
   });
 
@@ -63,7 +54,7 @@ describe('QwkSearch API Tools', () => {
       expect(parsed.timeout).toBe(10);
     });
 
-    it('should call QwkSearch.searchWeb with correct parameters', async () => {
+    it('should call QwkSearch.agentSearch with correct parameters', async () => {
       const mockResponse = {
         data: {
           results: [
@@ -78,7 +69,7 @@ describe('QwkSearch API Tools', () => {
         }
       };
 
-      vi.mocked(QwkSearch.searchWeb).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.agentSearch).mockResolvedValueOnce(mockResponse as any);
 
       const result = await webSearchTool.func({
         query: 'test query',
@@ -90,14 +81,14 @@ describe('QwkSearch API Tools', () => {
         timeout: 10
       });
 
-      expect(QwkSearch.searchWeb).toHaveBeenCalledWith({
+      expect(QwkSearch.agentSearch).toHaveBeenCalledWith({
         query: {
           q: 'test query',
           cat: 'general',
           recency: 'none',
           page: 1,
           lang: 'en-US',
-          public: false,
+          publicInstances: false,
           timeout: 10
         },
         baseUrl: expect.any(String),
@@ -110,7 +101,7 @@ describe('QwkSearch API Tools', () => {
     });
 
     it('should handle empty search results', async () => {
-      vi.mocked(QwkSearch.searchWeb).mockResolvedValueOnce({
+      vi.mocked(QwkSearch.agentSearch).mockResolvedValueOnce({
         data: { results: [] }
       } as any);
 
@@ -119,7 +110,7 @@ describe('QwkSearch API Tools', () => {
     });
 
     it('should handle search errors gracefully', async () => {
-      vi.mocked(QwkSearch.searchWeb).mockRejectedValueOnce(
+      vi.mocked(QwkSearch.agentSearch).mockRejectedValueOnce(
         new Error('Network error')
       );
 
@@ -130,7 +121,7 @@ describe('QwkSearch API Tools', () => {
 
     it('should pass custom baseURL and apiKey', async () => {
       const mockResponse = { data: { results: [] } };
-      vi.mocked(QwkSearch.searchWeb).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.agentSearch).mockResolvedValueOnce(mockResponse as any);
 
       await webSearchTool.func({
         query: 'test',
@@ -138,7 +129,7 @@ describe('QwkSearch API Tools', () => {
         apiKey: 'custom-key'
       });
 
-      expect(QwkSearch.searchWeb).toHaveBeenCalledWith(
+      expect(QwkSearch.agentSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           baseUrl: 'https://custom.api.com',
           headers: { 'x-api-key': 'custom-key' }
@@ -165,7 +156,7 @@ describe('QwkSearch API Tools', () => {
       expect(parsed.timeout).toBe(10);
     });
 
-    it('should call QwkSearch.extractContent with correct parameters', async () => {
+    it('should call QwkSearch.getArticle with correct parameters', async () => {
       const mockResponse = {
         data: {
           title: 'Test Article',
@@ -181,7 +172,7 @@ describe('QwkSearch API Tools', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool.func({
         url: 'https://example.com',
@@ -192,7 +183,7 @@ describe('QwkSearch API Tools', () => {
         timeout: 10
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith({
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith({
         query: {
           url: 'https://example.com',
           images: true,
@@ -213,7 +204,7 @@ describe('QwkSearch API Tools', () => {
     });
 
     it('should handle extraction with no data', async () => {
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce({
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce({
         data: null
       } as any);
 
@@ -225,7 +216,7 @@ describe('QwkSearch API Tools', () => {
     });
 
     it('should handle extraction errors gracefully', async () => {
-      vi.mocked(QwkSearch.extractContent).mockRejectedValueOnce(
+      vi.mocked(QwkSearch.getArticle).mockRejectedValueOnce(
         new Error('Timeout error')
       );
 
@@ -239,7 +230,7 @@ describe('QwkSearch API Tools', () => {
 
     it('should pass custom baseURL and apiKey', async () => {
       const mockResponse = { data: null };
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       await extractPageTool.func({
         url: 'https://example.com',
@@ -247,7 +238,7 @@ describe('QwkSearch API Tools', () => {
         apiKey: 'custom-key'
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith(
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith(
         expect.objectContaining({
           baseUrl: 'https://custom.api.com',
           headers: { 'x-api-key': 'custom-key' }
@@ -266,7 +257,7 @@ describe('QwkSearch API Tools', () => {
         }
       };
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce(mockResponse as any);
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce(mockResponse as any);
 
       const result = await extractPageTool.func({
         url: 'https://example.com'
@@ -279,156 +270,11 @@ describe('QwkSearch API Tools', () => {
     });
   });
 
-  describe('generate_ai_response tool', () => {
-    it('should validate schema for required parameters', () => {
-      const schema = generateAiResponseTool.schema;
-      expect(() => schema.parse({ provider: 'groq' })).not.toThrow();
-      expect(() => schema.parse({})).toThrow();
-    });
-
-    it('should have correct default values', () => {
-      const schema = generateAiResponseTool.schema;
-      const parsed = schema.parse({ provider: 'groq' });
-      expect(parsed.agent).toBe('question');
-      expect(parsed.model).toBe('meta-llama/llama-4-maverick-17b-128e-instruct');
-      expect(parsed.temperature).toBe(0.7);
-      expect(parsed.html).toBe(true);
-    });
-
-    it('should call QwkSearch.writeLanguage with correct parameters', async () => {
-      const mockResponse = {
-        data: {
-          content: '<p>AI generated response</p>'
-        }
-      };
-
-      vi.mocked(QwkSearch.writeLanguage).mockResolvedValueOnce(mockResponse as any);
-
-      const result = await generateAiResponseTool.func({
-        provider: 'groq',
-        agent: 'question',
-        model: 'meta-llama/llama-4-maverick-17b-128e-instruct',
-        temperature: 0.7,
-        html: true,
-        query: 'What is AI?'
-      });
-
-      expect(QwkSearch.writeLanguage).toHaveBeenCalledWith({
-        body: {
-          agent: 'question',
-          provider: 'groq',
-          model: 'meta-llama/llama-4-maverick-17b-128e-instruct',
-          html: true,
-          temperature: 0.7,
-          query: 'What is AI?'
-        },
-        baseUrl: expect.any(String),
-        headers: undefined
-      });
-
-      expect(result).toContain('AI generated response');
-    });
-
-    it('should handle response with extract data', async () => {
-      const mockResponse = {
-        data: {
-          content: '<p>Response</p>',
-          extract: { entities: ['AI', 'ML'], sentiment: 'positive' }
-        }
-      };
-
-      vi.mocked(QwkSearch.writeLanguage).mockResolvedValueOnce(mockResponse as any);
-
-      const result = await generateAiResponseTool.func({
-        provider: 'groq',
-        query: 'test'
-      });
-
-      expect(result).toContain('<p>Response</p>');
-      expect(result).toContain('Structured Extract:');
-      expect(result).toContain('entities');
-    });
-
-    it('should handle generation errors gracefully', async () => {
-      vi.mocked(QwkSearch.writeLanguage).mockRejectedValueOnce(
-        new Error('API key invalid')
-      );
-
-      const result = await generateAiResponseTool.func({
-        provider: 'groq',
-        key: 'invalid-key'
-      });
-
-      expect(result).toContain('Unable to generate AI response');
-      expect(result).toContain('API key invalid');
-    });
-
-    it('should support all agent types', () => {
-      const schema = generateAiResponseTool.schema;
-      const agentTypes = [
-        'question',
-        'summarize-bullets',
-        'summarize',
-        'suggest-followups',
-        'answer-cite-sources',
-        'query-resolution',
-        'knowledge-graph-nodes',
-        'summary-longtext'
-      ];
-
-      agentTypes.forEach(agent => {
-        expect(() => schema.parse({ provider: 'groq', agent })).not.toThrow();
-      });
-    });
-
-    it('should support all provider types', () => {
-      const schema = generateAiResponseTool.schema;
-      const providers = [
-        'groq',
-        'openai',
-        'anthropic',
-        'together',
-        'xai',
-        'google',
-        'perplexity',
-        'cloudflare'
-      ];
-
-      providers.forEach(provider => {
-        expect(() => schema.parse({ provider })).not.toThrow();
-      });
-    });
-
-    it('should include optional parameters when provided', async () => {
-      const mockResponse = { data: { content: 'Response' } };
-      vi.mocked(QwkSearch.writeLanguage).mockResolvedValueOnce(mockResponse as any);
-
-      await generateAiResponseTool.func({
-        provider: 'groq',
-        key: 'test-key',
-        query: 'test query',
-        chat_history: 'previous chat',
-        article: 'article content'
-      });
-
-      expect(QwkSearch.writeLanguage).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          key: 'test-key',
-          query: 'test query',
-          chat_history: 'previous chat',
-          article: 'article content'
-        }),
-        baseUrl: expect.any(String),
-        headers: undefined
-      });
-    });
-  });
-
   describe('Integration: Parameter passing', () => {
     it('should properly construct baseUrl from baseURL parameter', async () => {
       const customBaseURL = 'https://my-custom-api.com/v1';
 
-      vi.mocked(QwkSearch.searchWeb).mockResolvedValueOnce({
+      vi.mocked(QwkSearch.agentSearch).mockResolvedValueOnce({
         data: { results: [] }
       } as any);
 
@@ -437,7 +283,7 @@ describe('QwkSearch API Tools', () => {
         baseURL: customBaseURL
       });
 
-      expect(QwkSearch.searchWeb).toHaveBeenCalledWith(
+      expect(QwkSearch.agentSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           baseUrl: customBaseURL
         })
@@ -447,7 +293,7 @@ describe('QwkSearch API Tools', () => {
     it('should construct headers object when apiKey is provided', async () => {
       const apiKey = 'test-api-key-12345';
 
-      vi.mocked(QwkSearch.extractContent).mockResolvedValueOnce({
+      vi.mocked(QwkSearch.getArticle).mockResolvedValueOnce({
         data: null
       } as any);
 
@@ -456,7 +302,7 @@ describe('QwkSearch API Tools', () => {
         apiKey: apiKey
       });
 
-      expect(QwkSearch.extractContent).toHaveBeenCalledWith(
+      expect(QwkSearch.getArticle).toHaveBeenCalledWith(
         expect.objectContaining({
           headers: { 'x-api-key': apiKey }
         })
@@ -464,7 +310,7 @@ describe('QwkSearch API Tools', () => {
     });
 
     it('should not include headers when apiKey is not provided', async () => {
-      vi.mocked(QwkSearch.searchWeb).mockResolvedValueOnce({
+      vi.mocked(QwkSearch.agentSearch).mockResolvedValueOnce({
         data: { results: [] }
       } as any);
 
@@ -472,7 +318,7 @@ describe('QwkSearch API Tools', () => {
         query: 'test'
       });
 
-      expect(QwkSearch.searchWeb).toHaveBeenCalledWith(
+      expect(QwkSearch.agentSearch).toHaveBeenCalledWith(
         expect.not.objectContaining({
           headers: expect.anything()
         })

--- a/packages/extract-pdf/package.json
+++ b/packages/extract-pdf/package.json
@@ -26,7 +26,9 @@
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --coverage-reporter=text",
     "ship": "npm run build && npx standard-version --release-as patch; rm -f CHANGELOG.md; npm publish"
   },
-  "dependencies": {},
+  "dependencies": {
+    "grab-url": "^1.6.22"
+  },
   "devDependencies": {
     "terser": "^5.46.0",
     "typescript": "^5.9.3",

--- a/packages/research-agent-ui/src/assets.d.ts
+++ b/packages/research-agent-ui/src/assets.d.ts
@@ -7,3 +7,6 @@ declare module "*.png" {
   const src: string;
   export default src;
 }
+
+declare module "*.css";
+declare module "react-native-app-buttons/styles";

--- a/packages/research-agent-ui/src/cloudflare/worker.ts
+++ b/packages/research-agent-ui/src/cloudflare/worker.ts
@@ -9,12 +9,24 @@
  */
 import { Router, IRequest } from 'itty-router';
 import { json, text, error as httpError } from 'itty-router';
+import type { D1Database, R2Bucket, KVNamespace, ExecutionContext, ScheduledEvent } from '@cloudflare/workers-types';
 
 // itty-router v5 removed the `missing` helper; provide a 404 shim via `error`.
 const missing = (message?: string) => httpError(404, message ?? 'Not Found');
 
 // Cloudflare Workers runtime for research-agent-ui
 // Provides metadata endpoints, OAuth flows, connection management, and transit file handling
+
+interface TransitFileRow {
+  id: string;
+  connection_id: string;
+  name: string;
+  mime_type: string;
+  size_bytes: number;
+  backend: 'r2' | 'kv';
+  backend_key: string;
+  expires_at: string;
+}
 
 export interface Env {
   DB: D1Database;
@@ -165,7 +177,8 @@ router.post('/api/v1/oauth/callback', async (req: IRequest, env: Env) => {
 router.get('/api/v1/run-logs', async (req: IRequest, env: Env) => {
   if (!authenticateAdmin(req, env)) return httpError(401, 'Unauthorized');
 
-  const limit = Math.min(parseInt(req.query.limit || '100'), 1000);
+  const limitParam = Array.isArray(req.query.limit) ? req.query.limit[0] : req.query.limit;
+  const limit = Math.min(parseInt(limitParam || '100'), 1000);
   const { results } = await env.DB.prepare('SELECT * FROM run_logs ORDER BY created_at DESC LIMIT ?')
     .bind(limit)
     .all();
@@ -215,12 +228,12 @@ router.post('/api/v1/transit-files', async (req: IRequest, env: Env) => {
   const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
 
   // Store file in backend
+  const buffer = await file.arrayBuffer();
   if (env.TRANSIT_FILES_BACKEND === 'r2') {
     const bucket = env.TRANSIT_FILES as R2Bucket;
-    await bucket.put(backendKey, file);
+    await bucket.put(backendKey, buffer);
   } else {
     const kv = env.TRANSIT_FILES as KVNamespace;
-    const buffer = await file.arrayBuffer();
     await kv.put(backendKey, buffer, { expirationTtl: ttlSeconds });
   }
 
@@ -237,7 +250,7 @@ router.get('/api/v1/transit-files/:id', async (req: IRequest, env: Env) => {
   if (!authenticateAdmin(req, env)) return httpError(401, 'Unauthorized');
 
   const { id } = req.params;
-  const { results } = await env.DB.prepare('SELECT * FROM transit_files WHERE id = ?').bind(id).all();
+  const { results } = await env.DB.prepare('SELECT * FROM transit_files WHERE id = ?').bind(id).all<TransitFileRow>();
 
   if (!results || results.length === 0) {
     return missing('File not found');
@@ -250,7 +263,7 @@ router.get('/api/v1/transit-files/:id', async (req: IRequest, env: Env) => {
     const bucket = env.TRANSIT_FILES as R2Bucket;
     const obj = await bucket.get(fileRecord.backend_key);
     if (!obj) return missing('File not found in R2');
-    return new Response(obj.body, { headers: { 'Content-Type': fileRecord.mime_type } });
+    return new Response(obj.body as unknown as ReadableStream, { headers: { 'Content-Type': fileRecord.mime_type } });
   } else {
     const kv = env.TRANSIT_FILES as KVNamespace;
     const data = await kv.get(fileRecord.backend_key, 'arrayBuffer');
@@ -263,7 +276,7 @@ router.delete('/api/v1/transit-files/:id', async (req: IRequest, env: Env) => {
   if (!authenticateAdmin(req, env)) return httpError(401, 'Unauthorized');
 
   const { id } = req.params;
-  const { results } = await env.DB.prepare('SELECT * FROM transit_files WHERE id = ?').bind(id).all();
+  const { results } = await env.DB.prepare('SELECT * FROM transit_files WHERE id = ?').bind(id).all<TransitFileRow>();
 
   if (!results || results.length === 0) {
     return missing('File not found');
@@ -312,7 +325,7 @@ async function cleanupExpiredRecords(env: Env) {
   // Clean up expired transit files from DB and storage
   const { results: expiredFiles } = await env.DB.prepare(
     'SELECT * FROM transit_files WHERE expires_at < ?'
-  ).bind(now).all();
+  ).bind(now).all<TransitFileRow>();
 
   if (expiredFiles) {
     for (const file of expiredFiles) {

--- a/packages/search-web-api/package.json
+++ b/packages/search-web-api/package.json
@@ -12,10 +12,12 @@
   },
   "exports": {
     ".": {
+      "types": "./src/search.ts",
       "import": "./src/search.ts",
       "require": "./src/search.ts"
     },
     "./*": {
+      "types": "./src/*.ts",
       "import": "./src/*",
       "require": "./src/*"
     }

--- a/packages/search-web-api/src/types/search-engine-interface.ts
+++ b/packages/search-web-api/src/types/search-engine-interface.ts
@@ -5,9 +5,9 @@
  * import `EngineFunction` and `EngineResult` from here.
  */
 
-import { EngineResult, Engine, EngineFunction } from "./search-result-types.js";
+import type { EngineResult, Engine, EngineFunction } from "./search-result-types.js";
 
-export { EngineResult, Engine, EngineFunction };
+export type { EngineResult, Engine, EngineFunction };
 
 /**
  * Extract the actual data from a grab-url response.


### PR DESCRIPTION
## Summary
This PR removes the `generate_ai_response` tool from the QwkSearch API toolkit and updates all QwkSearch API client method calls to use the new API interface. The changes align with an updated version of the qwksearch-api-client library.

## Key Changes

- **Removed `generate_ai_response` tool**: Deleted the entire tool definition, schema, and all associated tests from the toolkit. This tool provided AI language model responses using various providers (Groq, OpenAI, Anthropic, etc.).

- **Updated QwkSearch API method calls**:
  - `searchWeb()` → `agentSearch()`
  - `extractContent()` → `getArticle()`
  - `writeLanguage()` → Removed (along with the tool that used it)

- **Updated API parameter names**:
  - `public` → `publicInstances` in the web search query parameters

- **Updated test mocks**: All test files now mock the new method names and verify calls against the updated API interface.

- **Type safety improvements**: Added TypeScript type annotations for Cloudflare Workers types and database query results in the research-agent-ui worker.

- **Fixed query parameter handling**: Improved handling of array-type query parameters in the Cloudflare worker to prevent type errors.

- **Updated package dependencies**: Changed qwksearch-api-client to use workspace reference instead of a specific version.

## Implementation Details

- The `web_search` and `extract_page` tools remain fully functional with the updated API calls
- All error handling and parameter validation logic is preserved
- The removal of `generate_ai_response` simplifies the toolkit to focus on search and content extraction capabilities
- Test coverage for the remaining tools has been updated to reflect the new API interface

https://claude.ai/code/session_01T6JGNWGBqBXkYCugePg1kC