### PR TITLE
Migrate frimousse from ESM-CDN to npm package

### DIFF
--- a/packages/react-reason-editor/src/components/ui/emoji-picker.tsx
+++ b/packages/react-reason-editor/src/components/ui/emoji-picker.tsx
@@ -17,11 +17,7 @@ async function loadFrimousse() {
   if (frimousseMod) return frimousseMod;
   if (loadPromise) return loadPromise;
 
-  if (typeof window !== 'undefined' && !window.React) {
-    window.React = React;
-  }
-
-  loadPromise = import('https://esm.sh/frimousse@0.3.0')
+  loadPromise = import('frimousse')
     .then(mod => {
       frimousseMod = mod;
       return mod;

--- a/packages/react-reason-editor/src/types/frimousse.d.ts
+++ b/packages/react-reason-editor/src/types/frimousse.d.ts
@@ -1,7 +1,0 @@
-/**
- * Ambient module declaration mapping the ESM-CDN `frimousse` import to its types. Lets TypeScript resolve the emoji-picker library imported via URL.
- */
-
-declare module 'https://esm.sh/frimousse@0.3.0' {
-  export * from 'frimousse';
-}


### PR DESCRIPTION
## Summary
This PR migrates the frimousse emoji picker library from being imported via ESM-CDN URL to using a standard npm package import.

## Key Changes
- Removed the ambient TypeScript module declaration for the ESM-CDN URL (`https://esm.sh/frimousse@0.3.0`)
- Updated the dynamic import in `emoji-picker.tsx` to use the standard package name (`'frimousse'`) instead of the full ESM-CDN URL
- Removed the runtime check that conditionally assigned `React` to the global window object, which is no longer needed with the npm package approach

## Implementation Details
The change simplifies the dependency management by treating frimousse as a regular npm dependency rather than a remote ESM module. This approach provides better type safety, improved bundling, and eliminates the need for manual global React assignment that was previously required for the CDN-hosted version.

https://claude.ai/code/session_01PCLCEhyTc691fjoyhLMvtZ