### PR TITLE
Fix draw.io integration with proto=json protocol

### DIFF
--- a/packages/react-reason-editor/src/extensions/Drawio/components/NodeViewDrawio/NodeViewDrawio.tsx
+++ b/packages/react-reason-editor/src/extensions/Drawio/components/NodeViewDrawio/NodeViewDrawio.tsx
@@ -48,33 +48,50 @@ function NodeViewDrawio({ editor, node, updateAttributes }: any) {
       return;
     }
 
+    toggleLoading(true);
+    setError(null);
+
     const iframe = document.createElement('iframe');
-    iframe.src = 'https://embed.diagrams.net/?embed=1&ui=minimal&spin=1&modified=unsaved&proto=json';
+    iframe.src = 'https://embed.diagrams.net/?embed=1&ui=minimal&spin=1&proto=json';
     iframe.style.display = 'none';
     document.body.appendChild(iframe);
 
+    // embed.diagrams.net only responds with 'init' once ready; with proto=json every
+    // message crossing the iframe boundary is a JSON string keyed by `event`/`action`.
     const handleMessage = (event: MessageEvent) => {
-      if (event.data && event.data.action === 'load') {
+      if (event.source !== iframe.contentWindow || typeof event.data !== 'string') return;
+
+      let message: any;
+      try {
+        message = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      if (message.event === 'init') {
         iframe.contentWindow?.postMessage(
-          { action: 'load', xml: data.xml },
+          JSON.stringify({ action: 'export', format: 'xmlsvg', xml: data.xml }),
           '*'
         );
-      } else if (event.data && event.data.action === 'export') {
-        const svgContent = event.data.svg;
-        if (svgContent) {
-          setSvg(svgContent);
-          toggleLoading(false);
+      } else if (message.event === 'export') {
+        if (message.data) {
+          setSvg(message.data);
+        } else {
+          setError(new Error('Unable to render diagram preview'));
         }
+        toggleLoading(false);
       }
     };
 
     window.addEventListener('message', handleMessage);
 
-    iframe.onload = () => {
-      iframe.contentWindow?.postMessage({ action: 'export' }, '*');
-    };
+    const timeout = window.setTimeout(() => {
+      setError(new Error('Timed out loading diagram preview'));
+      toggleLoading(false);
+    }, 15000);
 
     return () => {
+      window.clearTimeout(timeout);
       window.removeEventListener('message', handleMessage);
       document.body.removeChild(iframe);
     };
@@ -117,7 +134,6 @@ function NodeViewDrawio({ editor, node, updateAttributes }: any) {
 
           {!loading && !error && svg && (
             <div
-              dangerouslySetInnerHTML={{ __html: svg }}
               style={{
                 height: '100%',
                 maxHeight: '100%',
@@ -129,7 +145,13 @@ function NodeViewDrawio({ editor, node, updateAttributes }: any) {
                 transform: `scale(${zoom / 100})`,
                 transition: 'all ease-in-out .3s',
               }}
-            />
+            >
+              <img
+                alt='Diagram preview'
+                src={svg}
+                style={{ maxWidth: '100%', maxHeight: '100%' }}
+              />
+            </div>
           )}
 
           {!loading && !error && !svg && data?.xml && (

--- a/packages/react-reason-editor/src/extensions/Drawio/components/RichTextDrawio.tsx
+++ b/packages/react-reason-editor/src/extensions/Drawio/components/RichTextDrawio.tsx
@@ -49,30 +49,56 @@ export function RichTextDrawio() {
       return;
     }
 
-    const iframe = iframeRef as any;
     try {
-      iframe.contentWindow.postMessage({ action: 'export' }, '*');
+      iframeRef.contentWindow?.postMessage(
+        JSON.stringify({ action: 'export', format: 'xml' }),
+        '*'
+      );
     } catch (err) {
       setError(err);
     }
   }, [iframeRef]);
 
+  // With proto=json every message crossing the embed.diagrams.net iframe boundary
+  // is a JSON string keyed by `event` (incoming) / `action` (outgoing), not a plain object.
   const handleMessage = useCallback(
     (event: MessageEvent) => {
-      if (event.data && event.data.action === 'export') {
-        const xml = event.data.xml;
+      if (!iframeRef || event.source !== iframeRef.contentWindow || typeof event.data !== 'string') {
+        return;
+      }
+
+      let message: any;
+      try {
+        message = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      if (message.event === 'init') {
+        toggleLoading(false);
+        if (data) {
+          iframeRef.contentWindow?.postMessage(
+            JSON.stringify({ action: 'load', xml: data, autosave: 1 }),
+            '*'
+          );
+        }
+      } else if (message.event === 'export') {
+        const xml = message.xml || message.data;
         if (xml) {
           setData(xml);
           editor.chain().focus().setDrawio({ data: { xml } }).run();
           toggleVisible(false);
+        } else {
+          setError(new Error('Unable to export diagram'));
         }
       }
     },
-    [editor]
+    [editor, data, iframeRef]
   );
 
   const handler = (payload: any) => {
     toggleVisible(true);
+    setError(null);
     if (payload?.data?.xml) {
       setData(payload.data.xml);
     } else {
@@ -92,21 +118,11 @@ export function RichTextDrawio() {
   }, [handleMessage]);
 
   useEffect(() => {
-    if (visible && iframeRef) {
+    if (visible) {
       toggleLoading(true);
-      const handleIframeLoad = () => {
-        toggleLoading(false);
-        if (data) {
-          const iframe = iframeRef as any;
-          iframe.contentWindow.postMessage(
-            { action: 'load', xml: data },
-            '*'
-          );
-        }
-      };
-      iframeRef.onload = handleIframeLoad;
+      setError(null);
     }
-  }, [visible, iframeRef, data]);
+  }, [visible]);
 
   return (
     <Dialog onOpenChange={toggleVisible} open={visible}>


### PR DESCRIPTION
## Summary
Updates the draw.io iframe integration to properly handle the `proto=json` protocol, which requires all cross-iframe messages to be JSON strings rather than plain objects. This fixes message serialization issues and improves error handling and reliability.

## Key Changes

**RichTextDrawio.tsx:**
- Changed message format from plain objects to JSON strings for `postMessage` calls
- Updated message handling to parse incoming JSON strings and check for `event` property instead of `action`
- Moved iframe load logic from `onload` handler to message event handler, triggered by `init` event
- Added proper source validation and error handling for message events
- Added error state when export fails
- Improved dependency array in `handleMessage` callback

**NodeViewDrawio.tsx:**
- Changed message format to JSON strings for all `postMessage` calls
- Updated message handling to parse JSON and respond to `init` event
- Replaced `onload` handler with timeout-based fallback (15 second timeout)
- Added error handling for timeout and export failures
- Changed SVG rendering from `dangerouslySetInnerHTML` to `<img>` tag for better security
- Removed `modified=unsaved` parameter from iframe URL

## Implementation Details

- The `proto=json` protocol requires all messages crossing the iframe boundary to be JSON strings with `event` (incoming) or `action` (outgoing) keys
- The iframe now waits for an `init` event from embed.diagrams.net before sending commands
- Added proper error states and user feedback when diagram operations fail
- Improved security by using `<img>` tag instead of innerHTML for SVG rendering

https://claude.ai/code/session_01AksrnMDvce2vNmwqHrC6Qe