### PR TITLE
Add repository metadata to package.json files

### DIFF
--- a/packages/qwksearch-mcp-server/package.json
+++ b/packages/qwksearch-mcp-server/package.json
@@ -2,6 +2,11 @@
   "name": "qwksearch-mcp-server",
   "version": "1.0.0",
   "description": "MCP server exposing web search and content extraction tools via stdio transport",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
+    "directory": "packages/qwksearch-mcp-server"
+  },
   "type": "module",
   "bin": {
     "qwksearch-mcp": "./bin/qwksearch-mcp.ts"

--- a/packages/react-reason-editor/package.json
+++ b/packages/react-reason-editor/package.json
@@ -2,6 +2,11 @@
   "name": "react-reason-editor",
   "version": "1.0.24",
   "description": "A modern WYSIWYG rich text editor based on tiptap and shadcn ui for React",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
+    "directory": "packages/react-reason-editor"
+  },
   "keywords": [
     "editor",
     "react",

--- a/packages/react-weather-forecast/package.json
+++ b/packages/react-weather-forecast/package.json
@@ -5,6 +5,11 @@
   "keywords": ["react", "weather", "forecast", "open-meteo", "ipinfo", "component-library"],
   "license": "MIT",
   "author": "Perplexity",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
+    "directory": "packages/react-weather-forecast"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
Added repository information to the `package.json` files across three packages to properly document their location within the monorepo structure.

## Changes
- **qwksearch-mcp-server**: Added repository metadata pointing to the GitHub repository with the package subdirectory
- **react-reason-editor**: Added repository metadata pointing to the GitHub repository with the package subdirectory
- **react-weather-forecast**: Added repository metadata pointing to the GitHub repository with the package subdirectory

## Details
Each package now includes a `repository` field in its `package.json` that specifies:
- Repository type: `git`
- Repository URL: `git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git`
- Package directory: The relative path to each package within the monorepo

This metadata helps package managers, tools, and developers identify the source repository and locate the package within the monorepo structure.

https://claude.ai/code/session_01EsSmouGq851ZiSeVByvNya