### PR TITLE
Replace visible tab scraping with invisible offscreen document

### DIFF
--- a/apps/qwksearch-ext/background/offscreen-scraper.ts
+++ b/apps/qwksearch-ext/background/offscreen-scraper.ts
@@ -1,0 +1,49 @@
+// Manages a single offscreen document used to scrape page HTML invisibly
+// (no visible tab or window is ever created).
+const OFFSCREEN_DOCUMENT_PATH = "offscreen.html"
+
+interface ScrapeResult {
+  success: boolean
+  html?: string
+  error?: string
+}
+
+let creatingOffscreenDocument: Promise<void> | null = null
+
+async function hasOffscreenDocument(): Promise<boolean> {
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
+    documentUrls: [chrome.runtime.getURL(OFFSCREEN_DOCUMENT_PATH)]
+  })
+  return contexts.length > 0
+}
+
+async function ensureOffscreenDocument(): Promise<void> {
+  if (await hasOffscreenDocument()) return
+
+  // Chrome only allows one in-flight createDocument() call at a time,
+  // so concurrent extractURL requests share this promise instead of racing.
+  if (!creatingOffscreenDocument) {
+    creatingOffscreenDocument = chrome.offscreen
+      .createDocument({
+        url: OFFSCREEN_DOCUMENT_PATH,
+        reasons: [chrome.offscreen.Reason.DOM_SCRAPING],
+        justification: "Fetch and parse remote page HTML to extract article content invisibly."
+      })
+      .finally(() => {
+        creatingOffscreenDocument = null
+      })
+  }
+
+  await creatingOffscreenDocument
+}
+
+export async function scrapeURLViaOffscreen(url: string): Promise<ScrapeResult> {
+  await ensureOffscreenDocument()
+
+  return chrome.runtime.sendMessage({
+    target: "offscreen",
+    type: "scrapeURL",
+    url
+  })
+}

--- a/apps/qwksearch-ext/entrypoints/background.ts
+++ b/apps/qwksearch-ext/entrypoints/background.ts
@@ -1,5 +1,6 @@
 import { setupContextMenu } from "@/background/context-menu"
 import { setupAllowCORS } from "@/background/allow-cors"
+import { scrapeURLViaOffscreen } from "@/background/offscreen-scraper"
 
 export default defineBackground(() => {
   setupContextMenu()
@@ -9,33 +10,13 @@ export default defineBackground(() => {
   chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const { type, url } = request
 
-    // Open tab to extract HTML, then close
+    // Extract HTML invisibly via the offscreen document, no visible tab
     if (type === "extractURL") {
-      chrome.tabs.create(
-        { url, selected: false, active: false },
-        (tab) => {
-          const tabId = tab.id!
-          const onTabUpdated = (updatedTabId: number, changeInfo: chrome.tabs.TabChangeInfo) => {
-            if (updatedTabId === tabId && changeInfo.status === "complete") {
-              chrome.tabs.onUpdated.removeListener(onTabUpdated)
-              chrome.scripting
-                .executeScript({
-                  target: { tabId },
-                  func: () => document.documentElement.outerHTML
-                })
-                .then((htmlContent) => {
-                  sendResponse({ success: true, html: htmlContent?.[0]?.result })
-                  chrome.tabs.remove(tabId)
-                })
-                .catch((error) => {
-                  sendResponse({ success: false, error: error.message })
-                  chrome.tabs.remove(tabId)
-                })
-            }
-          }
-          chrome.tabs.onUpdated.addListener(onTabUpdated)
-        }
-      )
+      scrapeURLViaOffscreen(url)
+        .then((result) => sendResponse(result))
+        .catch((error) =>
+          sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) })
+        )
     }
 
     // Open tab in foreground or background

--- a/apps/qwksearch-ext/entrypoints/offscreen/index.html
+++ b/apps/qwksearch-ext/entrypoints/offscreen/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>QwkSearch Offscreen</title>
+  </head>
+  <body>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/qwksearch-ext/entrypoints/offscreen/main.ts
+++ b/apps/qwksearch-ext/entrypoints/offscreen/main.ts
@@ -1,0 +1,39 @@
+// Offscreen document: fetches a URL's HTML and parses it with DOMParser.
+// Runs invisibly (no tab, no window) — this is why it only sees the
+// server-rendered HTML, not DOM produced by the target page's own JS.
+interface ScrapeMessage {
+  target: "offscreen"
+  type: "scrapeURL"
+  url: string
+}
+
+interface ScrapeResult {
+  success: boolean
+  html?: string
+  error?: string
+}
+
+chrome.runtime.onMessage.addListener((message: ScrapeMessage, _sender, sendResponse) => {
+  if (message?.target !== "offscreen" || message.type !== "scrapeURL") return
+
+  scrapeURL(message.url)
+    .then((html) => sendResponse({ success: true, html } satisfies ScrapeResult))
+    .catch((error) =>
+      sendResponse({
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      } satisfies ScrapeResult)
+    )
+
+  return true // keep the message channel open for the async response
+})
+
+async function scrapeURL(url: string): Promise<string> {
+  const response = await fetch(url, { credentials: "omit" })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
+  }
+  const html = await response.text()
+  const doc = new DOMParser().parseFromString(html, "text/html")
+  return doc.documentElement.outerHTML
+}

--- a/apps/qwksearch-ext/wxt.config.ts
+++ b/apps/qwksearch-ext/wxt.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       'activeTab',
       'webRequest',
       'declarativeNetRequest',
+      'offscreen',
     ],
     host_permissions: ['<all_urls>'],
     commands: {


### PR DESCRIPTION
## Summary
Refactored URL scraping to use Chrome's Offscreen Document API instead of creating visible browser tabs. This provides a cleaner, more efficient approach to extracting page HTML without any visible UI disruption.

## Key Changes
- **New offscreen document infrastructure**: Added `offscreen-scraper.ts` to manage the lifecycle of a single offscreen document, including creation and reuse logic with concurrency handling
- **New offscreen entrypoint**: Created `entrypoints/offscreen/main.ts` that runs invisibly to fetch URLs and parse their HTML using the Fetch API and DOMParser
- **Simplified background script**: Replaced complex tab creation/monitoring logic in `background.ts` with a single call to `scrapeURLViaOffscreen()`, eliminating the need to wait for tab load completion and manually close tabs
- **Added manifest permission**: Updated `wxt.config.ts` to include the `offscreen` permission required by the Offscreen Document API
- **New HTML template**: Added `offscreen/index.html` as the document entry point

## Implementation Details
- The offscreen document is created on-demand and reused across multiple scrape requests
- Concurrent scrape requests share a single `createDocument()` promise to avoid Chrome's limitation of one in-flight creation call at a time
- The offscreen document only sees server-rendered HTML (no client-side JavaScript execution), which is the intended behavior for content extraction
- Error handling is consistent across both the background and offscreen contexts

https://claude.ai/code/session_017rM4opkqrbSUpBS8CeLDEF