### PR TITLE
Fix circular dependency and externalize tiptap packages

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -106,7 +106,6 @@
     "react-reason-editor": "workspace:*",
     "react-textarea-autosize": "^8.5.9",
     "remark-gfm": "^4.0.1",
-    "react-reason-editor": "workspace:*",
     "react-weather-forecast": "workspace:*",
     "research-agent-ui": "workspace:*",
     "scroll-into-view-if-needed": "^3.1.0",
@@ -119,6 +118,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tldts": "^7.4.2",
     "use-sync-external-store": "^1.6.0",
+    "write-language": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -172,6 +172,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tldts": "^7.4.2",
         "use-sync-external-store": "^1.6.0",
+        "write-language": "workspace:*",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -3584,7 +3585,7 @@
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
-    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "is-document.all": ["is-document.all@1.0.0", "", { "dependencies": { "call-bound": "^1.0.4" } }, "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g=="],
 
@@ -5710,6 +5711,8 @@
 
     "import-local/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
+    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
     "is-vpn/axios": ["axios@0.27.2", "", { "dependencies": { "follow-redirects": "^1.14.9", "form-data": "^4.0.0" } }, "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -6142,8 +6145,6 @@
 
     "@aklinker1/rollup-plugin-visualizer/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
-    "@aklinker1/rollup-plugin-visualizer/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
     "@aklinker1/rollup-plugin-visualizer/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "@aklinker1/rollup-plugin-visualizer/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
@@ -6314,8 +6315,6 @@
 
     "better-opn/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
-    "better-opn/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
     "better-opn/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "boxen/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -6339,8 +6338,6 @@
     "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "chrome-launcher/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
-
-    "chrome-launcher/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -6667,8 +6664,6 @@
     "node-html-parser/css-select/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "node-html-parser/css-select/nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
-
-    "node-notifier/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/packages/react-reason-editor/src/utils/columns.ts
+++ b/packages/react-reason-editor/src/utils/columns.ts
@@ -6,7 +6,12 @@ import { findParentNode } from '@tiptap/core';
 import { Node } from '@tiptap/pm/model';
 import { type EditorState, TextSelection } from '@tiptap/pm/state';
 
-import { ColumnNode, MultipleColumnNode } from '@/extensions/Column';
+// Node type names, kept as literals (matching the `name` given to
+// `Node.create()` in Column.ts) rather than importing the extensions
+// directly — that import would form a cycle, since Column.ts imports
+// these helpers from this module.
+const MULTIPLE_COLUMN_NODE_NAME = 'columns';
+const COLUMN_NODE_NAME = 'column';
 
 export function createColumn(colType: any, index: any, colContent = null) {
   if (colContent) {
@@ -56,10 +61,10 @@ export function addOrDeleteCol({
   dispatch: any;
   type: 'addBefore' | 'addAfter' | 'delete';
 }) {
-  const maybeColumns = findParentNode((node: Node) => node.type.name === MultipleColumnNode.name)(
+  const maybeColumns = findParentNode((node: Node) => node.type.name === MULTIPLE_COLUMN_NODE_NAME)(
     state.selection
   );
-  const maybeColumn = findParentNode((node: Node) => node.type.name === ColumnNode.name)(
+  const maybeColumn = findParentNode((node: Node) => node.type.name === COLUMN_NODE_NAME)(
     state.selection
   );
 
@@ -126,10 +131,10 @@ export function gotoCol({
   dispatch: any;
   type: 'before' | 'after';
 }) {
-  const maybeColumns = findParentNode((node: Node) => node.type.name === MultipleColumnNode.name)(
+  const maybeColumns = findParentNode((node: Node) => node.type.name === MULTIPLE_COLUMN_NODE_NAME)(
     state.selection
   );
-  const maybeColumn = findParentNode((node: Node) => node.type.name === ColumnNode.name)(
+  const maybeColumn = findParentNode((node: Node) => node.type.name === COLUMN_NODE_NAME)(
     state.selection
   );
 

--- a/packages/react-reason-editor/vite.config.ts
+++ b/packages/react-reason-editor/vite.config.ts
@@ -179,8 +179,27 @@ export default defineConfig(async ({ mode }) => {
           },
         },
         external: [
+          '@tiptap/core',
+          // Every @tiptap/pm/* subpath actually used by the bundled extensions
+          // must stay external, not just model/state/view: prosemirror-state
+          // keeps a module-scoped counter that auto-generates plugin keys
+          // ("plugin$", "plugin$1", ...). A subpath left un-externalized gets
+          // its dependency tree (down to prosemirror-state) inlined into this
+          // package's own dist bundle — a second copy of that module, with its
+          // own independent counter — so a plugin built from the inlined copy
+          // collides with one built from the app's externally-resolved copy
+          // the moment both land in the same EditorState (thrown as "Adding
+          // different instances of a keyed plugin").
+          '@tiptap/pm/commands',
+          '@tiptap/pm/dropcursor',
+          '@tiptap/pm/gapcursor',
+          '@tiptap/pm/history',
+          '@tiptap/pm/keymap',
           '@tiptap/pm/model',
+          '@tiptap/pm/schema-list',
           '@tiptap/pm/state',
+          '@tiptap/pm/tables',
+          '@tiptap/pm/transform',
           '@tiptap/pm/view',
           // @tiptap/react pulls in use-sync-external-store's CJS shim. Bundled
           // in (rather than externalized), Rolldown's CJS interop for it falls


### PR DESCRIPTION
## Summary
This PR resolves a circular dependency issue in the react-reason-editor package and ensures proper externalization of tiptap dependencies to prevent module duplication and plugin key collisions.

## Key Changes

- **Vite Configuration**: Added comprehensive externalization of `@tiptap/pm/*` subpaths and `@tiptap/core` to prevent duplicate prosemirror-state instances. Included detailed comments explaining why prosemirror-state must remain external due to its module-scoped plugin key counter.

- **Circular Dependency Fix**: Replaced direct imports of `ColumnNode` and `MultipleColumnNode` extensions in `columns.ts` with string literals (`'columns'` and `'column'`) matching the node type names. This breaks the circular dependency where Column.ts imports utilities from columns.ts.

- **Package.json Cleanup**: Removed duplicate `react-reason-editor` dependency entry and added missing `write-language` workspace dependency in qwksearch-web.

## Implementation Details

The circular dependency was resolved by using node type name literals instead of importing the extension classes. This approach is safe because:
- The node type names are already defined as string literals in the extensions
- The helper functions only need to match against node type names, not the extension classes themselves
- This pattern prevents the import cycle while maintaining the same functionality

https://claude.ai/code/session_01CTEWsnR2itn9xMT9dtgnZZ