### PR TITLE
Fix Tailwind v3/v4 CSS cascade conflict with vendor styles

### DIFF
--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -1,6 +1,13 @@
+/* Pin "vendor" as the lowest-priority cascade layer before any imports run,
+   so pre-built third-party CSS (e.g. still-on-Tailwind-v3 packages that ship
+   an unlayered `*` reset for --tw-translate-x etc.) can never clobber our own
+   Tailwind v4 utilities — unlayered rules always beat layered ones, so vendor
+   styles must be explicitly layered to lose that fight. */
+@layer vendor;
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=Montserrat:wght@400;500;600;700&family=Nunito:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&family=Oswald:wght@400;500;600;700&family=Playfair+Display:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=PT+Sans:wght@400;700&family=Raleway:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500;700&family=Roboto+Slab:wght@400;500;700&family=Source+Code+Pro:wght@400;500;700&family=Source+Sans+3:wght@400;500;600;700&family=Ubuntu:wght@400;500;700&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "react-native-app-buttons/styles" layer(vendor);
 /* Workspace packages aren't covered by Tailwind's automatic source detection,
    so their responsive utilities (e.g. md:hidden on the mobile dock) must be
    registered explicitly. */

--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -84,6 +84,7 @@
     "react-hook-form": "^7.78.0",
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
+    "react-native-app-buttons": "^0.1.4",
     "react-textarea-autosize": "^8.5.9",
     "remark-gfm": "^4.0.1",
     "react-weather-forecast": "workspace:*",

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -13,7 +13,9 @@ import { getBackgroundArtwork } from './background-art';
 import { researchAgentUIConfig } from '../../config';
 import QuantumWaveOrbital from 'quantum-sphere-loading-icon/react';
 import { DownloadAppButton } from 'react-native-app-buttons';
-import 'react-native-app-buttons/styles';
+// Stylesheet is imported by the host app (globals.css) inside a named cascade
+// layer instead of here — it's a Tailwind v3 build with an unlayered `*`
+// reset that would otherwise beat every Tailwind v4 utility in the app.
 
 /**
  * The homepage component for the chat interface.


### PR DESCRIPTION
## Summary
Resolves CSS cascade conflicts between Tailwind v3 and v4 by explicitly layering third-party vendor styles, preventing unlayered v3 resets from overriding v4 utilities.

## Changes
- Added `@layer vendor` declaration at the top of globals.css to establish a low-priority cascade layer for third-party styles
- Moved `react-native-app-buttons` stylesheet import into the vendor layer via `@import "react-native-app-buttons/styles" layer(vendor)` in globals.css
- Removed direct stylesheet import from ChatHomepage.tsx component and added explanatory comment about why the import is handled at the app level
- Added `react-native-app-buttons` dependency to package.json

## Implementation Details
The issue stems from Tailwind v3's unlayered `*` reset rules (for CSS variables like `--tw-translate-x`) having higher specificity than Tailwind v4's layered utilities. By explicitly placing vendor styles in a named cascade layer, they lose the cascade fight to our unlayered Tailwind v4 utilities, ensuring consistent styling across the application.

The stylesheet import is centralized in the host app's globals.css rather than in the component to maintain proper cascade layer control and prevent the v3 reset from being applied at component import time.

https://claude.ai/code/session_01JJYy7DsZPA5YECx5Rmfetn