### PR TITLE
Display email instead of account ID for linked providers

### DIFF
--- a/apps/qwksearch-web/components/Settings/Sections/Account.tsx
+++ b/apps/qwksearch-web/components/Settings/Sections/Account.tsx
@@ -676,7 +676,7 @@ export default function Account() {
                     <span className="font-medium">{provider.name}</span>
                     {linkedAccount && (
                       <span className="text-[10px] text-black/50 dark:text-white/50">
-                        {linkedAccount.accountId}
+                        {profile?.email ?? linkedAccount.accountId}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
Updated the Account settings page to display the user's email address instead of the account ID when showing linked provider information.

## Changes
- Modified the linked account display in the Account settings section to show `profile?.email` as the primary value, falling back to `linkedAccount.accountId` if email is not available
- This provides a more user-friendly identifier that is easier to recognize and verify

## Implementation Details
- The change uses optional chaining and nullish coalescing (`??`) to safely handle cases where the email may not be available
- Maintains backward compatibility by falling back to the account ID when email is unavailable

https://claude.ai/code/session_017cdFPoyEncpgh66NhGoNeQ