### PR TITLE
Fix import path for useToast hook in enterprise page

### DIFF
--- a/apps/qwksearch-web/app/enterprise/page.tsx
+++ b/apps/qwksearch-web/app/enterprise/page.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
-import { useToast } from "@/hooks/use-toast"
+import { useToast } from "@/lib/hooks/use-toast"
 import {
   Palette,
   Code,


### PR DESCRIPTION
## Summary
Updated the import path for the `useToast` hook to reflect the correct location in the project structure.

## Changes
- Updated import statement in `apps/qwksearch-web/app/enterprise/page.tsx` to import `useToast` from `@/lib/hooks/use-toast` instead of `@/hooks/use-toast`

## Details
This change corrects the module resolution path for the `useToast` hook, ensuring it points to the actual location of the hook in the `lib/hooks` directory rather than the root `hooks` directory.

https://claude.ai/code/session_01Hk1MvcnktCNhvSUc3ZzqyA