### PR TITLE
Add shadcn-settings package to Tailwind CSS sources

### DIFF
--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -6,6 +6,7 @@
    registered explicitly. */
 @source "../../../packages/shadcn-app-dock/src";
 @source "../../../packages/research-agent-ui/src";
+@source "../../../packages/shadcn-settings/src";
 
 @custom-variant dark (&:is(.dark *));
 /* @plugin "@tailwindcss/typography"; */


### PR DESCRIPTION
## Summary
Added the `shadcn-settings` package to the Tailwind CSS `@source` directive in the global stylesheet, enabling Tailwind to process styles from this package.

## Changes
- Added `@source "../../../packages/shadcn-settings/src"` to `apps/qwksearch-web/app/globals.css`

## Details
This change registers the `shadcn-settings` package as a source for Tailwind CSS to scan for class usage. This is necessary for Tailwind to properly generate utility classes used within the shadcn-settings package components in the qwksearch-web application.

https://claude.ai/code/session_01ECZNvyPjDSgaZD73iwNG7o