### PR TITLE
Fix SSR compatibility and improve extension resolution

### DIFF
--- a/apps/qwksearch-web/vitest.config.ts
+++ b/apps/qwksearch-web/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'chat-agent-toolkit': resolve(__dirname, '../../packages/chat-agent-toolkit/src'),
       'extract-webpage': resolve(__dirname, '../../packages/extract-webpage/src'),
       'research-agent-ui/api': resolve(__dirname, '../../packages/research-agent-ui/src/api/index.ts'),
+      'research-agent-ui/settings': resolve(__dirname, '../../packages/research-agent-ui/src/settings/index.ts'),
       'research-agent-ui': resolve(__dirname, '../../packages/research-agent-ui/src/index.ts'),
       'domain-rank': resolve(__dirname, '../../packages/domain-rank'),
       'search-web-api': resolve(__dirname, '../../packages/search-web-api/src'),

--- a/packages/react-reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/react-reason-editor/src/editor/ReasonDocs.tsx
@@ -14,6 +14,7 @@ import { useTheme } from 'next-themes';
 import { useState } from 'react';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
+import { ssrSafeLocalStorage } from '../utils/storage';
 import '../app-styles/split-pane.css';
 
 
@@ -28,7 +29,10 @@ const Index = () => {
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
 
   // Use persistence hook for sidebar sizes
-  const [sidebarSizes, setSidebarSizes] = usePersistence({ key: 'reason-docs-sidebar' });
+  const [sidebarSizes, setSidebarSizes] = usePersistence({
+    key: 'reason-docs-sidebar',
+    storage: ssrSafeLocalStorage,
+  });
 
   /** Toggles between 'dark' and 'light' application theme. */
   const handleToggleTheme = () => {

--- a/packages/react-reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/react-reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -16,6 +16,7 @@ import type { SidebarPanelType, SidebarAiProps } from './types';
 import type { TocEntry } from '../../app-types/toc';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
+import { ssrSafeLocalStorage } from '../../utils/storage';
 import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search } from 'lucide-react';
 import { FileTypeIcon } from '../../app-ui/FileTypeIcon';
 import { cn } from '../../app-utils/utils';
@@ -194,7 +195,10 @@ export const SidebarContent = ({
     );
   }, [outlineFilter, headings, sectionBodies]);
 
