### PR TITLE
Add is_anonymous field to user table

### DIFF
--- a/apps/qwksearch-web/drizzle/0007_add_user_is_anonymous.sql
+++ b/apps/qwksearch-web/drizzle/0007_add_user_is_anonymous.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `is_anonymous` integer;

--- a/apps/qwksearch-web/lib/database/schema.ts
+++ b/apps/qwksearch-web/lib/database/schema.ts
@@ -69,6 +69,7 @@ export const user = sqliteTable("user", {
   updatedAt: integer("updated_at", {
     mode: "timestamp",
   }).notNull(),
+  isAnonymous: integer("is_anonymous", { mode: "boolean" }),
 });
 
 export const session = sqliteTable("session", {


### PR DESCRIPTION
## Summary
This PR adds support for tracking anonymous users by introducing an `is_anonymous` boolean field to the user table.

## Changes
- Added database migration to create the `is_anonymous` column in the `user` table
- Updated the Drizzle schema to include the new `isAnonymous` field as an optional boolean property

## Implementation Details
- The `is_anonymous` column is nullable, allowing existing users to have an undefined anonymous status
- The field is defined as an integer with boolean mode in the schema, following SQLite's convention of using integers for boolean values

https://claude.ai/code/session_01WQME1vktPCVmFid7wTNndz