### PR TITLE
Add automatic reload on chunk load errors after deployment

### DIFF
--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -13,6 +13,7 @@ import { Toaster } from 'sonner';
 import { authClient } from '@/lib/auth/client';
 import { CategoryDock } from '@/components/layout/CategoryDock';
 import { CookieConsent } from '@/components/layout/CookieConsent';
+import { useChunkErrorReload } from '@/components/layout/useChunkErrorReload';
 import { SettingsModalProvider } from '@/components/Settings/SettingsModal';
 import {
   APP_NAME,
@@ -39,6 +40,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
   // Google provider configured — otherwise the prompt can only fail (a
   // sign-in with no provider to complete it against).
   const [googleOneTapEnabled, setGoogleOneTapEnabled] = useState(false);
+
+  useChunkErrorReload();
 
   useEffect(() => {
     fetch('/api/auth/providers')

--- a/apps/qwksearch-web/components/layout/useChunkErrorReload.ts
+++ b/apps/qwksearch-web/components/layout/useChunkErrorReload.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const RELOAD_FLAG = 'qwk:chunk-error-reload';
+
+const isChunkLoadError = (message: unknown): boolean =>
+  typeof message === 'string' && /Loading (chunk|CSS chunk)|ChunkLoadError/i.test(message);
+
+/**
+ * Deployments replace `_next/static` chunks with newly-hashed filenames, so a
+ * browser tab left open from before a deploy will 404 when it tries to fetch
+ * an old chunk (e.g. on a client-side navigation). Reload once to pick up the
+ * new build instead of leaving the user stuck on a broken page; the
+ * sessionStorage flag stops a reload loop if the new build somehow fails too.
+ */
+export function useChunkErrorReload(): void {
+  useEffect(() => {
+    const reloadOnce = (message: unknown): void => {
+      if (!isChunkLoadError(message)) return;
+      if (sessionStorage.getItem(RELOAD_FLAG)) return;
+      sessionStorage.setItem(RELOAD_FLAG, '1');
+      window.location.reload();
+    };
+
+    const onError = (event: ErrorEvent): void => reloadOnce(event.message);
+    const onRejection = (event: PromiseRejectionEvent): void =>
+      reloadOnce(event.reason?.message ?? event.reason);
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onRejection);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
This PR adds automatic page reloading when chunk load errors occur, which commonly happen when a browser tab is left open during a deployment. The new hook detects chunk-related errors and reloads the page once to pick up the newly-hashed static assets from the new build.

## Key Changes
- **New hook `useChunkErrorReload`**: Detects chunk loading errors (both synchronous errors and unhandled promise rejections) and triggers a single automatic reload
- **Error detection**: Uses regex pattern matching to identify chunk-related error messages (`Loading chunk`, `Loading CSS chunk`, `ChunkLoadError`)
- **Reload prevention loop**: Uses `sessionStorage` flag to prevent infinite reload loops if the new build also fails
- **Integration**: Hook is called in the `Providers` component to ensure it's active for the entire application

## Implementation Details
- The hook listens to both `error` and `unhandledrejection` events to catch chunk loading failures
- A `sessionStorage` flag (`qwk:chunk-error-reload`) ensures the page reloads at most once per session
- Event listeners are properly cleaned up on unmount to prevent memory leaks
- The solution is transparent to users—they simply see the page refresh and continue with the new build

https://claude.ai/code/session_01RF8tDP8dBrG4M2oUDYoKkF