-  const [panelSizes, setPanelSizes] = usePersistence({ key: `sidebar-panels-${persistenceKey}` });
+  const [panelSizes, setPanelSizes] = usePersistence({
+    key: `sidebar-panels-${persistenceKey}`,
+    storage: ssrSafeLocalStorage,
+  });
 
   const renderOpenTabs = () => (
     <div className="h-full overflow-auto">

--- a/packages/react-reason-editor/src/utils/storage.ts
+++ b/packages/react-reason-editor/src/utils/storage.ts
@@ -18,3 +18,24 @@ export function getStorage(key: any, defaultValue = null) {
 export function setStorage(key: any, value: any) {
   window.localStorage.setItem(key, `${value}`);
 }
+
+/**
+ * A `Storage` implementation that does nothing, for passing to third-party
+ * hooks (e.g. react-split-pane's `usePersistence`) that default their
+ * `storage` option to the bare `localStorage` global. That default is
+ * evaluated unconditionally wherever the option is omitted, which throws
+ * during SSR since `localStorage` doesn't exist there — passing this no-op
+ * explicitly on the server sidesteps the library's own default.
+ */
+const noopStorage: Storage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+  key: () => null,
+  length: 0,
+};
+
+/** `window.localStorage` on the client, or a no-op stand-in during SSR. */
+export const ssrSafeLocalStorage: Storage =
+  typeof window === 'undefined' ? noopStorage : window.localStorage;

--- a/packages/react-reason-editor/vite.config.ts
+++ b/packages/react-reason-editor/vite.config.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import react from '@vitejs/plugin-react';
@@ -19,7 +20,25 @@ import { defineConfig, type Plugin } from 'vite';
 // build there is no such install yet, so point those specifiers straight at
 // their source equivalents (mirrors demo/vite.config.ts's resolver, which
 // does the same for the demo build).
+//
+// Extension subpaths (e.g. react-reason-editor/wordcount) are handled
+// generically rather than as a fixed list: without this, an unresolved
+// subpath falls through to Node's own self-reference algorithm, which
+// points at the not-yet-written dist/*.js chunk for that entry. Whether
+// that resolves depends on Rolldown's (non-deterministic) transform order
+// relative to when the target entry's own chunk gets emitted, so the build
+// would pass or fail from run to run.
 function selfReferenceResolver(srcDir: string): Plugin {
+  const extDir = path.resolve(srcDir, 'extensions');
+  // Map lowercase package subpaths to PascalCase extension dirs
+  // (e.g. bulletlist -> BulletList). First-letter capitalization alone
+  // misses multi-word names, which would fall through to the package
+  // self-reference and race the not-yet-built dist output.
+  const extDirByLowerName = new Map<string, string>();
+  for (const dir of fs.readdirSync(extDir)) {
+    extDirByLowerName.set(dir.toLowerCase(), dir);
+  }
+
   return {
     name: 'reason-editor-self-reference',
     enforce: 'pre',
@@ -28,6 +47,22 @@ function selfReferenceResolver(srcDir: string): Plugin {
       if (id === 'react-reason-editor/style.css') return path.resolve(srcDir, 'styles/index.scss');
       if (id === 'react-reason-editor/theme') return path.resolve(srcDir, 'theme/theme.ts');
       if (id === 'react-reason-editor/locale-bundle') return path.resolve(srcDir, 'locale-bundle.ts');
+      if (id === 'react-reason-editor/bubble') return path.resolve(srcDir, 'bubble.ts');
+
+      const m = id.match(/^react-reason-editor\/(.+)$/);
+      if (!m) return;
+      const name = m[1];
+      const variants = [
+        extDirByLowerName.get(name.toLowerCase()),
+        name.charAt(0).toUpperCase() + name.slice(1),
+        name,
+      ].filter((v, i, arr): v is string => !!v && arr.indexOf(v) === i);
+      for (const v of variants) {
+        const idx = path.resolve(extDir, v, 'index.ts');
+        if (fs.existsSync(idx)) return idx;
+        const file = path.resolve(extDir, v, `${v}.ts`);
+        if (fs.existsSync(file)) return file;
+      }
     },
   };
 }
@@ -157,6 +192,11 @@ export default defineConfig(async ({ mode }) => {
           '@tiptap/pm/model',
           '@tiptap/pm/state',
           '@tiptap/pm/view',
+          // @tiptap/react pulls in use-sync-external-store's CJS shim. Bundled
+          // in (rather than externalized), Rolldown's CJS interop for it falls
+          // back to a runtime `require("react")`, which crashes under strict
+          // Node ESM — e.g. Next.js SSR — where no `require` global exists.
+          '@tiptap/react',
           'react',
           'react-dom',
           'react/jsx-runtime',
@@ -189,6 +229,9 @@ export default defineConfig(async ({ mode }) => {
           'clsx',
           'harper.js',
           'harper.js/binary',
+          // Pulls in swr, which shares the same use-sync-external-store CJS
+          // shim problem as @tiptap/react above.
+          'react-tweet',
         ],
       },
     },


### PR DESCRIPTION
## Summary
This PR addresses server-side rendering (SSR) compatibility issues and improves the extension subpath resolution logic in the Vite configuration.

## Key Changes

- **SSR-safe localStorage**: Created a no-op `Storage` implementation (`ssrSafeLocalStorage`) to handle cases where `localStorage` is unavailable during SSR. This is passed explicitly to `react-split-pane`'s `usePersistence` hook in `ReasonDocs.tsx` and `SidebarContent.tsx` to prevent runtime errors when the library's default `localStorage` global is evaluated on the server.

- **Enhanced extension subpath resolution**: Improved the `selfReferenceResolver` plugin to handle extension subpaths generically by:
  - Building a case-insensitive map of extension directories at plugin initialization
  - Attempting multiple naming variants (lowercase lookup, PascalCase, original name) to resolve extension imports
  - Checking for both `index.ts` and named entry files within extension directories
  - This prevents non-deterministic build failures caused by race conditions between chunk emission and module resolution

- **Updated externalization strategy**: Added `@tiptap/react` and `react-tweet` to the externals list with explanatory comments about their CommonJS interop issues with `use-sync-external-store` that cause failures in strict Node ESM environments (e.g., Next.js SSR).

- **Added explicit subpath mapping**: Added a direct mapping for `react-reason-editor/bubble` to `bubble.ts`.

- **Updated test aliases**: Added `research-agent-ui/settings` alias to the Vitest configuration.

## Implementation Details

The extension resolution now uses a deterministic approach that avoids relying on Rolldown's transform order, ensuring consistent builds regardless of chunk emission timing. The SSR compatibility improvements follow the pattern of explicitly providing safe defaults for third-party hooks that unconditionally evaluate browser globals.

https://claude.ai/code/session_01BAadVe5MSU1j6ZA2ZypjhC