### PR TITLE
Fix Rolldown resolution for wordcount extension subpath

### DIFF
--- a/packages/react-reason-editor/vite.config.ts
+++ b/packages/react-reason-editor/vite.config.ts
@@ -28,6 +28,11 @@ function selfReferenceResolver(srcDir: string): Plugin {
       if (id === 'react-reason-editor/style.css') return path.resolve(srcDir, 'styles/index.scss');
       if (id === 'react-reason-editor/theme') return path.resolve(srcDir, 'theme/theme.ts');
       if (id === 'react-reason-editor/locale-bundle') return path.resolve(srcDir, 'locale-bundle.ts');
+      // Rolldown fails to resolve this one extension subpath as a
+      // cross-entry self-reference (unlike every other `./extensions/*`
+      // export, which it resolves natively during this build), so it needs
+      // the same explicit source redirect as the paths above.
+      if (id === 'react-reason-editor/wordcount') return path.resolve(srcDir, 'extensions/WordCount/index.ts');
     },
   };
 }


### PR DESCRIPTION
## Summary
Added an explicit source redirect in the Vite config to resolve the `react-reason-editor/wordcount` subpath export, which Rolldown fails to resolve natively as a cross-entry self-reference.

## Changes
- Added a resolver rule in `selfReferenceResolver` plugin to map `react-reason-editor/wordcount` to `extensions/WordCount/index.ts`
- This brings the wordcount extension in line with other subpath exports that require explicit resolution during the build process

## Details
Unlike other `./extensions/*` exports which Rolldown resolves natively, the wordcount extension subpath was not being resolved correctly. The fix applies the same explicit source redirect pattern already used for other package exports like `style.css`, `theme`, and `locale-bundle`.

https://claude.ai/code/session_01UcVHA2VVgE3pqEkw9hf2wW