### PR TITLE
Add LiteParse integration and OCR detection for PDF extraction

### DIFF
--- a/apps/qwksearch-web/vite.config.ts
+++ b/apps/qwksearch-web/vite.config.ts
@@ -43,7 +43,11 @@ export default defineConfig(({ command }) => ({
       // require() lazily inside a try/catch; it has no place in the Worker
       // bundle and is never installed on Linux, so leave it external.
       // `@mastra/core` and `@mastra/mcp` are optional dependencies with incorrect package.json exports.
-      external: ["fsevents", /^@mastra\//],
+      // `@llamaindex/liteparse` (dynamically imported by extract-pdf's
+      // "liteparse" ParseMethod, behind a try/catch) ships a native napi addon
+      // that workerd cannot load; nothing in this app opts into that method,
+      // so keep it external rather than trying to bundle the .node binary.
+      external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse"],
     },
     rolldownOptions: {
       // Rolldown (Vite 8.x bundler) needs its own external list.
@@ -62,7 +66,10 @@ export default defineConfig(({ command }) => ({
       // lazy-loaded voice component. It is a browser-only library and must be
       // bundled client-side; the `externalize-kokoro-on-server` plugin below
       // keeps it external in the server (rsc/ssr) worker build instead.
-      external: ["fsevents", /^@mastra\//],
+      //
+      // `@llamaindex/liteparse` is likewise kept external — see the comment
+      // in `rollupOptions.external` above.
+      external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse"],
     },
   },
   ssr: {

--- a/packages/extract-pdf/README.md
+++ b/packages/extract-pdf/README.md
@@ -54,16 +54,75 @@ const { html } = await convertPDFToHTML(buffer, { addPageNumbers: true });
 
 ### Options
 
-| Option           | Default | Description                                                                                |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------ |
-| `addPageNumbers` | `false` | Inserts `[n]` markers at each page boundary                                                |
-| `addCitation`    | `true`  | Reads PDF metadata and first-page heading to populate `title`/`author` in the return value |
+| Option            | Default               | Description                                                                                |
+| ----------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| `addPageNumbers`  | `false`                | Inserts `[n]` markers at each page boundary                                                |
+| `addCitation`     | `true`                 | Reads PDF metadata and first-page heading to populate `title`/`author` in the return value |
+| `method`          | `"ts-block-algorithm"` | Parsing engine — `"ts-block-algorithm"` or `"liteparse"` (see below)                       |
+| `liteParseOptions`| `{}`                   | Passed through to LiteParse's constructor when `method: "liteparse"`                       |
 
 ### Return value
 
 ```ts
 { html: string, title?: string, author?: string, format: "pdf" }
 ```
+
+## Parse methods
+
+`convertPDFToHTML` supports two interchangeable parsing engines via `options.method`:
+
+| Method                              | Engine                                                              | Environments                       | OCR |
+| ------------------------------------ | -------------------------------------------------------------------- | ----------------------------------- | --- |
+| `"ts-block-algorithm"` (default)     | The pure-TS pipeline documented below (this package)                  | Node.js, Cloudflare Workers, browser | No  |
+| `"liteparse"`                        | [LiteParse](https://github.com/run-llama/liteparse) (native, `@llamaindex/liteparse`) | Node.js only                        | Optional |
+
+```ts
+import { convertPDFToHTML } from "extract-pdf";
+
+const { html } = await convertPDFToHTML(buffer, { method: "liteparse" });
+```
+
+LiteParse ships a native (napi) addon, so `method: "liteparse"` only runs in
+Node.js — it is not bundled into browser or Cloudflare Workers builds. Install
+it explicitly (`bun add @llamaindex/liteparse`) since it's an optional
+dependency; if it isn't installed, `convertPDFToHTML` returns `{ error }`
+instead of throwing.
+
+By default the LiteParse path runs with OCR disabled (`ocrEnabled: false`) —
+matching this package's "instant, no backend" philosophy. Use
+`detectPdfNeedsOcr` (below) to decide when a document is worth re-parsing with
+`liteParseOptions: { ocrEnabled: true }`.
+
+## Detecting whether a PDF needs OCR
+
+Before committing to a full (and potentially slow) OCR parse, `detectPdfNeedsOcr`
+runs a cheap, text-layer-only pass and reports whether each page needs OCR or
+other heavy parsing — useful for routing documents to different pipelines
+(fast path vs. OCR vs. screenshots vs. a heavier parser like LlamaParse or
+Docling):
+
+```ts
+import { detectPdfNeedsOcr, convertPDFToHTML } from "extract-pdf";
+
+const assessment = await detectPdfNeedsOcr(buffer);
+// { needsOcr: boolean, pages: PageComplexityStats[], reasons: string[] }
+
+if (!assessment.needsOcr) {
+  const { html } = await convertPDFToHTML(buffer, { method: "liteparse" });
+} else {
+  console.log("Needs OCR:", assessment.reasons); // e.g. ["scanned", "sparse-text"]
+  // Route to an OCR-enabled pipeline, e.g.:
+  const { html } = await convertPDFToHTML(buffer, {
+    method: "liteparse",
+    liteParseOptions: { ocrEnabled: true },
+  });
+}
+```
+
+`reasons` collects every distinct signal found across pages: `"scanned"`,
+`"no-text"`, `"sparse-text"`, `"embedded-images"`, `"garbled"`, or
+`"vector-text"`. Like `method: "liteparse"`, this is Node.js only and requires
+`@llamaindex/liteparse`.
 
 ## Pipeline
 

--- a/packages/extract-pdf/package.json
+++ b/packages/extract-pdf/package.json
@@ -27,6 +27,9 @@
     "ship": "npm run build && npx standard-version --release-as patch; rm -f CHANGELOG.md; npm publish"
   },
   "dependencies": {},
+  "optionalDependencies": {
+    "@llamaindex/liteparse": "^2.10.0"
+  },
   "devDependencies": {
     "terser": "^5.46.0",
     "typescript": "^5.9.3",

--- a/packages/extract-pdf/src/detect-needs-ocr.ts
+++ b/packages/extract-pdf/src/detect-needs-ocr.ts
@@ -1,0 +1,52 @@
+/**
+ * Cheap, text-layer-only pass that determines whether a PDF needs OCR (or
+ * other heavy parsing) before committing to a full parse — useful for routing
+ * documents to different pipelines. Backed by LiteParse's `isComplex`, so this
+ * is Node.js only (native napi addon) and requires the optional
+ * `@llamaindex/liteparse` dependency.
+ */
+import { grab } from "./utils/grab";
+import type { LiteParseConfig, PageComplexityStats } from "@llamaindex/liteparse";
+
+export interface DetectPdfNeedsOcrOptions {
+  liteParseOptions?: Partial<LiteParseConfig>;
+}
+
+export interface PdfOcrAssessment {
+  /** True when any page needs OCR or other advanced parsing. */
+  needsOcr: boolean;
+  /** Per-page complexity signals, one entry per page. */
+  pages: PageComplexityStats[];
+  /**
+   * Every distinct reason found across all pages, e.g. `"scanned"`,
+   * `"no-text"`, `"sparse-text"`, `"embedded-images"`, `"garbled"`,
+   * `"vector-text"`. Empty when `needsOcr` is false.
+   */
+  reasons: string[];
+}
+
+/**
+ * Determines whether a PDF (URL or ArrayBuffer) needs OCR to extract usable
+ * text, without running a full parse.
+ * @param pdfURLOrBuffer - URL to a PDF file or buffer from fs.readFile
+ * @category Extract
+ */
+export async function detectPdfNeedsOcr(
+  pdfURLOrBuffer: any,
+  options: DetectPdfNeedsOcrOptions = {},
+): Promise<PdfOcrAssessment> {
+  const buffer =
+    typeof pdfURLOrBuffer === "string"
+      ? await grab(pdfURLOrBuffer, { responseType: "arraybuffer", timeout: 10 })
+      : pdfURLOrBuffer;
+
+  const { LiteParse } = await import("@llamaindex/liteparse");
+  const parser = new LiteParse({ quiet: true, ...options.liteParseOptions });
+  const pages = await parser.isComplex(new Uint8Array(buffer));
+
+  return {
+    needsOcr: pages.some((page) => page.needsOcr),
+    pages,
+    reasons: [...new Set(pages.flatMap((page) => page.reasons))],
+  };
+}

--- a/packages/extract-pdf/src/liteparse-to-html.ts
+++ b/packages/extract-pdf/src/liteparse-to-html.ts
@@ -1,0 +1,95 @@
+/**
+ * Alternate `ParseMethod` for convertPDFToHTML that delegates to
+ * [LiteParse](https://github.com/run-llama/liteparse) instead of the built-in
+ * ts-block-algorithm pipeline. LiteParse ships a native (napi) addon, so this
+ * path is Node.js only — it will not run in Cloudflare Workers or browsers —
+ * and requires the optional `@llamaindex/liteparse` dependency to be installed.
+ */
+import { grab } from "./utils/grab";
+import type { LiteParseConfig } from "@llamaindex/liteparse";
+
+export interface LiteParseHTMLOptions {
+  addPageNumbers?: boolean;
+  addCitation?: boolean;
+  liteParseOptions?: Partial<LiteParseConfig>;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Converts a PDF (URL or ArrayBuffer) into HTML using LiteParse's spatial text
+ * extraction, mirroring the return shape of `convertPDFToHTML`.
+ * @param pdfURLOrBuffer - URL to a PDF file or buffer from fs.readFile
+ * @param options.addPageNumbers default=false - Adds `[n]` markers at each page boundary
+ * @param options.addCitation default=true - Populates `title`/`author` from PDF metadata
+ * @param options.liteParseOptions - Passed through to the `LiteParse` constructor;
+ *   defaults to `{ ocrEnabled: false, ocrFailureFatal: false }` (use detectPdfNeedsOcr
+ *   to decide when a document is worth re-parsing with `ocrEnabled: true`)
+ * @returns `{ html, title, author, format: "pdf" }`, or `{ error }` on failure
+ * @category Extract
+ */
+export async function convertPDFToHTMLWithLiteParse(
+  pdfURLOrBuffer: any,
+  options: LiteParseHTMLOptions = {},
+) {
+  const { addPageNumbers = false, addCitation = true, liteParseOptions = {} } = options;
+
+  const buffer =
+    typeof pdfURLOrBuffer === "string"
+      ? await grab(pdfURLOrBuffer, { responseType: "arraybuffer", timeout: 10 })
+      : pdfURLOrBuffer;
+
+  let LiteParse: typeof import("@llamaindex/liteparse").LiteParse;
+  try {
+    ({ LiteParse } = await import("@llamaindex/liteparse"));
+  } catch (e: any) {
+    return {
+      error:
+        "method: 'liteparse' requires the optional @llamaindex/liteparse dependency " +
+        `(Node.js only): ${e.message}`,
+    };
+  }
+
+  // Default to no OCR: this method exists for the fast/local path (see
+  // detectPdfNeedsOcr for routing scanned/complex pages elsewhere), and OCR
+  // requires downloading tessdata on first use, which is slow and can fail
+  // offline. `ocrFailureFatal: false` keeps already-recovered native text
+  // instead of discarding the whole parse if a caller opts OCR back in and it
+  // fails on some pages.
+  const parser = new LiteParse({
+    quiet: true,
+    ocrEnabled: false,
+    ocrFailureFatal: false,
+    ...liteParseOptions,
+  });
+
+  let result;
+  try {
+    result = await parser.parse(new Uint8Array(buffer));
+  } catch (e: any) {
+    return { error: e.message };
+  }
+
+  const html = result.pages.reduce((acc, page) => {
+    const body = page.text
+      .split(/\n{2,}/)
+      .filter((paragraph) => paragraph.trim().length > 0)
+      .map((paragraph) => escapeHtml(paragraph).replace(/\n/g, "<br/>"))
+      .join("</p><p>");
+    return (
+      acc +
+      `<p id="page-${page.pageNum}">${addPageNumbers ? ` [${page.pageNum}] ` : ""}${body}</p>`
+    );
+  }, "");
+
+  let title: string | undefined;
+  let author: string | undefined;
+  if (addCitation) {
+    author = result.creator || result.producer;
+    title = result.pages[0]?.text.split("\n").find((line) => line.trim().length > 0);
+  }
+
+  return { author, title, html, format: "pdf" };
+}

--- a/packages/extract-pdf/src/pdf-to-html.ts
+++ b/packages/extract-pdf/src/pdf-to-html.ts
@@ -9,34 +9,7 @@ import {
 } from "./utils/page-number-functions";
 import TextItem from "./models/text-item";
 import Page from "./models/page";
-
-/**
- * Fetch wrapper for grabbing binary content
- */
-async function grab(url: string, options: { responseType?: string; timeout?: number } = {}) {
-  const timeout = options.timeout ? options.timeout * 1000 : 10000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
-
-  try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-
-    if (options.responseType === "arraybuffer") {
-      return await response.arrayBuffer();
-    }
-    return await response.text();
-  } catch (error) {
-    clearTimeout(timeoutId);
-    throw error;
-  }
-}
+import { grab } from "./utils/grab";
 
 import CalculateGlobalStats from "./transforms/calculate-global-stats";
 import CompactLines from "./transforms/line-item/compact-lines";
@@ -52,6 +25,21 @@ import DetectListLevels from "./transforms/block/detect-list-levels";
 import ToTextBlocks from "./transforms/to-text-blocks";
 import ToHTML from "./transforms/to-html";
 import ParseResult from "./models/parse-result";
+import {
+  convertPDFToHTMLWithLiteParse,
+  type LiteParseHTMLOptions,
+} from "./liteparse-to-html";
+
+/**
+ * Which parsing engine {@link convertPDFToHTML} runs.
+ * - `"ts-block-algorithm"` (default) — the pure-TS pipeline in this file: groups
+ *   pdfjs text spans into lines/blocks and renders headings/lists/code blocks.
+ *   Works in Node.js, Cloudflare Workers, and browsers.
+ * - `"liteparse"` — delegates to [LiteParse](https://github.com/run-llama/liteparse),
+ *   a native/OCR-capable parser. Node.js only (ships a napi addon), and requires
+ *   the optional `@llamaindex/liteparse` dependency to be installed.
+ */
+export type ParseMethod = "ts-block-algorithm" | "liteparse";
 
 /**
  * Extracts formatted text from PDF with parsing of linebreaks ,
@@ -67,6 +55,8 @@ import ParseResult from "./models/parse-result";
  * @param {Object} [options]
  * @param {boolean} options.addPageNumbers default=false - Adds  #  to end of each page
  * @param {boolean} options.removePageHeaders default=true - Removes repeated headers found on each page
+ * @param {ParseMethod} options.method default="ts-block-algorithm" - Parsing engine to use;
+ *   `"liteparse"` delegates to LiteParse (Node.js only, see {@link ParseMethod})
  * @returns {string|Object} HTML formatted text
  * @category Extract
  * @author [vtempest (2025)](https://github.com/vtempest),
@@ -75,8 +65,17 @@ import ParseResult from "./models/parse-result";
  */
 export async function convertPDFToHTML(
   pdfURLOrBuffer: any,
-  options: { addPageNumbers?: boolean; addCitation?: boolean } = {},
+  options: {
+    addPageNumbers?: boolean;
+    addCitation?: boolean;
+    method?: ParseMethod;
+  } & Pick<LiteParseHTMLOptions, "liteParseOptions"> = {},
 ) {
+  if (options.method === "liteparse") {
+    const { method: _method, ...liteParseOptions } = options;
+    return convertPDFToHTMLWithLiteParse(pdfURLOrBuffer, liteParseOptions);
+  }
+
   // try {
   var { addPageNumbers = false, addCitation = true } = options;
 
@@ -222,4 +221,11 @@ export async function convertPDFToHTML(
   return { author, title, html, format: "pdf" };
 }
 
+export { convertPDFToHTMLWithLiteParse };
+export type { LiteParseHTMLOptions } from "./liteparse-to-html";
+export { detectPdfNeedsOcr } from "./detect-needs-ocr";
+export type {
+  DetectPdfNeedsOcrOptions,
+  PdfOcrAssessment,
+} from "./detect-needs-ocr";
 

--- a/packages/extract-pdf/src/utils/grab.ts
+++ b/packages/extract-pdf/src/utils/grab.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal fetch wrapper for grabbing binary/text content, shared by every
+ * parse method (ts-block-algorithm, liteparse) and the OCR-need detector.
+ */
+export async function grab(
+  url: string,
+  options: { responseType?: string; timeout?: number } = {},
+) {
+  const timeout = options.timeout ? options.timeout * 1000 : 10000;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    if (options.responseType === "arraybuffer") {
+      return await response.arrayBuffer();
+    }
+    return await response.text();
+  } catch (error) {
+    clearTimeout(timeoutId);
+    throw error;
+  }
+}

--- a/packages/extract-pdf/test/helpers/minimal-pdf.ts
+++ b/packages/extract-pdf/test/helpers/minimal-pdf.ts
@@ -1,0 +1,47 @@
+/**
+ * Builds a minimal 1-page valid PDF in memory with a 24pt heading
+ * ("Test Document") and a 12pt body line ("This is a sample paragraph.").
+ */
+export function minimalPDFBuffer(): ArrayBuffer {
+  const stream = [
+    "BT",
+    "/F1 24 Tf 72 700 Td (Test Document) Tj",
+    "/F1 12 Tf 0 -50 Td (This is a sample paragraph.) Tj",
+    "ET",
+  ].join("\n");
+
+  return buildSinglePagePDF(stream);
+}
+
+/** Builds a 1-page valid PDF with an empty content stream (no text at all). */
+export function blankPDFBuffer(): ArrayBuffer {
+  return buildSinglePagePDF("");
+}
+
+function buildSinglePagePDF(stream: string): ArrayBuffer {
+  const objs: (string | null)[] = [
+    null,
+    "<</Type /Catalog /Pages 2 0 R>>",
+    "<</Type /Pages /Kids [3 0 R] /Count 1>>",
+    "<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources <</Font <</F1 4 0 R>>>> /Contents 5 0 R>>",
+    "<</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>",
+    `<</Length ${stream.length}>>\nstream\n${stream}\nendstream`,
+  ];
+
+  let doc = "%PDF-1.4\n";
+  const offsets: number[] = [];
+
+  for (let n = 1; n <= 5; n++) {
+    offsets[n] = doc.length;
+    doc += `${n} 0 obj\n${objs[n]}\nendobj\n`;
+  }
+
+  const xrefAt = doc.length;
+  doc += "xref\n0 6\n";
+  doc += "0000000000 65535 f \n";
+  for (let i = 1; i <= 5; i++)
+    doc += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  doc += `trailer\n<</Size 6 /Root 1 0 R>>\nstartxref\n${xrefAt}\n%%EOF\n`;
+
+  return new TextEncoder().encode(doc).buffer;
+}

--- a/packages/extract-pdf/test/liteparse.test.ts
+++ b/packages/extract-pdf/test/liteparse.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "bun:test";
+import { convertPDFToHTML } from "../src/pdf-to-html";
+import { convertPDFToHTMLWithLiteParse } from "../src/liteparse-to-html";
+import { detectPdfNeedsOcr } from "../src/detect-needs-ocr";
+import { minimalPDFBuffer, blankPDFBuffer } from "./helpers/minimal-pdf";
+
+const TIMEOUT = 30_000;
+
+describe("convertPDFToHTMLWithLiteParse", () => {
+  it("returns html and format fields from a buffer", async () => {
+    const result = (await convertPDFToHTMLWithLiteParse(minimalPDFBuffer())) as any;
+    expect(result.error).toBeUndefined();
+    expect(result.format).toBe("pdf");
+    expect(typeof result.html).toBe("string");
+    expect(result.html.length).toBeGreaterThan(0);
+  }, TIMEOUT);
+
+  it("html contains text extracted from the PDF", async () => {
+    const result = (await convertPDFToHTMLWithLiteParse(minimalPDFBuffer())) as any;
+    expect(result.html).toContain("Test Document");
+    expect(result.html).toContain("sample paragraph");
+  }, TIMEOUT);
+
+  it("addPageNumbers inserts [1] marker", async () => {
+    const result = (await convertPDFToHTMLWithLiteParse(minimalPDFBuffer(), {
+      addPageNumbers: true,
+    })) as any;
+    expect(result.html).toMatch(/\[1\]/);
+  }, TIMEOUT);
+
+  it("addCitation: false returns html without extracting metadata", async () => {
+    const result = (await convertPDFToHTMLWithLiteParse(minimalPDFBuffer(), {
+      addCitation: false,
+    })) as any;
+    expect(typeof result.html).toBe("string");
+    expect(result.author).toBeUndefined();
+    expect(result.title).toBeUndefined();
+  }, TIMEOUT);
+
+  it("returns error object for an invalid buffer", async () => {
+    const bad = new Uint8Array([0x00, 0x01, 0x02, 0x03]).buffer;
+    const result = await convertPDFToHTMLWithLiteParse(bad);
+    expect(result).toHaveProperty("error");
+  }, TIMEOUT);
+});
+
+describe("convertPDFToHTML method dispatch", () => {
+  it("method: 'liteparse' delegates to convertPDFToHTMLWithLiteParse", async () => {
+    const result = (await convertPDFToHTML(minimalPDFBuffer(), {
+      method: "liteparse",
+    })) as any;
+    expect(result.error).toBeUndefined();
+    expect(result.format).toBe("pdf");
+    expect(result.html).toContain("Test Document");
+  }, TIMEOUT);
+});
+
+describe("detectPdfNeedsOcr", () => {
+  it("flags a page with no text at all as needing OCR", async () => {
+    const assessment = await detectPdfNeedsOcr(blankPDFBuffer());
+    expect(assessment.needsOcr).toBe(true);
+    expect(assessment.pages).toHaveLength(1);
+    expect(assessment.pages[0].needsOcr).toBe(true);
+    expect(assessment.reasons.length).toBeGreaterThan(0);
+  }, TIMEOUT);
+
+  it("returns one complexity entry per page with a reasons array", async () => {
+    const assessment = await detectPdfNeedsOcr(minimalPDFBuffer());
+    expect(assessment.pages).toHaveLength(1);
+    expect(assessment.pages[0].pageNumber).toBe(1);
+    expect(typeof assessment.pages[0].needsOcr).toBe("boolean");
+    expect(Array.isArray(assessment.pages[0].reasons)).toBe(true);
+    expect(Array.isArray(assessment.reasons)).toBe(true);
+  }, TIMEOUT);
+});

--- a/packages/extract-pdf/test/pdf-to-html.test.ts
+++ b/packages/extract-pdf/test/pdf-to-html.test.ts
@@ -1,44 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { convertPDFToHTML } from "../src/pdf-to-html";
-
-/**
- * Builds a minimal 1-page valid PDF in memory with a 24pt heading
- * ("Test Document") and a 12pt body line ("This is a sample paragraph.").
- */
-function minimalPDFBuffer(): ArrayBuffer {
-  const stream = [
-    "BT",
-    "/F1 24 Tf 72 700 Td (Test Document) Tj",
-    "/F1 12 Tf 0 -50 Td (This is a sample paragraph.) Tj",
-    "ET",
-  ].join("\n");
-
-  const objs: (string | null)[] = [
-    null,
-    "<</Type /Catalog /Pages 2 0 R>>",
-    "<</Type /Pages /Kids [3 0 R] /Count 1>>",
-    "<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources <</Font <</F1 4 0 R>>>> /Contents 5 0 R>>",
-    "<</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>",
-    `<</Length ${stream.length}>>\nstream\n${stream}\nendstream`,
-  ];
-
-  let doc = "%PDF-1.4\n";
-  const offsets: number[] = [];
-
-  for (let n = 1; n <= 5; n++) {
-    offsets[n] = doc.length;
-    doc += `${n} 0 obj\n${objs[n]}\nendobj\n`;
-  }
-
-  const xrefAt = doc.length;
-  doc += "xref\n0 6\n";
-  doc += "0000000000 65535 f \n";
-  for (let i = 1; i <= 5; i++)
-    doc += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
-  doc += `trailer\n<</Size 6 /Root 1 0 R>>\nstartxref\n${xrefAt}\n%%EOF\n`;
-
-  return new TextEncoder().encode(doc).buffer;
-}
+import { minimalPDFBuffer } from "./helpers/minimal-pdf";
 
 const TIMEOUT = 30_000;
 

--- a/packages/extract-pdf/tsconfig.json
+++ b/packages/extract-pdf/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/pdf-to-html.ts", "src/models/**/*.ts", "src/transforms/**/*.ts", "src/utils/**/*.ts"],
+  "include": ["src/pdf-to-html.ts", "src/liteparse-to-html.ts", "src/detect-needs-ocr.ts", "src/models/**/*.ts", "src/transforms/**/*.ts", "src/utils/**/*.ts"],
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "target": "ESNext",

--- a/packages/extract-pdf/vite.config.ts
+++ b/packages/extract-pdf/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
       format: { comments: false },
     },
     rollupOptions: {
-      external: [],
+      // @llamaindex/liteparse ships a native (napi) addon — never inline it,
+      // keep it as a runtime dependency resolved by Node.js when the
+      // "liteparse" ParseMethod is actually used.
+      external: ["@llamaindex/liteparse"],
     },
   },
   plugins: [
@@ -26,6 +29,8 @@ export default defineConfig({
       rollupTypes: true,
       include: [
         "src/pdf-to-html.ts",
+        "src/liteparse-to-html.ts",
+        "src/detect-needs-ocr.ts",
         "src/models/**/*.ts",
         "src/transforms/**/*.ts",
         "src/utils/**/*.ts",


### PR DESCRIPTION
## Summary

This PR adds support for an alternative PDF parsing engine (LiteParse) alongside the existing ts-block-algorithm, and introduces OCR-need detection to help route documents to appropriate parsing pipelines.

## Key Changes

- **LiteParse parsing method**: Added `convertPDFToHTMLWithLiteParse()` function that delegates PDF parsing to the native LiteParse library, with optional OCR support. Accessible via `convertPDFToHTML(buffer, { method: "liteparse" })`.

- **OCR detection**: Implemented `detectPdfNeedsOcr()` to perform a cheap, text-layer-only assessment of whether a PDF requires OCR or advanced parsing, returning per-page complexity signals and aggregated reasons (e.g., "scanned", "no-text", "sparse-text").

- **Parse method dispatch**: Extended `convertPDFToHTML()` to accept a `method` option (`"ts-block-algorithm"` or `"liteparse"`) and route to the appropriate implementation.

- **Shared utilities**: Extracted the `grab()` fetch wrapper into a reusable utility module (`src/utils/grab.ts`) used by all parsing methods.

- **Test helpers**: Moved PDF test fixtures into a dedicated helpers module and added comprehensive tests for LiteParse integration and OCR detection.

- **Documentation**: Updated README with parse method comparison table, LiteParse usage examples, and OCR detection workflow guidance.

## Implementation Details

- LiteParse is an optional dependency (`@llamaindex/liteparse`) with graceful error handling—returns `{ error }` if not installed rather than throwing.
- LiteParse path defaults to OCR disabled (`ocrEnabled: false`) to maintain the "instant, no backend" philosophy; callers can opt in via `liteParseOptions`.
- Both LiteParse and OCR detection are Node.js only (native napi addon); ts-block-algorithm remains the cross-platform default.
- Build configuration updated to keep `@llamaindex/liteparse` external (not bundled) in both the library and Cloudflare Workers builds.

https://claude.ai/code/session_01SsuDyyQBPfCoNkdY2X5R1f